### PR TITLE
6.5: Updated RT to v6.5-rt5

### DIFF
--- a/6.5/misc/0001-rt.patch
+++ b/6.5/misc/0001-rt.patch
@@ -2712,10 +2712,10 @@ index 9ea0b28..00a01d5 100644
  
  #ifndef CONFIG_HAVE_ARCH_WITHIN_STACK_FRAMES
 diff --git a/include/linux/trace_events.h b/include/linux/trace_events.h
-index 3930e67..0ca957d 100644
+index 1e8bbdb..936c798 100644
 --- a/include/linux/trace_events.h
 +++ b/include/linux/trace_events.h
-@@ -70,6 +70,7 @@ struct trace_entry {
+@@ -81,6 +81,7 @@ struct trace_entry {
  	unsigned char		flags;
  	unsigned char		preempt_count;
  	int			pid;
@@ -2723,7 +2723,7 @@ index 3930e67..0ca957d 100644
  };
  
  #define TRACE_EVENT_TYPE_MAX						\
-@@ -158,9 +159,10 @@ static inline void tracing_generic_entry_update(struct trace_entry *entry,
+@@ -169,9 +170,10 @@ static inline void tracing_generic_entry_update(struct trace_entry *entry,
  						unsigned int trace_ctx)
  {
  	entry->preempt_count		= trace_ctx & 0xff;
@@ -2735,7 +2735,7 @@ index 3930e67..0ca957d 100644
  }
  
  unsigned int tracing_gen_ctx_irq_test(unsigned int irqs_status);
-@@ -171,7 +173,13 @@ enum trace_flag_type {
+@@ -182,7 +184,13 @@ enum trace_flag_type {
  	TRACE_FLAG_NEED_RESCHED		= 0x04,
  	TRACE_FLAG_HARDIRQ		= 0x08,
  	TRACE_FLAG_SOFTIRQ		= 0x10,
@@ -2750,7 +2750,7 @@ index 3930e67..0ca957d 100644
  	TRACE_FLAG_BH_OFF		= 0x80,
  };
 diff --git a/kernel/Kconfig.preempt b/kernel/Kconfig.preempt
-index c2f1fd9..5924fc7 100644
+index c2f1fd9..b787bb9 100644
 --- a/kernel/Kconfig.preempt
 +++ b/kernel/Kconfig.preempt
 @@ -1,5 +1,11 @@
@@ -6738,7 +6738,7 @@ index 63a8ce7..b3fbe97 100644
  
  /*
 diff --git a/kernel/trace/trace.c b/kernel/trace/trace.c
-index b887007..ea1c539 100644
+index 8e64aaa..2676f9f 100644
 --- a/kernel/trace/trace.c
 +++ b/kernel/trace/trace.c
 @@ -2720,11 +2720,19 @@ unsigned int tracing_gen_ctx_irq_test(unsigned int irqs_status)
@@ -6763,7 +6763,7 @@ index b887007..ea1c539 100644
  		(min_t(unsigned int, migration_disable_value(), 0xf)) << 4;
  }
  
-@@ -4333,15 +4341,17 @@ unsigned long trace_total_entries(struct trace_array *tr)
+@@ -4340,15 +4348,17 @@ unsigned long trace_total_entries(struct trace_array *tr)
  
  static void print_lat_help_header(struct seq_file *m)
  {
@@ -6790,7 +6790,7 @@ index b887007..ea1c539 100644
  }
  
  static void print_event_info(struct array_buffer *buf, struct seq_file *m)
-@@ -4375,14 +4385,16 @@ static void print_func_help_header_irq(struct array_buffer *buf, struct seq_file
+@@ -4382,14 +4392,16 @@ static void print_func_help_header_irq(struct array_buffer *buf, struct seq_file
  
  	print_event_info(buf, m);
  


### PR DESCRIPTION
Using v6.5-rt5 as a base
removed conflicting EEVDF/TT changes
removed EXPERT requirement
removed local version
removed ARM changes