### PR TITLE
6.5: Updated RT to v6.5.2-rt8

### DIFF
--- a/6.5/misc/0001-rt.patch
+++ b/6.5/misc/0001-rt.patch
@@ -1,5 +1,5 @@
 diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index 16df141bd..ae4ec7137 100644
+index 16df141..ae4ec71 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
 @@ -116,6 +116,7 @@ config X86
@@ -19,7 +19,7 @@ index 16df141bd..ae4ec7137 100644
  	select MMU_GATHER_MERGE_VMAS
  	select HAVE_POSIX_CPU_TIMERS_TASK_WORK
 diff --git a/arch/x86/include/asm/preempt.h b/arch/x86/include/asm/preempt.h
-index 2d13f25b1..5b096893f 100644
+index 2d13f25..5b09689 100644
 --- a/arch/x86/include/asm/preempt.h
 +++ b/arch/x86/include/asm/preempt.h
 @@ -90,18 +90,49 @@ static __always_inline void __preempt_count_sub(int val)
@@ -74,7 +74,7 @@ index 2d13f25b1..5b096893f 100644
  
  #ifdef CONFIG_PREEMPTION
 diff --git a/arch/x86/include/asm/thread_info.h b/arch/x86/include/asm/thread_info.h
-index d63b02940..2de8ec302 100644
+index d63b029..2de8ec3 100644
 --- a/arch/x86/include/asm/thread_info.h
 +++ b/arch/x86/include/asm/thread_info.h
 @@ -57,6 +57,8 @@ struct thread_info {
@@ -111,7 +111,7 @@ index d63b02940..2de8ec302 100644
  #define _TIF_IO_BITMAP		(1 << TIF_IO_BITMAP)
  #define _TIF_SPEC_FORCE_UPDATE	(1 << TIF_SPEC_FORCE_UPDATE)
 diff --git a/arch/x86/kernel/cpu/common.c b/arch/x86/kernel/cpu/common.c
-index e3a65e9fc..1b27c47c5 100644
+index e3a65e9..1b27c47 100644
 --- a/arch/x86/kernel/cpu/common.c
 +++ b/arch/x86/kernel/cpu/common.c
 @@ -2300,8 +2300,7 @@ void store_cpu_caps(struct cpuinfo_x86 *curr_info)
@@ -125,7 +125,7 @@ index e3a65e9fc..1b27c47c5 100644
   * Return: None
   */
 diff --git a/arch/x86/kernel/cpu/microcode/core.c b/arch/x86/kernel/cpu/microcode/core.c
-index 3afcf3de0..2f9d35744 100644
+index 3afcf3d..2f9d357 100644
 --- a/arch/x86/kernel/cpu/microcode/core.c
 +++ b/arch/x86/kernel/cpu/microcode/core.c
 @@ -54,15 +54,12 @@ LIST_HEAD(microcode_cache);
@@ -156,7 +156,7 @@ index 3afcf3de0..2f9d35744 100644
  	cpus_read_unlock();
  
 diff --git a/drivers/block/zram/zram_drv.c b/drivers/block/zram/zram_drv.c
-index 06673c6ca..a5d0f7c06 100644
+index 06673c6..a5d0f7c 100644
 --- a/drivers/block/zram/zram_drv.c
 +++ b/drivers/block/zram/zram_drv.c
 @@ -57,6 +57,41 @@ static void zram_free_page(struct zram *zram, size_t index);
@@ -218,7 +218,7 @@ index 06673c6ca..a5d0f7c06 100644
  }
  
 diff --git a/drivers/block/zram/zram_drv.h b/drivers/block/zram/zram_drv.h
-index ca7a15bd4..e64eb607e 100644
+index ca7a15b..e64eb60 100644
 --- a/drivers/block/zram/zram_drv.h
 +++ b/drivers/block/zram/zram_drv.h
 @@ -69,6 +69,9 @@ struct zram_table_entry {
@@ -232,7 +232,7 @@ index ca7a15bd4..e64eb607e 100644
  	ktime_t ac_time;
  #endif
 diff --git a/drivers/gpu/drm/i915/Kconfig b/drivers/gpu/drm/i915/Kconfig
-index 01b5a8272..0741b52cb 100644
+index 01b5a82..0741b52 100644
 --- a/drivers/gpu/drm/i915/Kconfig
 +++ b/drivers/gpu/drm/i915/Kconfig
 @@ -3,7 +3,6 @@ config DRM_I915
@@ -244,7 +244,7 @@ index 01b5a8272..0741b52cb 100644
  	select INTERVAL_TREE
  	# we need shmfs for the swappable backing store, and in particular
 diff --git a/drivers/gpu/drm/i915/display/intel_crtc.c b/drivers/gpu/drm/i915/display/intel_crtc.c
-index 182c6dd64..e7083689c 100644
+index 182c6dd..e708368 100644
 --- a/drivers/gpu/drm/i915/display/intel_crtc.c
 +++ b/drivers/gpu/drm/i915/display/intel_crtc.c
 @@ -534,7 +534,8 @@ void intel_pipe_update_start(struct intel_crtc_state *new_crtc_state)
@@ -294,7 +294,7 @@ index 182c6dd64..e7083689c 100644
  	if (intel_vgpu_active(dev_priv))
  		return;
 diff --git a/drivers/gpu/drm/i915/display/intel_vblank.c b/drivers/gpu/drm/i915/display/intel_vblank.c
-index f5659ebd0..5b6d2f555 100644
+index f5659eb..5b6d2f5 100644
 --- a/drivers/gpu/drm/i915/display/intel_vblank.c
 +++ b/drivers/gpu/drm/i915/display/intel_vblank.c
 @@ -294,7 +294,8 @@ static bool i915_get_crtc_scanoutpos(struct drm_crtc *_crtc,
@@ -318,7 +318,7 @@ index f5659ebd0..5b6d2f555 100644
  	spin_unlock_irqrestore(&dev_priv->uncore.lock, irqflags);
  
 diff --git a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
-index ecc990ec1..8d04b1068 100644
+index ecc990e..8d04b10 100644
 --- a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
 +++ b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
 @@ -312,10 +312,9 @@ void __intel_breadcrumbs_park(struct intel_breadcrumbs *b)
@@ -335,7 +335,7 @@ index ecc990ec1..8d04b1068 100644
  }
  
 diff --git a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
-index 2ebd937f3..e155866f9 100644
+index 2ebd937..e155866 100644
 --- a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 +++ b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 @@ -1303,7 +1303,7 @@ static void execlists_dequeue(struct intel_engine_cs *engine)
@@ -365,7 +365,7 @@ index 2ebd937f3..e155866f9 100644
  			return; /* leave this for another sibling */
  		}
  
-@@ -1591,7 +1591,7 @@ static void execlists_dequeue(struct intel_engine_cs *engine)
+@@ -1591,7 +1591,7 @@ done:
  	 */
  	sched_engine->queue_priority_hint = queue_prio(sched_engine);
  	i915_sched_engine_reset_on_empty(sched_engine);
@@ -374,7 +374,7 @@ index 2ebd937f3..e155866f9 100644
  
  	/*
  	 * We can skip poking the HW if we ended up with exactly the same set
-@@ -1617,13 +1617,6 @@ static void execlists_dequeue(struct intel_engine_cs *engine)
+@@ -1617,13 +1617,6 @@ done:
  	}
  }
  
@@ -398,7 +398,7 @@ index 2ebd937f3..e155866f9 100644
  	}
  
 diff --git a/drivers/gpu/drm/i915/gt/intel_reset.c b/drivers/gpu/drm/i915/gt/intel_reset.c
-index e2152f75b..6916eba3b 100644
+index e2152f7..6916eba 100644
 --- a/drivers/gpu/drm/i915/gt/intel_reset.c
 +++ b/drivers/gpu/drm/i915/gt/intel_reset.c
 @@ -167,13 +167,13 @@ static int i915_do_reset(struct intel_gt *gt,
@@ -455,7 +455,7 @@ index e2152f75b..6916eba3b 100644
  		wa_14015076503_end(gt, reset_mask);
  	}
 diff --git a/drivers/gpu/drm/i915/i915_request.c b/drivers/gpu/drm/i915/i915_request.c
-index 833b73ede..d8c383109 100644
+index 833b73e..d8c3831 100644
 --- a/drivers/gpu/drm/i915/i915_request.c
 +++ b/drivers/gpu/drm/i915/i915_request.c
 @@ -612,7 +612,6 @@ bool __i915_request_submit(struct i915_request *request)
@@ -475,7 +475,7 @@ index 833b73ede..d8c383109 100644
  
  	/*
 diff --git a/drivers/gpu/drm/i915/i915_trace.h b/drivers/gpu/drm/i915/i915_trace.h
-index f6f9228a1..0ff1b60be 100644
+index f6f9228..0ff1b60 100644
 --- a/drivers/gpu/drm/i915/i915_trace.h
 +++ b/drivers/gpu/drm/i915/i915_trace.h
 @@ -6,6 +6,10 @@
@@ -499,7 +499,7 @@ index f6f9228a1..0ff1b60be 100644
  	     TP_PROTO(struct i915_request *rq),
  	     TP_ARGS(rq)
 diff --git a/drivers/gpu/drm/i915/i915_utils.h b/drivers/gpu/drm/i915/i915_utils.h
-index c61066498..48e19e55d 100644
+index c610664..48e19e5 100644
 --- a/drivers/gpu/drm/i915/i915_utils.h
 +++ b/drivers/gpu/drm/i915/i915_utils.h
 @@ -288,7 +288,7 @@ wait_remaining_ms_from_jiffies(unsigned long timestamp_jiffies, int to_wait_ms)
@@ -512,7 +512,7 @@ index c61066498..48e19e55d 100644
  #else
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) do { } while (0)
 diff --git a/drivers/tty/serial/8250/8250.h b/drivers/tty/serial/8250/8250.h
-index 1aa3e55c8..2ec04e071 100644
+index 1aa3e55..2ec04e0 100644
 --- a/drivers/tty/serial/8250/8250.h
 +++ b/drivers/tty/serial/8250/8250.h
 @@ -176,6 +176,271 @@ static inline void serial_dl_write(struct uart_8250_port *up, u32 value)
@@ -806,7 +806,7 @@ index 1aa3e55c8..2ec04e071 100644
  }
  
 diff --git a/drivers/tty/serial/8250/8250_aspeed_vuart.c b/drivers/tty/serial/8250/8250_aspeed_vuart.c
-index 4a9e71b2d..e813de4fd 100644
+index 4a9e71b..e813de4 100644
 --- a/drivers/tty/serial/8250/8250_aspeed_vuart.c
 +++ b/drivers/tty/serial/8250/8250_aspeed_vuart.c
 @@ -281,7 +281,7 @@ static void __aspeed_vuart_set_throttle(struct uart_8250_port *up,
@@ -819,7 +819,7 @@ index 4a9e71b2d..e813de4fd 100644
  static void aspeed_vuart_set_throttle(struct uart_port *port, bool throttle)
  {
 diff --git a/drivers/tty/serial/8250/8250_bcm7271.c b/drivers/tty/serial/8250/8250_bcm7271.c
-index d4b05d7ad..f29e09d04 100644
+index d4b05d7..f29e09d 100644
 --- a/drivers/tty/serial/8250/8250_bcm7271.c
 +++ b/drivers/tty/serial/8250/8250_bcm7271.c
 @@ -610,7 +610,7 @@ static int brcmuart_startup(struct uart_port *port)
@@ -878,7 +878,7 @@ index d4b05d7ad..f29e09d04 100644
  	spin_unlock_irqrestore(&p->lock, flags);
  	return HRTIMER_NORESTART;
 diff --git a/drivers/tty/serial/8250/8250_core.c b/drivers/tty/serial/8250/8250_core.c
-index 3449f8790..40d521640 100644
+index 3449f87..40d5216 100644
 --- a/drivers/tty/serial/8250/8250_core.c
 +++ b/drivers/tty/serial/8250/8250_core.c
 @@ -256,6 +256,7 @@ static void serial8250_timeout(struct timer_list *t)
@@ -983,7 +983,7 @@ index 3449f8790..40d521640 100644
  }
  
 diff --git a/drivers/tty/serial/8250/8250_exar.c b/drivers/tty/serial/8250/8250_exar.c
-index 077c3ba35..81e6c9a32 100644
+index 077c3ba..81e6c9a 100644
 --- a/drivers/tty/serial/8250/8250_exar.c
 +++ b/drivers/tty/serial/8250/8250_exar.c
 @@ -189,6 +189,10 @@ static void xr17v35x_set_divisor(struct uart_port *p, unsigned int baud,
@@ -1007,7 +1007,7 @@ index 077c3ba35..81e6c9a32 100644
  
  	return serial8250_do_startup(port);
 diff --git a/drivers/tty/serial/8250/8250_fsl.c b/drivers/tty/serial/8250/8250_fsl.c
-index 6af4e1c12..24c76e46e 100644
+index 6af4e1c..24c76e4 100644
 --- a/drivers/tty/serial/8250/8250_fsl.c
 +++ b/drivers/tty/serial/8250/8250_fsl.c
 @@ -70,7 +70,8 @@ int fsl8250_handle_irq(struct uart_port *port)
@@ -1021,7 +1021,7 @@ index 6af4e1c12..24c76e46e 100644
  			port->ops->stop_rx(port);
  		} else {
 diff --git a/drivers/tty/serial/8250/8250_mtk.c b/drivers/tty/serial/8250/8250_mtk.c
-index 74da5676c..899d3febc 100644
+index 74da567..899d3fe 100644
 --- a/drivers/tty/serial/8250/8250_mtk.c
 +++ b/drivers/tty/serial/8250/8250_mtk.c
 @@ -222,18 +222,44 @@ static void mtk8250_shutdown(struct uart_port *port)
@@ -1072,7 +1072,7 @@ index 74da5676c..899d3febc 100644
  
  static void mtk8250_set_flow_ctrl(struct uart_8250_port *up, int mode)
 diff --git a/drivers/tty/serial/8250/8250_omap.c b/drivers/tty/serial/8250/8250_omap.c
-index d48a82f16..00207bfc3 100644
+index d48a82f..00207bf 100644
 --- a/drivers/tty/serial/8250/8250_omap.c
 +++ b/drivers/tty/serial/8250/8250_omap.c
 @@ -339,8 +339,7 @@ static void omap8250_restore_regs(struct uart_8250_port *up)
@@ -1155,7 +1155,7 @@ index d48a82f16..00207bfc3 100644
  }
  
 diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
-index 483bb552c..7bb97df2c 100644
+index 483bb55..7bb97df 100644
 --- a/drivers/tty/serial/8250/8250_port.c
 +++ b/drivers/tty/serial/8250/8250_port.c
 @@ -689,7 +689,7 @@ static void serial8250_set_sleep(struct uart_8250_port *p, int sleep)
@@ -1402,7 +1402,7 @@ index 483bb552c..7bb97df2c 100644
  
  	if (lsr & UART_LSR_TEMT && iir & UART_IIR_NO_INT) {
  		if (!(up->bugs & UART_BUG_TXEN)) {
-@@ -2438,7 +2472,7 @@ int serial8250_do_startup(struct uart_port *port)
+@@ -2438,7 +2472,7 @@ dont_test_tx_en:
  	if (up->dma) {
  		const char *msg = NULL;
  
@@ -1789,7 +1789,7 @@ index 483bb552c..7bb97df2c 100644
  		uart_parse_options(options, &baud, &parity, &bits, &flow);
  	else if (probe)
 diff --git a/drivers/tty/serial/8250/Kconfig b/drivers/tty/serial/8250/Kconfig
-index ee17cf5c4..b8896596c 100644
+index ee17cf5..b889659 100644
 --- a/drivers/tty/serial/8250/Kconfig
 +++ b/drivers/tty/serial/8250/Kconfig
 @@ -9,6 +9,7 @@ config SERIAL_8250
@@ -1801,7 +1801,7 @@ index ee17cf5c4..b8896596c 100644
  	  This selects whether you want to include the driver for the standard
  	  serial ports.  The standard answer is Y.  People who might say N
 diff --git a/drivers/tty/serial/amba-pl011.c b/drivers/tty/serial/amba-pl011.c
-index c5c3f4674..d67591160 100644
+index c5c3f46..d675911 100644
 --- a/drivers/tty/serial/amba-pl011.c
 +++ b/drivers/tty/serial/amba-pl011.c
 @@ -2326,18 +2326,24 @@ pl011_console_write(struct console *co, const char *s, unsigned int count)
@@ -1844,7 +1844,7 @@ index c5c3f4674..d67591160 100644
  	clk_disable(uap->clk);
  }
 diff --git a/drivers/tty/serial/omap-serial.c b/drivers/tty/serial/omap-serial.c
-index 82d35dbbf..511cf17d8 100644
+index 82d35db..511cf17 100644
 --- a/drivers/tty/serial/omap-serial.c
 +++ b/drivers/tty/serial/omap-serial.c
 @@ -1219,13 +1219,10 @@ serial_omap_console_write(struct console *co, const char *s,
@@ -1875,7 +1875,7 @@ index 82d35dbbf..511cf17d8 100644
  
  static int __init
 diff --git a/drivers/tty/tty_io.c b/drivers/tty/tty_io.c
-index 63db04b91..4778fc78d 100644
+index 63db04b..4778fc7 100644
 --- a/drivers/tty/tty_io.c
 +++ b/drivers/tty/tty_io.c
 @@ -3550,8 +3550,13 @@ static ssize_t show_cons_active(struct device *dev,
@@ -1895,7 +1895,7 @@ index 63db04b91..4778fc78d 100644
  			continue;
  		cs[i++] = c;
 diff --git a/fs/proc/consoles.c b/fs/proc/consoles.c
-index e0758fe79..ab9f42d47 100644
+index e0758fe..ab9f42d 100644
 --- a/fs/proc/consoles.c
 +++ b/fs/proc/consoles.c
 @@ -21,12 +21,14 @@ static int show_console_dev(struct seq_file *m, void *v)
@@ -1933,7 +1933,7 @@ index e0758fe79..ab9f42d47 100644
  		seq_printf(m, " %4d:%d", MAJOR(dev), MINOR(dev));
  
 diff --git a/include/linux/bottom_half.h b/include/linux/bottom_half.h
-index fc53e0ad5..448bbef47 100644
+index fc53e0a..448bbef 100644
 --- a/include/linux/bottom_half.h
 +++ b/include/linux/bottom_half.h
 @@ -35,8 +35,10 @@ static inline void local_bh_enable(void)
@@ -1948,7 +1948,7 @@ index fc53e0ad5..448bbef47 100644
  
  #endif /* _LINUX_BH_H */
 diff --git a/include/linux/console.h b/include/linux/console.h
-index d3195664b..1e9d5bc8f 100644
+index d319566..1e9d5bc 100644
 --- a/include/linux/console.h
 +++ b/include/linux/console.h
 @@ -16,7 +16,9 @@
@@ -2175,7 +2175,7 @@ index d3195664b..1e9d5bc8f 100644
  extern struct console *early_console;
  
 diff --git a/include/linux/entry-common.h b/include/linux/entry-common.h
-index d95ab85f9..3dc3704a3 100644
+index d95ab85..3dc3704 100644
 --- a/include/linux/entry-common.h
 +++ b/include/linux/entry-common.h
 @@ -57,9 +57,15 @@
@@ -2196,7 +2196,7 @@ index d95ab85f9..3dc3704a3 100644
  
  /**
 diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
-index a92bce40b..bf82980f5 100644
+index a92bce4..bf82980 100644
 --- a/include/linux/interrupt.h
 +++ b/include/linux/interrupt.h
 @@ -605,6 +605,35 @@ extern void __raise_softirq_irqoff(unsigned int nr);
@@ -2236,7 +2236,7 @@ index a92bce40b..bf82980f5 100644
  
  static inline struct task_struct *this_cpu_ksoftirqd(void)
 diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
-index b828c7a75..2f7abbaa0 100644
+index b828c7a..2f7abba 100644
 --- a/include/linux/netdevice.h
 +++ b/include/linux/netdevice.h
 @@ -3244,7 +3244,11 @@ struct softnet_data {
@@ -2252,7 +2252,7 @@ index b828c7a75..2f7abbaa0 100644
  
  static inline void input_queue_head_incr(struct softnet_data *sd)
 diff --git a/include/linux/preempt.h b/include/linux/preempt.h
-index 1424670df..3c56b6f38 100644
+index 1424670..3c56b6f 100644
 --- a/include/linux/preempt.h
 +++ b/include/linux/preempt.h
 @@ -197,6 +197,20 @@ extern void preempt_count_sub(int val);
@@ -2383,7 +2383,7 @@ index 1424670df..3c56b6f38 100644
  #endif /* CONFIG_SMP */
  
 diff --git a/include/linux/printk.h b/include/linux/printk.h
-index 8ef499ab3..b55662624 100644
+index 8ef499a..b556626 100644
 --- a/include/linux/printk.h
 +++ b/include/linux/printk.h
 @@ -139,6 +139,7 @@ void early_printk(const char *s, ...) { }
@@ -2438,8 +2438,76 @@ index 8ef499ab3..b55662624 100644
  #endif
  
  #ifdef CONFIG_SMP
+diff --git a/include/linux/sched/rt.h b/include/linux/sched/rt.h
+index 994c256..b2b9e6e 100644
+--- a/include/linux/sched/rt.h
++++ b/include/linux/sched/rt.h
+@@ -30,6 +30,10 @@ static inline bool task_is_realtime(struct task_struct *tsk)
+ }
+ 
+ #ifdef CONFIG_RT_MUTEXES
++extern void rt_mutex_pre_schedule(void);
++extern void rt_mutex_schedule(void);
++extern void rt_mutex_post_schedule(void);
++
+ /*
+  * Must hold either p->pi_lock or task_rq(p)->lock.
+  */
+diff --git a/include/linux/sched/task.h b/include/linux/sched/task.h
+index dd35ce2..a23af22 100644
+--- a/include/linux/sched/task.h
++++ b/include/linux/sched/task.h
+@@ -118,11 +118,47 @@ static inline struct task_struct *get_task_struct(struct task_struct *t)
+ }
+ 
+ extern void __put_task_struct(struct task_struct *t);
++extern void __put_task_struct_rcu_cb(struct rcu_head *rhp);
+ 
+ static inline void put_task_struct(struct task_struct *t)
+ {
+-	if (refcount_dec_and_test(&t->usage))
++	if (!refcount_dec_and_test(&t->usage))
++		return;
++
++	/*
++	 * In !RT, it is always safe to call __put_task_struct().
++	 * Under RT, we can only call it in preemptible context.
++	 */
++	if (!IS_ENABLED(CONFIG_PREEMPT_RT) || preemptible()) {
++		static DEFINE_WAIT_OVERRIDE_MAP(put_task_map, LD_WAIT_SLEEP);
++
++		lock_map_acquire_try(&put_task_map);
+ 		__put_task_struct(t);
++		lock_map_release(&put_task_map);
++		return;
++	}
++
++	/*
++	 * under PREEMPT_RT, we can't call put_task_struct
++	 * in atomic context because it will indirectly
++	 * acquire sleeping locks.
++	 *
++	 * call_rcu() will schedule delayed_put_task_struct_rcu()
++	 * to be called in process context.
++	 *
++	 * __put_task_struct() is called when
++	 * refcount_dec_and_test(&t->usage) succeeds.
++	 *
++	 * This means that it can't "conflict" with
++	 * put_task_struct_rcu_user() which abuses ->rcu the same
++	 * way; rcu_users has a reference so task->usage can't be
++	 * zero after rcu_users 1 -> 0 transition.
++	 *
++	 * delayed_free_task() also uses ->rcu, but it is only called
++	 * when it fails to fork a process. Therefore, there is no
++	 * way it can conflict with put_task_struct().
++	 */
++	call_rcu(&t->rcu, __put_task_struct_rcu_cb);
+ }
+ 
+ DEFINE_FREE(put_task, struct task_struct *, if (_T) put_task_struct(_T))
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 984931de0..7a680c907 100644
+index 984931d..7a680c9 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -936,6 +936,9 @@ struct task_struct {
@@ -2504,76 +2572,8 @@ index 984931de0..7a680c907 100644
  /*
   * cond_resched() and cond_resched_lock(): latency reduction via
   * explicit rescheduling in places that are safe. The return
-diff --git a/include/linux/sched/rt.h b/include/linux/sched/rt.h
-index 994c25640..b2b9e6eb9 100644
---- a/include/linux/sched/rt.h
-+++ b/include/linux/sched/rt.h
-@@ -30,6 +30,10 @@ static inline bool task_is_realtime(struct task_struct *tsk)
- }
- 
- #ifdef CONFIG_RT_MUTEXES
-+extern void rt_mutex_pre_schedule(void);
-+extern void rt_mutex_schedule(void);
-+extern void rt_mutex_post_schedule(void);
-+
- /*
-  * Must hold either p->pi_lock or task_rq(p)->lock.
-  */
-diff --git a/include/linux/sched/task.h b/include/linux/sched/task.h
-index dd35ce28b..a23af225c 100644
---- a/include/linux/sched/task.h
-+++ b/include/linux/sched/task.h
-@@ -118,11 +118,47 @@ static inline struct task_struct *get_task_struct(struct task_struct *t)
- }
- 
- extern void __put_task_struct(struct task_struct *t);
-+extern void __put_task_struct_rcu_cb(struct rcu_head *rhp);
- 
- static inline void put_task_struct(struct task_struct *t)
- {
--	if (refcount_dec_and_test(&t->usage))
-+	if (!refcount_dec_and_test(&t->usage))
-+		return;
-+
-+	/*
-+	 * In !RT, it is always safe to call __put_task_struct().
-+	 * Under RT, we can only call it in preemptible context.
-+	 */
-+	if (!IS_ENABLED(CONFIG_PREEMPT_RT) || preemptible()) {
-+		static DEFINE_WAIT_OVERRIDE_MAP(put_task_map, LD_WAIT_SLEEP);
-+
-+		lock_map_acquire_try(&put_task_map);
- 		__put_task_struct(t);
-+		lock_map_release(&put_task_map);
-+		return;
-+	}
-+
-+	/*
-+	 * under PREEMPT_RT, we can't call put_task_struct
-+	 * in atomic context because it will indirectly
-+	 * acquire sleeping locks.
-+	 *
-+	 * call_rcu() will schedule delayed_put_task_struct_rcu()
-+	 * to be called in process context.
-+	 *
-+	 * __put_task_struct() is called when
-+	 * refcount_dec_and_test(&t->usage) succeeds.
-+	 *
-+	 * This means that it can't "conflict" with
-+	 * put_task_struct_rcu_user() which abuses ->rcu the same
-+	 * way; rcu_users has a reference so task->usage can't be
-+	 * zero after rcu_users 1 -> 0 transition.
-+	 *
-+	 * delayed_free_task() also uses ->rcu, but it is only called
-+	 * when it fails to fork a process. Therefore, there is no
-+	 * way it can conflict with put_task_struct().
-+	 */
-+	call_rcu(&t->rcu, __put_task_struct_rcu_cb);
- }
- 
- DEFINE_FREE(put_task, struct task_struct *, if (_T) put_task_struct(_T))
 diff --git a/include/linux/seqlock.h b/include/linux/seqlock.h
-index 987a59d97..e9bd2f65d 100644
+index 987a59d..e9bd2f6 100644
 --- a/include/linux/seqlock.h
 +++ b/include/linux/seqlock.h
 @@ -512,8 +512,8 @@ do {									\
@@ -2587,7 +2587,7 @@ index 987a59d97..e9bd2f65d 100644
  
  /**
 diff --git a/include/linux/serial_8250.h b/include/linux/serial_8250.h
-index be65de65f..ceb7a1ce9 100644
+index be65de6..ceb7a1c 100644
 --- a/include/linux/serial_8250.h
 +++ b/include/linux/serial_8250.h
 @@ -153,6 +153,8 @@ struct uart_8250_port {
@@ -2623,7 +2623,7 @@ index be65de65f..ceb7a1ce9 100644
  int serial8250_console_exit(struct uart_port *port);
  
 diff --git a/include/linux/thread_info.h b/include/linux/thread_info.h
-index 9ea0b2806..00a01d50a 100644
+index 9ea0b28..00a01d5 100644
 --- a/include/linux/thread_info.h
 +++ b/include/linux/thread_info.h
 @@ -178,14 +178,65 @@ static __always_inline unsigned long read_ti_thread_flags(struct thread_info *ti
@@ -2712,7 +2712,7 @@ index 9ea0b2806..00a01d50a 100644
  
  #ifndef CONFIG_HAVE_ARCH_WITHIN_STACK_FRAMES
 diff --git a/include/linux/trace_events.h b/include/linux/trace_events.h
-index 1e8bbdb8d..936c79821 100644
+index 1e8bbdb..936c798 100644
 --- a/include/linux/trace_events.h
 +++ b/include/linux/trace_events.h
 @@ -81,6 +81,7 @@ struct trace_entry {
@@ -2750,7 +2750,7 @@ index 1e8bbdb8d..936c79821 100644
  	TRACE_FLAG_BH_OFF		= 0x80,
  };
 diff --git a/kernel/Kconfig.preempt b/kernel/Kconfig.preempt
-index c2f1fd95a..b787bb947 100644
+index c2f1fd9..b787bb9 100644
 --- a/kernel/Kconfig.preempt
 +++ b/kernel/Kconfig.preempt
 @@ -1,5 +1,11 @@
@@ -2775,7 +2775,7 @@ index c2f1fd95a..b787bb947 100644
  	help
  	  This option turns the kernel into a real-time kernel by replacing
 diff --git a/kernel/debug/kdb/kdb_io.c b/kernel/debug/kdb/kdb_io.c
-index 813cb6cf7..9443bc63c 100644
+index 813cb6c..9443bc6 100644
 --- a/kernel/debug/kdb/kdb_io.c
 +++ b/kernel/debug/kdb/kdb_io.c
 @@ -590,6 +590,8 @@ static void kdb_msg_write(const char *msg, int msg_len)
@@ -2788,7 +2788,7 @@ index 813cb6cf7..9443bc63c 100644
  		 * Set oops_in_progress to encourage the console drivers to
  		 * disregard their internal spin locks: in the current calling
 diff --git a/kernel/entry/common.c b/kernel/entry/common.c
-index be61332c6..c6301e520 100644
+index be61332..c6301e5 100644
 --- a/kernel/entry/common.c
 +++ b/kernel/entry/common.c
 @@ -155,7 +155,7 @@ static unsigned long exit_to_user_mode_loop(struct pt_regs *regs,
@@ -2810,7 +2810,7 @@ index be61332c6..c6301e520 100644
  	}
  }
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 95ca80492..36fb0b711 100644
+index 95ca804..36fb0b7 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -989,6 +989,14 @@ void __put_task_struct(struct task_struct *tsk)
@@ -2829,7 +2829,7 @@ index 95ca80492..36fb0b711 100644
  
  /*
 diff --git a/kernel/futex/futex.h b/kernel/futex/futex.h
-index b5379c0e6..58fbc34a5 100644
+index b5379c0..58fbc34 100644
 --- a/kernel/futex/futex.h
 +++ b/kernel/futex/futex.h
 @@ -254,6 +254,29 @@ double_unlock_hb(struct futex_hash_bucket *hb1, struct futex_hash_bucket *hb2)
@@ -2863,7 +2863,7 @@ index b5379c0e6..58fbc34a5 100644
  
  extern int futex_wait_requeue_pi(u32 __user *uaddr, unsigned int flags, u32
 diff --git a/kernel/futex/pi.c b/kernel/futex/pi.c
-index ce2889f12..1440fdcdb 100644
+index ce2889f..1440fdc 100644
 --- a/kernel/futex/pi.c
 +++ b/kernel/futex/pi.c
 @@ -1,6 +1,7 @@
@@ -2874,7 +2874,7 @@ index ce2889f12..1440fdcdb 100644
  #include <linux/sched/task.h>
  
  #include "futex.h"
-@@ -1002,6 +1003,12 @@ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int tryl
+@@ -1002,6 +1003,12 @@ retry_private:
  		goto no_block;
  	}
  
@@ -2887,7 +2887,7 @@ index ce2889f12..1440fdcdb 100644
  	rt_mutex_init_waiter(&rt_waiter);
  
  	/*
-@@ -1039,7 +1046,10 @@ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int tryl
+@@ -1039,7 +1046,10 @@ retry_private:
  	ret = rt_mutex_wait_proxy_lock(&q.pi_state->pi_mutex, to, &rt_waiter);
  
  cleanup:
@@ -2899,7 +2899,7 @@ index ce2889f12..1440fdcdb 100644
  	/*
  	 * If we failed to acquire the lock (deadlock/signal/timeout), we must
  	 * first acquire the hb->lock before removing the lock from the
-@@ -1051,7 +1061,6 @@ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int tryl
+@@ -1051,7 +1061,6 @@ cleanup:
  	 */
  	if (ret && !rt_mutex_cleanup_proxy_lock(&q.pi_state->pi_mutex, &rt_waiter))
  		ret = 0;
@@ -2908,7 +2908,7 @@ index ce2889f12..1440fdcdb 100644
  	/*
  	 * Fixup the pi_state owner and possibly acquire the lock if we
 diff --git a/kernel/futex/requeue.c b/kernel/futex/requeue.c
-index cba8b1a6a..26888cfa7 100644
+index cba8b1a..26888cf 100644
 --- a/kernel/futex/requeue.c
 +++ b/kernel/futex/requeue.c
 @@ -850,8 +850,8 @@ int futex_wait_requeue_pi(u32 __user *uaddr, unsigned int flags,
@@ -2923,7 +2923,7 @@ index cba8b1a6a..26888cfa7 100644
  			ret = 0;
  
 diff --git a/kernel/ksysfs.c b/kernel/ksysfs.c
-index aad7a3bfd..fe654a979 100644
+index aad7a3b..fe654a9 100644
 --- a/kernel/ksysfs.c
 +++ b/kernel/ksysfs.c
 @@ -167,6 +167,15 @@ KERNEL_ATTR_RO(vmcoreinfo);
@@ -2953,7 +2953,7 @@ index aad7a3bfd..fe654a979 100644
  	NULL
  };
 diff --git a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
-index 21db0df0e..e56585ef4 100644
+index 21db0df..e56585e 100644
 --- a/kernel/locking/rtmutex.c
 +++ b/kernel/locking/rtmutex.c
 @@ -218,6 +218,11 @@ static __always_inline bool rt_mutex_cmpxchg_acquire(struct rt_mutex_base *lock,
@@ -3059,7 +3059,7 @@ index 21db0df0e..e56585ef4 100644
  
  	return rt_mutex_slowlock(lock, NULL, state);
 diff --git a/kernel/locking/rwbase_rt.c b/kernel/locking/rwbase_rt.c
-index 25ec02394..b5e881250 100644
+index 25ec023..34a5956 100644
 --- a/kernel/locking/rwbase_rt.c
 +++ b/kernel/locking/rwbase_rt.c
 @@ -71,6 +71,7 @@ static int __sched __rwbase_read_lock(struct rwbase_rt *rwb,
@@ -3090,7 +3090,7 @@ index 25ec02394..b5e881250 100644
  	/* Force readers into slow path */
  	atomic_sub(READER_BIAS, &rwb->readers);
  
-+	rt_mutex_pre_schedule();
++	rwbase_pre_schedule();
 +
  	raw_spin_lock_irqsave(&rtm->wait_lock, flags);
  	if (__rwbase_write_trylock(rwb))
@@ -3099,7 +3099,7 @@ index 25ec02394..b5e881250 100644
  		if (rwbase_signal_pending_state(state, current)) {
  			rwbase_restore_current_state();
  			__rwbase_write_unlock(rwb, 0, flags);
-+			rt_mutex_post_schedule();
++			rwbase_post_schedule();
  			trace_contention_end(rwb, -EINTR);
  			return -EINTR;
  		}
@@ -3107,12 +3107,12 @@ index 25ec02394..b5e881250 100644
  
  out_unlock:
  	raw_spin_unlock_irqrestore(&rtm->wait_lock, flags);
-+	rt_mutex_post_schedule();
++	rwbase_post_schedule();
  	return 0;
  }
  
 diff --git a/kernel/locking/rwsem.c b/kernel/locking/rwsem.c
-index 9eabd585c..2340b6d90 100644
+index 9eabd58..2340b6d 100644
 --- a/kernel/locking/rwsem.c
 +++ b/kernel/locking/rwsem.c
 @@ -1427,8 +1427,14 @@ static inline void __downgrade_write(struct rw_semaphore *sem)
@@ -3132,7 +3132,7 @@ index 9eabd585c..2340b6d90 100644
  #include "rwbase_rt.c"
  
 diff --git a/kernel/locking/spinlock_rt.c b/kernel/locking/spinlock_rt.c
-index 48a19ed84..38e292454 100644
+index 48a19ed..38e2924 100644
 --- a/kernel/locking/spinlock_rt.c
 +++ b/kernel/locking/spinlock_rt.c
 @@ -37,6 +37,8 @@
@@ -3159,7 +3159,7 @@ index 48a19ed84..38e292454 100644
  /*
   * The common functions which get wrapped into the rwlock API.
 diff --git a/kernel/locking/ww_rt_mutex.c b/kernel/locking/ww_rt_mutex.c
-index d1473c624..c7196de83 100644
+index d1473c6..c7196de 100644
 --- a/kernel/locking/ww_rt_mutex.c
 +++ b/kernel/locking/ww_rt_mutex.c
 @@ -62,7 +62,7 @@ __ww_rt_mutex_lock(struct ww_mutex *lock, struct ww_acquire_ctx *ww_ctx,
@@ -3172,7 +3172,7 @@ index d1473c624..c7196de83 100644
  			ww_mutex_set_context_fastpath(lock, ww_ctx);
  		return 0;
 diff --git a/kernel/panic.c b/kernel/panic.c
-index 10effe40a..5af624f62 100644
+index 10effe4..5af624f 100644
 --- a/kernel/panic.c
 +++ b/kernel/panic.c
 @@ -275,6 +275,7 @@ static void panic_other_cpus_shutdown(bool crash_kexec)
@@ -3255,7 +3255,7 @@ index 10effe40a..5af624f62 100644
  
  #ifdef CONFIG_BUG
 diff --git a/kernel/printk/Makefile b/kernel/printk/Makefile
-index f5b388e81..b36683bd2 100644
+index f5b388e..b36683b 100644
 --- a/kernel/printk/Makefile
 +++ b/kernel/printk/Makefile
 @@ -1,6 +1,6 @@
@@ -3267,7 +3267,7 @@ index f5b388e81..b36683bd2 100644
  obj-$(CONFIG_PRINTK_INDEX)	+= index.o
  
 diff --git a/kernel/printk/internal.h b/kernel/printk/internal.h
-index 2a1770413..6631fd705 100644
+index 2a17704..6631fd7 100644
 --- a/kernel/printk/internal.h
 +++ b/kernel/printk/internal.h
 @@ -3,6 +3,8 @@
@@ -3456,7 +3456,7 @@ index 2a1770413..6631fd705 100644
 +
 +#endif
 diff --git a/kernel/printk/printk.c b/kernel/printk/printk.c
-index 357a4d18f..5b12e969c 100644
+index 357a4d1..5b12e96 100644
 --- a/kernel/printk/printk.c
 +++ b/kernel/printk/printk.c
 @@ -444,6 +444,21 @@ static int console_msg_format = MSG_FORMAT_DEFAULT;
@@ -3490,7 +3490,7 @@ index 357a4d18f..5b12e969c 100644
  
  /*
   * We cannot access per-CPU data (e.g. per-CPU flush irq_work) before
-@@ -698,9 +713,6 @@ static ssize_t msg_print_ext_body(char *buf, size_t size,
+@@ -698,9 +713,6 @@ out:
  	return len;
  }
  
@@ -3737,7 +3737,7 @@ index 357a4d18f..5b12e969c 100644
  				continue;
  			any_usable = true;
  
-@@ -2964,30 +3026,13 @@ static bool console_flush_all(bool do_cond_resched, u64 *next_seq, bool *handove
+@@ -2964,30 +3026,13 @@ abandon:
  	return false;
  }
  
@@ -4254,7 +4254,7 @@ index 357a4d18f..5b12e969c 100644
  int _printk_deferred(const char *fmt, ...)
 diff --git a/kernel/printk/printk_nobkl.c b/kernel/printk/printk_nobkl.c
 new file mode 100644
-index 000000000..e0b818a4f
+index 0000000..e0b818a
 --- /dev/null
 +++ b/kernel/printk/printk_nobkl.c
 @@ -0,0 +1,1825 @@
@@ -6084,7 +6084,7 @@ index 000000000..e0b818a4f
 +}
 +device_initcall(printk_init_ops);
 diff --git a/kernel/printk/printk_safe.c b/kernel/printk/printk_safe.c
-index ef0f9a204..a324eaeb2 100644
+index ef0f9a2..a324eae 100644
 --- a/kernel/printk/printk_safe.c
 +++ b/kernel/printk/printk_safe.c
 @@ -12,18 +12,41 @@
@@ -6151,7 +6151,7 @@ index ef0f9a204..a324eaeb2 100644
  	/* No obstacles. */
  	return vprintk_default(fmt, args);
 diff --git a/kernel/rcu/rcutorture.c b/kernel/rcu/rcutorture.c
-index 147551c23..b8e47e18e 100644
+index 147551c..b8e47e1 100644
 --- a/kernel/rcu/rcutorture.c
 +++ b/kernel/rcu/rcutorture.c
 @@ -2407,6 +2407,12 @@ static int rcutorture_booster_init(unsigned int cpu)
@@ -6168,7 +6168,7 @@ index 147551c23..b8e47e18e 100644
  
  	/* Don't allow time recalculation while creating a new task. */
 diff --git a/kernel/rcu/tree_stall.h b/kernel/rcu/tree_stall.h
-index b10b8349b..804306204 100644
+index b10b834..8043062 100644
 --- a/kernel/rcu/tree_stall.h
 +++ b/kernel/rcu/tree_stall.h
 @@ -8,6 +8,7 @@
@@ -6206,7 +6206,7 @@ index b10b8349b..804306204 100644
  
  static void print_cpu_stall(unsigned long gps)
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 688eef3bc..836bd4c5d 100644
+index 688eef3..836bd4c 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -1062,6 +1062,46 @@ void resched_curr(struct rq *rq)
@@ -6478,7 +6478,7 @@ index 688eef3bc..836bd4c5d 100644
  	 * The idle tasks have their own, simple scheduling class:
  	 */
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index f51d0f93d..41b594a80 100644
+index f51d0f9..41b594a 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -5402,7 +5402,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
@@ -6518,7 +6518,7 @@ index f51d0f93d..41b594a80 100644
  		check_preempt_curr(rq, p, 0);
  }
 diff --git a/kernel/sched/features.h b/kernel/sched/features.h
-index 546d212ef..c088a046e 100644
+index 546d212..c088a04 100644
 --- a/kernel/sched/features.h
 +++ b/kernel/sched/features.h
 @@ -37,6 +37,9 @@ SCHED_FEAT(NONTASK_CAPACITY, true)
@@ -6532,7 +6532,7 @@ index 546d212ef..c088a046e 100644
  
  /*
 diff --git a/kernel/sched/rt.c b/kernel/sched/rt.c
-index 00e0e5074..338cd1509 100644
+index 00e0e50..338cd15 100644
 --- a/kernel/sched/rt.c
 +++ b/kernel/sched/rt.c
 @@ -2247,8 +2247,11 @@ static int rto_next_cpu(struct root_domain *rd)
@@ -6549,7 +6549,7 @@ index 00e0e5074..338cd1509 100644
  		rd->rto_cpu = -1;
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 67cd7e1fd..cf7f315ff 100644
+index 67cd7e1..cf7f315 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2418,6 +2418,15 @@ extern void reweight_task(struct task_struct *p, int prio);
@@ -6569,7 +6569,7 @@ index 67cd7e1fd..cf7f315ff 100644
  extern void init_rt_bandwidth(struct rt_bandwidth *rt_b, u64 period, u64 runtime);
  extern bool sched_rt_bandwidth_account(struct rt_rq *rt_rq);
 diff --git a/kernel/signal.c b/kernel/signal.c
-index 128e9bb3d..6c9af878b 100644
+index 128e9bb..6c9af87 100644
 --- a/kernel/signal.c
 +++ b/kernel/signal.c
 @@ -2318,15 +2318,35 @@ static int ptrace_stop(int exit_code, int why, unsigned long message,
@@ -6614,10 +6614,10 @@ index 128e9bb3d..6c9af878b 100644
  	cgroup_leave_frozen(true);
  
 diff --git a/kernel/softirq.c b/kernel/softirq.c
-index 807b34ccd..334232227 100644
+index 807b34c..3342322 100644
 --- a/kernel/softirq.c
 +++ b/kernel/softirq.c
-@@ -247,6 +247,19 @@ void __local_bh_enable_ip(unsigned long ip, unsigned int cnt)
+@@ -247,6 +247,19 @@ out:
  }
  EXPORT_SYMBOL(__local_bh_enable_ip);
  
@@ -6746,10 +6746,10 @@ index 807b34ccd..334232227 100644
  }
  early_initcall(spawn_ksoftirqd);
 diff --git a/kernel/time/hrtimer.c b/kernel/time/hrtimer.c
-index 238262e4a..be97b2380 100644
+index 238262e..be97b23 100644
 --- a/kernel/time/hrtimer.c
 +++ b/kernel/time/hrtimer.c
-@@ -1808,7 +1808,7 @@ void hrtimer_interrupt(struct clock_event_device *dev)
+@@ -1808,7 +1808,7 @@ retry:
  	if (!ktime_before(now, cpu_base->softirq_expires_next)) {
  		cpu_base->softirq_expires_next = KTIME_MAX;
  		cpu_base->softirq_activated = 1;
@@ -6768,7 +6768,7 @@ index 238262e4a..be97b2380 100644
  
  	__hrtimer_run_queues(cpu_base, now, flags, HRTIMER_ACTIVE_HARD);
 diff --git a/kernel/time/tick-sched.c b/kernel/time/tick-sched.c
-index 4df14db4d..3bea1d0f2 100644
+index 4df14db..3bea1d0 100644
 --- a/kernel/time/tick-sched.c
 +++ b/kernel/time/tick-sched.c
 @@ -795,7 +795,7 @@ static void tick_nohz_restart(struct tick_sched *ts, ktime_t now)
@@ -6790,7 +6790,7 @@ index 4df14db4d..3bea1d0f2 100644
  
  	pr_warn("NOHZ tick-stop error: local softirq work is pending, handler #%02x!!!\n",
 diff --git a/kernel/time/timer.c b/kernel/time/timer.c
-index 63a8ce717..b3fbe97d1 100644
+index 63a8ce7..b3fbe97 100644
 --- a/kernel/time/timer.c
 +++ b/kernel/time/timer.c
 @@ -1470,9 +1470,16 @@ static inline void timer_base_unlock_expiry(struct timer_base *base)
@@ -6821,7 +6821,7 @@ index 63a8ce717..b3fbe97d1 100644
  
  /*
 diff --git a/kernel/trace/trace.c b/kernel/trace/trace.c
-index 8e64aaad5..2676f9fdc 100644
+index 2656ca3..8fa7566 100644
 --- a/kernel/trace/trace.c
 +++ b/kernel/trace/trace.c
 @@ -2720,11 +2720,19 @@ unsigned int tracing_gen_ctx_irq_test(unsigned int irqs_status)
@@ -6899,7 +6899,7 @@ index 8e64aaad5..2676f9fdc 100644
  
  void
 diff --git a/kernel/trace/trace_events.c b/kernel/trace/trace_events.c
-index 578f1f7d4..d69c28edf 100644
+index 578f1f7..d69c28e 100644
 --- a/kernel/trace/trace_events.c
 +++ b/kernel/trace/trace_events.c
 @@ -210,6 +210,7 @@ static int trace_define_common_fields(void)
@@ -6911,7 +6911,7 @@ index 578f1f7d4..d69c28edf 100644
  	return ret;
  }
 diff --git a/kernel/trace/trace_output.c b/kernel/trace/trace_output.c
-index db575094c..6e1b552fd 100644
+index db57509..6e1b552 100644
 --- a/kernel/trace/trace_output.c
 +++ b/kernel/trace/trace_output.c
 @@ -445,6 +445,7 @@ int trace_print_lat_fmt(struct trace_seq *s, struct trace_entry *entry)
@@ -6974,7 +6974,7 @@ index db575094c..6e1b552fd 100644
  		trace_seq_printf(s, "%x", entry->preempt_count >> 4);
  	else
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 7d3460c7a..4ff76c8c9 100644
+index 7d3460c..4ff76c8 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -5139,19 +5139,17 @@ static void __build_all_zonelists(void *data)
@@ -7014,7 +7014,7 @@ index 7d3460c7a..4ff76c8c9 100644
  
  static noinline void __init
 diff --git a/net/core/dev.c b/net/core/dev.c
-index 69a3e5446..dcbea7460 100644
+index 69a3e54..dcbea74 100644
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
 @@ -4536,15 +4536,6 @@ static void rps_trigger_softirq(void *data)
@@ -7079,7 +7079,7 @@ index 69a3e5446..dcbea7460 100644
  
  		init_gro_hash(&sd->backlog);
 diff --git a/net/core/skbuff.c b/net/core/skbuff.c
-index a29899206..e188f2232 100644
+index a298992..e188f22 100644
 --- a/net/core/skbuff.c
 +++ b/net/core/skbuff.c
 @@ -6762,8 +6762,13 @@ nodefer:	__kfree_skb(skb);
@@ -7098,7 +7098,7 @@ index a29899206..e188f2232 100644
  
  static void skb_splice_csum_page(struct sk_buff *skb, struct page *page,
 diff --git a/sound/soc/mediatek/mt8186/mt8186-afe-clk.c b/sound/soc/mediatek/mt8186/mt8186-afe-clk.c
-index 539e3a023..70ec10189 100644
+index 539e3a0..70ec101 100644
 --- a/sound/soc/mediatek/mt8186/mt8186-afe-clk.c
 +++ b/sound/soc/mediatek/mt8186/mt8186-afe-clk.c
 @@ -13,8 +13,6 @@


### PR DESCRIPTION
Based on [v6.5.2-rt8](https://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-rt-devel.git/tag/?h=v6.5.2-rt8) 
Removed patches related to ARM
Removed patches conflicting with EEVDF/TT
Removed EXPERT requirement for PREEMPT_RT
