### PR TITLE
6.6: Updated RT to v6.6-rc6-rt9

### DIFF
--- a/6.6/misc/0001-rt.patch
+++ b/6.6/misc/0001-rt.patch
@@ -1,7 +1,7 @@
-diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index a92a7b6..a6c87e4 100644
---- a/arch/x86/Kconfig
-+++ b/arch/x86/Kconfig
+diff --git a/linux-6.6-rc6/arch/x86/Kconfig b/rc6-cachy-rt/arch/x86/Kconfig
+index a2e163a..4ac96d2 100644
+--- a/linux-6.6-rc6/arch/x86/Kconfig
++++ b/rc6-cachy-rt/arch/x86/Kconfig
 @@ -117,6 +117,7 @@ config X86
  	select ARCH_USES_CFI_TRAPS		if X86_64 && CFI_CLANG
  	select ARCH_SUPPORTS_LTO_CLANG
@@ -18,10 +18,10 @@ index a92a7b6..a6c87e4 100644
  	select MMU_GATHER_RCU_TABLE_FREE	if PARAVIRT
  	select MMU_GATHER_MERGE_VMAS
  	select HAVE_POSIX_CPU_TIMERS_TASK_WORK
-diff --git a/arch/x86/include/asm/preempt.h b/arch/x86/include/asm/preempt.h
+diff --git a/linux-6.6-rc6/arch/x86/include/asm/preempt.h b/rc6-cachy-rt/arch/x86/include/asm/preempt.h
 index 2d13f25..5b09689 100644
---- a/arch/x86/include/asm/preempt.h
-+++ b/arch/x86/include/asm/preempt.h
+--- a/linux-6.6-rc6/arch/x86/include/asm/preempt.h
++++ b/rc6-cachy-rt/arch/x86/include/asm/preempt.h
 @@ -90,18 +90,49 @@ static __always_inline void __preempt_count_sub(int val)
   * a decrement which hits zero means we have no preempt_count and should
   * reschedule.
@@ -73,10 +73,10 @@ index 2d13f25..5b09689 100644
  }
  
  #ifdef CONFIG_PREEMPTION
-diff --git a/arch/x86/include/asm/thread_info.h b/arch/x86/include/asm/thread_info.h
+diff --git a/linux-6.6-rc6/arch/x86/include/asm/thread_info.h b/rc6-cachy-rt/arch/x86/include/asm/thread_info.h
 index d63b029..2de8ec3 100644
---- a/arch/x86/include/asm/thread_info.h
-+++ b/arch/x86/include/asm/thread_info.h
+--- a/linux-6.6-rc6/arch/x86/include/asm/thread_info.h
++++ b/rc6-cachy-rt/arch/x86/include/asm/thread_info.h
 @@ -57,6 +57,8 @@ struct thread_info {
  	unsigned long		flags;		/* low level flags */
  	unsigned long		syscall_work;	/* SYSCALL_WORK_ flags */
@@ -110,10 +110,10 @@ index d63b029..2de8ec3 100644
  #define _TIF_POLLING_NRFLAG	(1 << TIF_POLLING_NRFLAG)
  #define _TIF_IO_BITMAP		(1 << TIF_IO_BITMAP)
  #define _TIF_SPEC_FORCE_UPDATE	(1 << TIF_SPEC_FORCE_UPDATE)
-diff --git a/drivers/block/zram/zram_drv.c b/drivers/block/zram/zram_drv.c
+diff --git a/linux-6.6-rc6/drivers/block/zram/zram_drv.c b/rc6-cachy-rt/drivers/block/zram/zram_drv.c
 index 06673c6..a5d0f7c 100644
---- a/drivers/block/zram/zram_drv.c
-+++ b/drivers/block/zram/zram_drv.c
+--- a/linux-6.6-rc6/drivers/block/zram/zram_drv.c
++++ b/rc6-cachy-rt/drivers/block/zram/zram_drv.c
 @@ -57,6 +57,41 @@ static void zram_free_page(struct zram *zram, size_t index);
  static int zram_read_page(struct zram *zram, struct page *page, u32 index,
  			  struct bio *parent);
@@ -172,10 +172,10 @@ index 06673c6..a5d0f7c 100644
  	return true;
  }
  
-diff --git a/drivers/block/zram/zram_drv.h b/drivers/block/zram/zram_drv.h
+diff --git a/linux-6.6-rc6/drivers/block/zram/zram_drv.h b/rc6-cachy-rt/drivers/block/zram/zram_drv.h
 index ca7a15b..e64eb60 100644
---- a/drivers/block/zram/zram_drv.h
-+++ b/drivers/block/zram/zram_drv.h
+--- a/linux-6.6-rc6/drivers/block/zram/zram_drv.h
++++ b/rc6-cachy-rt/drivers/block/zram/zram_drv.h
 @@ -69,6 +69,9 @@ struct zram_table_entry {
  		unsigned long element;
  	};
@@ -186,10 +186,10 @@ index ca7a15b..e64eb60 100644
  #ifdef CONFIG_ZRAM_MEMORY_TRACKING
  	ktime_t ac_time;
  #endif
-diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c b/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
 index 172aa10..4ae4720 100644
---- a/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
-+++ b/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
 @@ -60,11 +60,9 @@ static DEFINE_PER_CPU(int, fpu_recursion_depth);
   */
  inline void dc_assert_fp_enabled(void)
@@ -288,10 +288,10 @@ index 172aa10..4ae4720 100644
 +	TRACE_DCN_FPU(false, function_name, line, depth);
 +	preempt_enable();
  }
-diff --git a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
 index d587f80..5036a3e 100644
---- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
-+++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
 @@ -2141,9 +2141,17 @@ bool dcn20_validate_bandwidth(struct dc *dc, struct dc_state *context,
  		bool fast_validate)
  {
@@ -311,10 +311,10 @@ index d587f80..5036a3e 100644
  	return voltage_supported;
  }
  
-diff --git a/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c b/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
 index d1a25fe..5674c34 100644
---- a/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
-+++ b/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
 @@ -953,9 +953,17 @@ static bool dcn21_validate_bandwidth(struct dc *dc, struct dc_state *context,
  		bool fast_validate)
  {
@@ -334,10 +334,10 @@ index d1a25fe..5674c34 100644
  	return voltage_supported;
  }
  
-diff --git a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
 index 5805fb0..2ad9249 100644
---- a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
-+++ b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
 @@ -1923,7 +1923,7 @@ void dcn20_patch_bounding_box(struct dc *dc, struct _vcs_dpi_soc_bounding_box_st
  }
  
@@ -426,10 +426,10 @@ index 5805fb0..2ad9249 100644
  
  	BW_VAL_TRACE_FINISH();
  
-diff --git a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
 index c51badf..b6c3419 100644
---- a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
-+++ b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
+--- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
++++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
 @@ -61,9 +61,8 @@ void dcn20_update_bounding_box(struct dc *dc,
  			       unsigned int num_states);
  void dcn20_patch_bounding_box(struct dc *dc,
@@ -454,10 +454,10 @@ index c51badf..b6c3419 100644
  void dcn21_update_bw_bounding_box(struct dc *dc, struct clk_bw_params *bw_params);
  
  void dcn21_clk_mgr_set_bw_params_wm_table(struct clk_bw_params *bw_params);
-diff --git a/drivers/gpu/drm/i915/Kconfig b/drivers/gpu/drm/i915/Kconfig
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/Kconfig b/rc6-cachy-rt/drivers/gpu/drm/i915/Kconfig
 index ce397a8..98c3f53 100644
---- a/drivers/gpu/drm/i915/Kconfig
-+++ b/drivers/gpu/drm/i915/Kconfig
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/Kconfig
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/Kconfig
 @@ -3,7 +3,6 @@ config DRM_I915
  	tristate "Intel 8xx/9xx/G3x/G4x/HD Graphics"
  	depends on DRM
@@ -466,10 +466,10 @@ index ce397a8..98c3f53 100644
  	select INTEL_GTT if X86
  	select INTERVAL_TREE
  	# we need shmfs for the swappable backing store, and in particular
-diff --git a/drivers/gpu/drm/i915/display/intel_crtc.c b/drivers/gpu/drm/i915/display/intel_crtc.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_crtc.c b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_crtc.c
 index 182c6dd..e708368 100644
---- a/drivers/gpu/drm/i915/display/intel_crtc.c
-+++ b/drivers/gpu/drm/i915/display/intel_crtc.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_crtc.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_crtc.c
 @@ -534,7 +534,8 @@ void intel_pipe_update_start(struct intel_crtc_state *new_crtc_state)
  	 */
  	intel_psr_wait_for_idle_locked(new_crtc_state);
@@ -516,10 +516,10 @@ index 182c6dd..e708368 100644
  
  	if (intel_vgpu_active(dev_priv))
  		return;
-diff --git a/drivers/gpu/drm/i915/display/intel_vblank.c b/drivers/gpu/drm/i915/display/intel_vblank.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_vblank.c b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_vblank.c
 index f5659eb..5b6d2f5 100644
---- a/drivers/gpu/drm/i915/display/intel_vblank.c
-+++ b/drivers/gpu/drm/i915/display/intel_vblank.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_vblank.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_vblank.c
 @@ -294,7 +294,8 @@ static bool i915_get_crtc_scanoutpos(struct drm_crtc *_crtc,
  	 */
  	spin_lock_irqsave(&dev_priv->uncore.lock, irqflags);
@@ -540,10 +540,10 @@ index f5659eb..5b6d2f5 100644
  
  	spin_unlock_irqrestore(&dev_priv->uncore.lock, irqflags);
  
-diff --git a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
 index ecc990e..8d04b10 100644
---- a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
-+++ b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
 @@ -312,10 +312,9 @@ void __intel_breadcrumbs_park(struct intel_breadcrumbs *b)
  	/* Kick the work once more to drain the signalers, and disarm the irq */
  	irq_work_sync(&b->irq_work);
@@ -557,10 +557,10 @@ index ecc990e..8d04b10 100644
  	}
  }
  
-diff --git a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_execlists_submission.c b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 index 3292524..00cb9fd 100644
---- a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
-+++ b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 @@ -1303,7 +1303,7 @@ static void execlists_dequeue(struct intel_engine_cs *engine)
  	 * and context switches) submission.
  	 */
@@ -620,10 +620,10 @@ index 3292524..00cb9fd 100644
  		start_timeslice(engine);
  	}
  
-diff --git a/drivers/gpu/drm/i915/gt/intel_reset.c b/drivers/gpu/drm/i915/gt/intel_reset.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_reset.c b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_reset.c
 index cc6bd21..cdbc08d 100644
---- a/drivers/gpu/drm/i915/gt/intel_reset.c
-+++ b/drivers/gpu/drm/i915/gt/intel_reset.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_reset.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_reset.c
 @@ -164,13 +164,13 @@ static int i915_do_reset(struct intel_gt *gt,
  	/* Assert reset for at least 20 usec, and wait for acknowledgement. */
  	pci_write_config_byte(pdev, I915_GDRST, GRDOM_RESET_ENABLE);
@@ -677,10 +677,10 @@ index cc6bd21..cdbc08d 100644
  
  		wa_14015076503_end(gt, reset_mask);
  	}
-diff --git a/drivers/gpu/drm/i915/gt/uc/intel_guc.h b/drivers/gpu/drm/i915/gt/uc/intel_guc.h
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/uc/intel_guc.h b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/uc/intel_guc.h
 index 8dc291f..5b8d084 100644
---- a/drivers/gpu/drm/i915/gt/uc/intel_guc.h
-+++ b/drivers/gpu/drm/i915/gt/uc/intel_guc.h
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/uc/intel_guc.h
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/uc/intel_guc.h
 @@ -317,7 +317,7 @@ static inline int intel_guc_send_busy_loop(struct intel_guc *guc,
  {
  	int err;
@@ -690,10 +690,10 @@ index 8dc291f..5b8d084 100644
  
  	/*
  	 * FIXME: Have caller pass in if we are in an atomic context to avoid
-diff --git a/drivers/gpu/drm/i915/i915_request.c b/drivers/gpu/drm/i915/i915_request.c
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_request.c b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_request.c
 index f590810..014d020 100644
---- a/drivers/gpu/drm/i915/i915_request.c
-+++ b/drivers/gpu/drm/i915/i915_request.c
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_request.c
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_request.c
 @@ -609,7 +609,6 @@ bool __i915_request_submit(struct i915_request *request)
  
  	RQ_TRACE(request, "\n");
@@ -710,10 +710,10 @@ index f590810..014d020 100644
  	lockdep_assert_held(&engine->sched_engine->lock);
  
  	/*
-diff --git a/drivers/gpu/drm/i915/i915_trace.h b/drivers/gpu/drm/i915/i915_trace.h
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_trace.h b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_trace.h
 index ce1cbee..3c51620 100644
---- a/drivers/gpu/drm/i915/i915_trace.h
-+++ b/drivers/gpu/drm/i915/i915_trace.h
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_trace.h
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_trace.h
 @@ -6,6 +6,10 @@
  #if !defined(_I915_TRACE_H_) || defined(TRACE_HEADER_MULTI_READ)
  #define _I915_TRACE_H_
@@ -734,10 +734,10 @@ index ce1cbee..3c51620 100644
  DEFINE_EVENT(i915_request, i915_request_guc_submit,
  	     TP_PROTO(struct i915_request *rq),
  	     TP_ARGS(rq)
-diff --git a/drivers/gpu/drm/i915/i915_utils.h b/drivers/gpu/drm/i915/i915_utils.h
+diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_utils.h b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_utils.h
 index c610664..48e19e5 100644
---- a/drivers/gpu/drm/i915/i915_utils.h
-+++ b/drivers/gpu/drm/i915/i915_utils.h
+--- a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_utils.h
++++ b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_utils.h
 @@ -288,7 +288,7 @@ wait_remaining_ms_from_jiffies(unsigned long timestamp_jiffies, int to_wait_ms)
  #define wait_for(COND, MS)		_wait_for((COND), (MS) * 1000, 10, 1000)
  
@@ -747,10 +747,10 @@ index c610664..48e19e5 100644
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) WARN_ON_ONCE((ATOMIC) && !in_atomic())
  #else
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) do { } while (0)
-diff --git a/drivers/tty/serial/21285.c b/drivers/tty/serial/21285.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/21285.c b/rc6-cachy-rt/drivers/tty/serial/21285.c
 index d756fcc..4de0c97 100644
---- a/drivers/tty/serial/21285.c
-+++ b/drivers/tty/serial/21285.c
+--- a/linux-6.6-rc6/drivers/tty/serial/21285.c
++++ b/rc6-cachy-rt/drivers/tty/serial/21285.c
 @@ -185,14 +185,14 @@ static void serial21285_break_ctl(struct uart_port *port, int break_state)
  	unsigned long flags;
  	unsigned int h_lcr;
@@ -786,10 +786,10 @@ index d756fcc..4de0c97 100644
  }
  
  static const char *serial21285_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/8250/8250_aspeed_vuart.c b/drivers/tty/serial/8250/8250_aspeed_vuart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_aspeed_vuart.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_aspeed_vuart.c
 index 4a9e71b..021949f 100644
---- a/drivers/tty/serial/8250/8250_aspeed_vuart.c
-+++ b/drivers/tty/serial/8250/8250_aspeed_vuart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_aspeed_vuart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_aspeed_vuart.c
 @@ -288,9 +288,9 @@ static void aspeed_vuart_set_throttle(struct uart_port *port, bool throttle)
  	struct uart_8250_port *up = up_to_u8250p(port);
  	unsigned long flags;
@@ -811,10 +811,10 @@ index 4a9e71b..021949f 100644
  
  	lsr = serial_port_in(port, UART_LSR);
  
-diff --git a/drivers/tty/serial/8250/8250_bcm7271.c b/drivers/tty/serial/8250/8250_bcm7271.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_bcm7271.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_bcm7271.c
 index aa5aff0..ff0662c 100644
---- a/drivers/tty/serial/8250/8250_bcm7271.c
-+++ b/drivers/tty/serial/8250/8250_bcm7271.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_bcm7271.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_bcm7271.c
 @@ -567,7 +567,7 @@ static irqreturn_t brcmuart_isr(int irq, void *dev_id)
  	if (interrupts == 0)
  		return IRQ_NONE;
@@ -926,10 +926,10 @@ index aa5aff0..ff0662c 100644
  	}
  
  	return 0;
-diff --git a/drivers/tty/serial/8250/8250_core.c b/drivers/tty/serial/8250/8250_core.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_core.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_core.c
 index 3449f87..0535e49 100644
---- a/drivers/tty/serial/8250/8250_core.c
-+++ b/drivers/tty/serial/8250/8250_core.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_core.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_core.c
 @@ -259,7 +259,7 @@ static void serial8250_backup_timeout(struct timer_list *t)
  	unsigned int iir, ier = 0, lsr;
  	unsigned long flags;
@@ -1010,10 +1010,10 @@ index 3449f87..0535e49 100644
  	}
  
  	uart_remove_one_port(&serial8250_reg, &uart->port);
-diff --git a/drivers/tty/serial/8250/8250_dma.c b/drivers/tty/serial/8250/8250_dma.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dma.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dma.c
 index 7fa6650..8b30ca8 100644
---- a/drivers/tty/serial/8250/8250_dma.c
-+++ b/drivers/tty/serial/8250/8250_dma.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dma.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dma.c
 @@ -22,7 +22,7 @@ static void __dma_tx_complete(void *param)
  	dma_sync_single_for_cpu(dma->txchan->device->dev, dma->tx_addr,
  				UART_XMIT_SIZE, DMA_TO_DEVICE);
@@ -1050,10 +1050,10 @@ index 7fa6650..8b30ca8 100644
  }
  
  int serial8250_tx_dma(struct uart_8250_port *p)
-diff --git a/drivers/tty/serial/8250/8250_dw.c b/drivers/tty/serial/8250/8250_dw.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dw.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dw.c
 index f4cafca..95d45dc 100644
---- a/drivers/tty/serial/8250/8250_dw.c
-+++ b/drivers/tty/serial/8250/8250_dw.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dw.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dw.c
 @@ -263,20 +263,20 @@ static int dw8250_handle_irq(struct uart_port *p)
  	 * so we limit the workaround only to non-DMA mode.
  	 */
@@ -1079,10 +1079,10 @@ index f4cafca..95d45dc 100644
  
  		if (status & (UART_LSR_DR | UART_LSR_BI)) {
  			dw8250_writel_ext(p, RZN1_UART_RDMACR, 0);
-diff --git a/drivers/tty/serial/8250/8250_exar.c b/drivers/tty/serial/8250/8250_exar.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_exar.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_exar.c
 index 077c3ba..07ad213 100644
---- a/drivers/tty/serial/8250/8250_exar.c
-+++ b/drivers/tty/serial/8250/8250_exar.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_exar.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_exar.c
 @@ -201,9 +201,9 @@ static int xr17v35x_startup(struct uart_port *port)
  	 *
  	 * Synchronize UART_IER access against the console.
@@ -1095,10 +1095,10 @@ index 077c3ba..07ad213 100644
  
  	return serial8250_do_startup(port);
  }
-diff --git a/drivers/tty/serial/8250/8250_fsl.c b/drivers/tty/serial/8250/8250_fsl.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_fsl.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_fsl.c
 index 6af4e1c..f522eb5 100644
---- a/drivers/tty/serial/8250/8250_fsl.c
-+++ b/drivers/tty/serial/8250/8250_fsl.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_fsl.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_fsl.c
 @@ -30,11 +30,11 @@ int fsl8250_handle_irq(struct uart_port *port)
  	unsigned int iir;
  	struct uart_8250_port *up = up_to_u8250p(port);
@@ -1122,10 +1122,10 @@ index 6af4e1c..f522eb5 100644
  		return 1;
  	}
  
-diff --git a/drivers/tty/serial/8250/8250_mtk.c b/drivers/tty/serial/8250/8250_mtk.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_mtk.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_mtk.c
 index 74da567..23457da 100644
---- a/drivers/tty/serial/8250/8250_mtk.c
-+++ b/drivers/tty/serial/8250/8250_mtk.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_mtk.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_mtk.c
 @@ -102,7 +102,7 @@ static void mtk8250_dma_rx_complete(void *param)
  	if (data->rx_status == DMA_RX_SHUTDOWN)
  		return;
@@ -1162,10 +1162,10 @@ index 74da567..23457da 100644
  	/* Don't rewrite B0 */
  	if (tty_termios_baud_rate(termios))
  		tty_termios_encode_baud_rate(termios, baud, baud);
-diff --git a/drivers/tty/serial/8250/8250_omap.c b/drivers/tty/serial/8250/8250_omap.c
-index 26dd089..9ea38e2 100644
---- a/drivers/tty/serial/8250/8250_omap.c
-+++ b/drivers/tty/serial/8250/8250_omap.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_omap.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_omap.c
+index ca972fd..999c660 100644
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_omap.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_omap.c
 @@ -401,7 +401,7 @@ static void omap_8250_set_termios(struct uart_port *port,
  	 * interrupts disabled.
  	 */
@@ -1342,7 +1342,7 @@ index 26dd089..9ea38e2 100644
  
  	status = serial_port_in(port, UART_LSR);
  
-@@ -1761,15 +1761,15 @@ static int omap8250_runtime_resume(struct device *dev)
+@@ -1756,15 +1756,15 @@ static int omap8250_runtime_resume(struct device *dev)
  		up = serial8250_get_port(priv->line);
  
  	if (up && omap8250_lost_context(up)) {
@@ -1362,10 +1362,10 @@ index 26dd089..9ea38e2 100644
  	}
  
  	priv->latency = priv->calc_latency;
-diff --git a/drivers/tty/serial/8250/8250_pci1xxxx.c b/drivers/tty/serial/8250/8250_pci1xxxx.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_pci1xxxx.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_pci1xxxx.c
 index a3b2577..53e238c 100644
---- a/drivers/tty/serial/8250/8250_pci1xxxx.c
-+++ b/drivers/tty/serial/8250/8250_pci1xxxx.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_pci1xxxx.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_pci1xxxx.c
 @@ -225,10 +225,10 @@ static bool pci1xxxx_port_suspend(int line)
  	if (port->suspended == 0 && port->dev) {
  		wakeup_mask = readb(up->port.membase + UART_WAKE_MASK_REG);
@@ -1392,10 +1392,10 @@ index a3b2577..53e238c 100644
  	}
  	mutex_unlock(&tport->mutex);
  }
-diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_port.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_port.c
 index 1416273..ed29d84 100644
---- a/drivers/tty/serial/8250/8250_port.c
-+++ b/drivers/tty/serial/8250/8250_port.c
+--- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_port.c
++++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_port.c
 @@ -557,6 +557,9 @@ static int serial8250_em485_init(struct uart_8250_port *p)
  	if (!p->em485)
  		return -ENOMEM;
@@ -1852,10 +1852,10 @@ index 1416273..ed29d84 100644
  }
  
  static unsigned int probe_baud(struct uart_port *port)
-diff --git a/drivers/tty/serial/altera_jtaguart.c b/drivers/tty/serial/altera_jtaguart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/altera_jtaguart.c b/rc6-cachy-rt/drivers/tty/serial/altera_jtaguart.c
 index 5fab4c9..7090b25 100644
---- a/drivers/tty/serial/altera_jtaguart.c
-+++ b/drivers/tty/serial/altera_jtaguart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/altera_jtaguart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/altera_jtaguart.c
 @@ -147,14 +147,14 @@ static irqreturn_t altera_jtaguart_interrupt(int irq, void *data)
  	isr = (readl(port->membase + ALTERA_JTAGUART_CONTROL_REG) >>
  	       ALTERA_JTAGUART_CONTROL_RI_OFF) & port->read_status_mask;
@@ -1949,10 +1949,10 @@ index 5fab4c9..7090b25 100644
  }
  #endif
  
-diff --git a/drivers/tty/serial/altera_uart.c b/drivers/tty/serial/altera_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/altera_uart.c b/rc6-cachy-rt/drivers/tty/serial/altera_uart.c
 index a9c4194..77835ac 100644
---- a/drivers/tty/serial/altera_uart.c
-+++ b/drivers/tty/serial/altera_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/altera_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/altera_uart.c
 @@ -164,13 +164,13 @@ static void altera_uart_break_ctl(struct uart_port *port, int break_state)
  	struct altera_uart *pp = container_of(port, struct altera_uart, port);
  	unsigned long flags;
@@ -2029,10 +2029,10 @@ index a9c4194..77835ac 100644
  
  	if (port->irq)
  		free_irq(port->irq, port);
-diff --git a/drivers/tty/serial/amba-pl010.c b/drivers/tty/serial/amba-pl010.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/amba-pl010.c b/rc6-cachy-rt/drivers/tty/serial/amba-pl010.c
 index b5a7404..eabbf8a 100644
---- a/drivers/tty/serial/amba-pl010.c
-+++ b/drivers/tty/serial/amba-pl010.c
+--- a/linux-6.6-rc6/drivers/tty/serial/amba-pl010.c
++++ b/rc6-cachy-rt/drivers/tty/serial/amba-pl010.c
 @@ -207,7 +207,7 @@ static irqreturn_t pl010_int(int irq, void *dev_id)
  	unsigned int status, pass_counter = AMBA_ISR_PASS_LIMIT;
  	int handled = 0;
@@ -2105,10 +2105,10 @@ index b5a7404..eabbf8a 100644
  		}
  	}
  }
-diff --git a/drivers/tty/serial/amba-pl011.c b/drivers/tty/serial/amba-pl011.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/amba-pl011.c b/rc6-cachy-rt/drivers/tty/serial/amba-pl011.c
 index 3dc9b0f..c6c2d3e 100644
---- a/drivers/tty/serial/amba-pl011.c
-+++ b/drivers/tty/serial/amba-pl011.c
+--- a/linux-6.6-rc6/drivers/tty/serial/amba-pl011.c
++++ b/rc6-cachy-rt/drivers/tty/serial/amba-pl011.c
 @@ -345,9 +345,9 @@ static int pl011_fifo_to_tty(struct uart_amba_port *uap)
  				flag = TTY_FRAME;
  		}
@@ -2402,10 +2402,10 @@ index 3dc9b0f..c6c2d3e 100644
  
  	clk_disable(uap->clk);
  }
-diff --git a/drivers/tty/serial/apbuart.c b/drivers/tty/serial/apbuart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/apbuart.c b/rc6-cachy-rt/drivers/tty/serial/apbuart.c
 index d7658f3..716cb01 100644
---- a/drivers/tty/serial/apbuart.c
-+++ b/drivers/tty/serial/apbuart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/apbuart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/apbuart.c
 @@ -133,7 +133,7 @@ static irqreturn_t apbuart_int(int irq, void *dev_id)
  	struct uart_port *port = dev_id;
  	unsigned int status;
@@ -2442,10 +2442,10 @@ index d7658f3..716cb01 100644
  }
  
  static const char *apbuart_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/ar933x_uart.c b/drivers/tty/serial/ar933x_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/ar933x_uart.c b/rc6-cachy-rt/drivers/tty/serial/ar933x_uart.c
 index 924c1a8..ffd2346 100644
---- a/drivers/tty/serial/ar933x_uart.c
-+++ b/drivers/tty/serial/ar933x_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/ar933x_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/ar933x_uart.c
 @@ -133,9 +133,9 @@ static unsigned int ar933x_uart_tx_empty(struct uart_port *port)
  	unsigned long flags;
  	unsigned int rdata;
@@ -2550,10 +2550,10 @@ index 924c1a8..ffd2346 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/drivers/tty/serial/arc_uart.c b/drivers/tty/serial/arc_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/arc_uart.c b/rc6-cachy-rt/drivers/tty/serial/arc_uart.c
 index ad4ae19..1aa5b2b 100644
---- a/drivers/tty/serial/arc_uart.c
-+++ b/drivers/tty/serial/arc_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/arc_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/arc_uart.c
 @@ -279,9 +279,9 @@ static irqreturn_t arc_serial_isr(int irq, void *dev_id)
  	if (status & RXIENB) {
  
@@ -2611,10 +2611,10 @@ index ad4ae19..1aa5b2b 100644
  }
  
  static struct console arc_console = {
-diff --git a/drivers/tty/serial/atmel_serial.c b/drivers/tty/serial/atmel_serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/atmel_serial.c b/rc6-cachy-rt/drivers/tty/serial/atmel_serial.c
 index 88cdafa..1946faf 100644
---- a/drivers/tty/serial/atmel_serial.c
-+++ b/drivers/tty/serial/atmel_serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/atmel_serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/atmel_serial.c
 @@ -861,7 +861,7 @@ static void atmel_complete_tx_dma(void *arg)
  	struct dma_chan *chan = atmel_port->chan_tx;
  	unsigned long flags;
@@ -2694,10 +2694,10 @@ index 88cdafa..1946faf 100644
  		}
  	}
  }
-diff --git a/drivers/tty/serial/bcm63xx_uart.c b/drivers/tty/serial/bcm63xx_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/bcm63xx_uart.c b/rc6-cachy-rt/drivers/tty/serial/bcm63xx_uart.c
 index 0dd8cce..4a08fd5 100644
---- a/drivers/tty/serial/bcm63xx_uart.c
-+++ b/drivers/tty/serial/bcm63xx_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/bcm63xx_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/bcm63xx_uart.c
 @@ -201,7 +201,7 @@ static void bcm_uart_break_ctl(struct uart_port *port, int ctl)
  	unsigned long flags;
  	unsigned int val;
@@ -2785,10 +2785,10 @@ index 0dd8cce..4a08fd5 100644
  	local_irq_restore(flags);
  }
  
-diff --git a/drivers/tty/serial/cpm_uart.c b/drivers/tty/serial/cpm_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/cpm_uart.c b/rc6-cachy-rt/drivers/tty/serial/cpm_uart.c
 index 6264230..be4af6e 100644
---- a/drivers/tty/serial/cpm_uart.c
-+++ b/drivers/tty/serial/cpm_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/cpm_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/cpm_uart.c
 @@ -569,7 +569,7 @@ static void cpm_uart_set_termios(struct uart_port *port,
  	if ((termios->c_cflag & CREAD) == 0)
  		port->read_status_mask &= ~BD_SC_EMPTY;
@@ -2819,10 +2819,10 @@ index 6264230..be4af6e 100644
  	}
  }
  
-diff --git a/drivers/tty/serial/digicolor-usart.c b/drivers/tty/serial/digicolor-usart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/digicolor-usart.c b/rc6-cachy-rt/drivers/tty/serial/digicolor-usart.c
 index 128b547..5004125 100644
---- a/drivers/tty/serial/digicolor-usart.c
-+++ b/drivers/tty/serial/digicolor-usart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/digicolor-usart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/digicolor-usart.c
 @@ -133,7 +133,7 @@ static void digicolor_uart_rx(struct uart_port *port)
  {
  	unsigned long flags;
@@ -2895,10 +2895,10 @@ index 128b547..5004125 100644
  
  	/* Wait for transmitter to become empty */
  	do {
-diff --git a/drivers/tty/serial/dz.c b/drivers/tty/serial/dz.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/dz.c b/rc6-cachy-rt/drivers/tty/serial/dz.c
 index 667f52e..6df7af9 100644
---- a/drivers/tty/serial/dz.c
-+++ b/drivers/tty/serial/dz.c
+--- a/linux-6.6-rc6/drivers/tty/serial/dz.c
++++ b/rc6-cachy-rt/drivers/tty/serial/dz.c
 @@ -268,9 +268,9 @@ static inline void dz_transmit_chars(struct dz_mux *mux)
  	}
  	/* If nothing to do or stopped or hardware stopped. */
@@ -3020,10 +3020,10 @@ index 667f52e..6df7af9 100644
  
  	do {
  		trdy = dz_in(dport, DZ_CSR);
-diff --git a/drivers/tty/serial/fsl_linflexuart.c b/drivers/tty/serial/fsl_linflexuart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/fsl_linflexuart.c b/rc6-cachy-rt/drivers/tty/serial/fsl_linflexuart.c
 index 249cb38..7fa809a 100644
---- a/drivers/tty/serial/fsl_linflexuart.c
-+++ b/drivers/tty/serial/fsl_linflexuart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/fsl_linflexuart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/fsl_linflexuart.c
 @@ -203,7 +203,7 @@ static irqreturn_t linflex_txint(int irq, void *dev_id)
  	struct circ_buf *xmit = &sport->state->xmit;
  	unsigned long flags;
@@ -3127,10 +3127,10 @@ index 249cb38..7fa809a 100644
  }
  
  /*
-diff --git a/drivers/tty/serial/fsl_lpuart.c b/drivers/tty/serial/fsl_lpuart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/fsl_lpuart.c b/rc6-cachy-rt/drivers/tty/serial/fsl_lpuart.c
 index f72e134..6d0cfb2 100644
---- a/drivers/tty/serial/fsl_lpuart.c
-+++ b/drivers/tty/serial/fsl_lpuart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/fsl_lpuart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/fsl_lpuart.c
 @@ -532,9 +532,9 @@ static void lpuart_dma_tx_complete(void *arg)
  	struct dma_chan *chan = sport->dma_tx_chan;
  	unsigned long flags;
@@ -3480,10 +3480,10 @@ index f72e134..6d0cfb2 100644
  			sport->dma_tx_in_progress = false;
  			dmaengine_terminate_sync(sport->dma_tx_chan);
  		}
-diff --git a/drivers/tty/serial/icom.c b/drivers/tty/serial/icom.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/icom.c b/rc6-cachy-rt/drivers/tty/serial/icom.c
 index 819f957..a75eafb 100644
---- a/drivers/tty/serial/icom.c
-+++ b/drivers/tty/serial/icom.c
+--- a/linux-6.6-rc6/drivers/tty/serial/icom.c
++++ b/rc6-cachy-rt/drivers/tty/serial/icom.c
 @@ -929,7 +929,7 @@ static inline void check_modem_status(struct icom_port *icom_port)
  	char delta_status;
  	unsigned char status;
@@ -3595,10 +3595,10 @@ index 819f957..a75eafb 100644
  }
  
  static const char *icom_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/imx.c b/drivers/tty/serial/imx.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/imx.c b/rc6-cachy-rt/drivers/tty/serial/imx.c
 index 13cb783..0fb679c 100644
---- a/drivers/tty/serial/imx.c
-+++ b/drivers/tty/serial/imx.c
+--- a/linux-6.6-rc6/drivers/tty/serial/imx.c
++++ b/rc6-cachy-rt/drivers/tty/serial/imx.c
 @@ -575,7 +575,7 @@ static void imx_uart_dma_tx_callback(void *data)
  	unsigned long flags;
  	u32 ucr1;
@@ -3913,10 +3913,10 @@ index 13cb783..0fb679c 100644
  }
  
  static void imx_uart_enable_wakeup(struct imx_port *sport, bool on)
-diff --git a/drivers/tty/serial/ip22zilog.c b/drivers/tty/serial/ip22zilog.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/ip22zilog.c b/rc6-cachy-rt/drivers/tty/serial/ip22zilog.c
 index 845ff70..320b29c 100644
---- a/drivers/tty/serial/ip22zilog.c
-+++ b/drivers/tty/serial/ip22zilog.c
+--- a/linux-6.6-rc6/drivers/tty/serial/ip22zilog.c
++++ b/rc6-cachy-rt/drivers/tty/serial/ip22zilog.c
 @@ -432,7 +432,7 @@ static irqreturn_t ip22zilog_interrupt(int irq, void *dev_id)
  		unsigned char r3;
  		bool push = false;
@@ -4062,10 +4062,10 @@ index 845ff70..320b29c 100644
  
  	if (options)
  		uart_parse_options(options, &baud, &parity, &bits, &flow);
-diff --git a/drivers/tty/serial/jsm/jsm_neo.c b/drivers/tty/serial/jsm/jsm_neo.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_neo.c b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_neo.c
 index 0c78f66..2bd6404 100644
---- a/drivers/tty/serial/jsm/jsm_neo.c
-+++ b/drivers/tty/serial/jsm/jsm_neo.c
+--- a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_neo.c
++++ b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_neo.c
 @@ -816,9 +816,9 @@ static void neo_parse_isr(struct jsm_board *brd, u32 port)
  		/* Parse any modem signal changes */
  		jsm_dbg(INTR, &ch->ch_bd->pci_dev,
@@ -4078,10 +4078,10 @@ index 0c78f66..2bd6404 100644
  	}
  }
  
-diff --git a/drivers/tty/serial/jsm/jsm_tty.c b/drivers/tty/serial/jsm/jsm_tty.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_tty.c b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_tty.c
 index 222afc2..ce0fef7 100644
---- a/drivers/tty/serial/jsm/jsm_tty.c
-+++ b/drivers/tty/serial/jsm/jsm_tty.c
+--- a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_tty.c
++++ b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_tty.c
 @@ -152,14 +152,14 @@ static void jsm_tty_send_xchar(struct uart_port *port, char ch)
  		container_of(port, struct jsm_channel, uart_port);
  	struct ktermios *termios;
@@ -4151,10 +4151,10 @@ index 222afc2..ce0fef7 100644
  }
  
  static const char *jsm_tty_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/liteuart.c b/drivers/tty/serial/liteuart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/liteuart.c b/rc6-cachy-rt/drivers/tty/serial/liteuart.c
 index d881cdd..a25ab1e 100644
---- a/drivers/tty/serial/liteuart.c
-+++ b/drivers/tty/serial/liteuart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/liteuart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/liteuart.c
 @@ -139,13 +139,13 @@ static irqreturn_t liteuart_interrupt(int irq, void *data)
  	 * if polling, the context would be "in_serving_softirq", so use
  	 * irq[save|restore] spin_lock variants to cover all possibilities
@@ -4224,10 +4224,10 @@ index d881cdd..a25ab1e 100644
  }
  
  static int liteuart_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/lpc32xx_hs.c b/drivers/tty/serial/lpc32xx_hs.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/lpc32xx_hs.c b/rc6-cachy-rt/drivers/tty/serial/lpc32xx_hs.c
 index b38fe47..5149a94 100644
---- a/drivers/tty/serial/lpc32xx_hs.c
-+++ b/drivers/tty/serial/lpc32xx_hs.c
+--- a/linux-6.6-rc6/drivers/tty/serial/lpc32xx_hs.c
++++ b/rc6-cachy-rt/drivers/tty/serial/lpc32xx_hs.c
 @@ -140,15 +140,15 @@ static void lpc32xx_hsuart_console_write(struct console *co, const char *s,
  	if (up->port.sysrq)
  		locked = 0;
@@ -4336,10 +4336,10 @@ index b38fe47..5149a94 100644
  
  	/* Don't rewrite B0 */
  	if (tty_termios_baud_rate(termios))
-diff --git a/drivers/tty/serial/ma35d1_serial.c b/drivers/tty/serial/ma35d1_serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/ma35d1_serial.c b/rc6-cachy-rt/drivers/tty/serial/ma35d1_serial.c
 index 465b1de..6fac924 100644
---- a/drivers/tty/serial/ma35d1_serial.c
-+++ b/drivers/tty/serial/ma35d1_serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/ma35d1_serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/ma35d1_serial.c
 @@ -269,16 +269,16 @@ static void receive_chars(struct uart_ma35d1_port *up)
  		if (uart_handle_sysrq_char(&up->port, ch))
  			continue;
@@ -4417,10 +4417,10 @@ index 465b1de..6fac924 100644
  }
  
  static int __init ma35d1serial_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/mcf.c b/drivers/tty/serial/mcf.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/mcf.c b/rc6-cachy-rt/drivers/tty/serial/mcf.c
 index 1666ce0..91b1524 100644
---- a/drivers/tty/serial/mcf.c
-+++ b/drivers/tty/serial/mcf.c
+--- a/linux-6.6-rc6/drivers/tty/serial/mcf.c
++++ b/rc6-cachy-rt/drivers/tty/serial/mcf.c
 @@ -135,12 +135,12 @@ static void mcf_break_ctl(struct uart_port *port, int break_state)
  {
  	unsigned long flags;
@@ -4508,10 +4508,10 @@ index 1666ce0..91b1524 100644
  
  	return ret;
  }
-diff --git a/drivers/tty/serial/men_z135_uart.c b/drivers/tty/serial/men_z135_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/men_z135_uart.c b/rc6-cachy-rt/drivers/tty/serial/men_z135_uart.c
 index d2502aa..8048fa5 100644
---- a/drivers/tty/serial/men_z135_uart.c
-+++ b/drivers/tty/serial/men_z135_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/men_z135_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/men_z135_uart.c
 @@ -392,7 +392,7 @@ static irqreturn_t men_z135_intr(int irq, void *data)
  	if (!irq_id)
  		goto out;
@@ -4548,10 +4548,10 @@ index d2502aa..8048fa5 100644
  }
  
  static const char *men_z135_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/meson_uart.c b/drivers/tty/serial/meson_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/meson_uart.c b/rc6-cachy-rt/drivers/tty/serial/meson_uart.c
 index 790d910..45cc23e 100644
---- a/drivers/tty/serial/meson_uart.c
-+++ b/drivers/tty/serial/meson_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/meson_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/meson_uart.c
 @@ -129,14 +129,14 @@ static void meson_uart_shutdown(struct uart_port *port)
  
  	free_irq(port->irq, port);
@@ -4679,10 +4679,10 @@ index 790d910..45cc23e 100644
  	local_irq_restore(flags);
  }
  
-diff --git a/drivers/tty/serial/milbeaut_usio.c b/drivers/tty/serial/milbeaut_usio.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/milbeaut_usio.c b/rc6-cachy-rt/drivers/tty/serial/milbeaut_usio.c
 index 70a9100..db3b81f 100644
---- a/drivers/tty/serial/milbeaut_usio.c
-+++ b/drivers/tty/serial/milbeaut_usio.c
+--- a/linux-6.6-rc6/drivers/tty/serial/milbeaut_usio.c
++++ b/rc6-cachy-rt/drivers/tty/serial/milbeaut_usio.c
 @@ -207,9 +207,9 @@ static irqreturn_t mlb_usio_rx_irq(int irq, void *dev_id)
  {
  	struct uart_port *port = dev_id;
@@ -4744,10 +4744,10 @@ index 70a9100..db3b81f 100644
  }
  
  static const char *mlb_usio_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/mpc52xx_uart.c b/drivers/tty/serial/mpc52xx_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/mpc52xx_uart.c b/rc6-cachy-rt/drivers/tty/serial/mpc52xx_uart.c
 index 916507b..a252465 100644
---- a/drivers/tty/serial/mpc52xx_uart.c
-+++ b/drivers/tty/serial/mpc52xx_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/mpc52xx_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/mpc52xx_uart.c
 @@ -1096,14 +1096,14 @@ static void
  mpc52xx_uart_break_ctl(struct uart_port *port, int ctl)
  {
@@ -4797,10 +4797,10 @@ index 916507b..a252465 100644
  
  	return ret;
  }
-diff --git a/drivers/tty/serial/mps2-uart.c b/drivers/tty/serial/mps2-uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/mps2-uart.c b/rc6-cachy-rt/drivers/tty/serial/mps2-uart.c
 index ea5a791..2a4c09f 100644
---- a/drivers/tty/serial/mps2-uart.c
-+++ b/drivers/tty/serial/mps2-uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/mps2-uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/mps2-uart.c
 @@ -188,12 +188,12 @@ static irqreturn_t mps2_uart_rxirq(int irq, void *data)
  	if (unlikely(!(irqflag & UARTn_INT_RX)))
  		return IRQ_NONE;
@@ -4864,10 +4864,10 @@ index ea5a791..2a4c09f 100644
  
  	if (tty_termios_baud_rate(termios))
  		tty_termios_encode_baud_rate(termios, baud, baud);
-diff --git a/drivers/tty/serial/msm_serial.c b/drivers/tty/serial/msm_serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/msm_serial.c b/rc6-cachy-rt/drivers/tty/serial/msm_serial.c
 index 90953e6..597264b 100644
---- a/drivers/tty/serial/msm_serial.c
-+++ b/drivers/tty/serial/msm_serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/msm_serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/msm_serial.c
 @@ -444,7 +444,7 @@ static void msm_complete_tx_dma(void *args)
  	unsigned int count;
  	u32 val;
@@ -5012,10 +5012,10 @@ index 90953e6..597264b 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/drivers/tty/serial/mvebu-uart.c b/drivers/tty/serial/mvebu-uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/mvebu-uart.c b/rc6-cachy-rt/drivers/tty/serial/mvebu-uart.c
 index ea924e9..0255646 100644
---- a/drivers/tty/serial/mvebu-uart.c
-+++ b/drivers/tty/serial/mvebu-uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/mvebu-uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/mvebu-uart.c
 @@ -187,9 +187,9 @@ static unsigned int mvebu_uart_tx_empty(struct uart_port *port)
  	unsigned long flags;
  	unsigned int st;
@@ -5084,10 +5084,10 @@ index ea924e9..0255646 100644
  }
  
  static int mvebu_uart_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/omap-serial.c b/drivers/tty/serial/omap-serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/omap-serial.c b/rc6-cachy-rt/drivers/tty/serial/omap-serial.c
 index 0ead88c..90369ad 100644
---- a/drivers/tty/serial/omap-serial.c
-+++ b/drivers/tty/serial/omap-serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/omap-serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/omap-serial.c
 @@ -390,10 +390,10 @@ static void serial_omap_throttle(struct uart_port *port)
  	struct uart_omap_port *up = to_uart_omap_port(port);
  	unsigned long flags;
@@ -5234,10 +5234,10 @@ index 0ead88c..90369ad 100644
  }
  
  static int __init
-diff --git a/drivers/tty/serial/owl-uart.c b/drivers/tty/serial/owl-uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/owl-uart.c b/rc6-cachy-rt/drivers/tty/serial/owl-uart.c
 index e99970a..919f5e5 100644
---- a/drivers/tty/serial/owl-uart.c
-+++ b/drivers/tty/serial/owl-uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/owl-uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/owl-uart.c
 @@ -125,12 +125,12 @@ static unsigned int owl_uart_tx_empty(struct uart_port *port)
  	u32 val;
  	unsigned int ret;
@@ -5345,10 +5345,10 @@ index e99970a..919f5e5 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/drivers/tty/serial/pch_uart.c b/drivers/tty/serial/pch_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/pch_uart.c b/rc6-cachy-rt/drivers/tty/serial/pch_uart.c
 index cc83b77..436cc6d 100644
---- a/drivers/tty/serial/pch_uart.c
-+++ b/drivers/tty/serial/pch_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/pch_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/pch_uart.c
 @@ -1347,7 +1347,7 @@ static void pch_uart_set_termios(struct uart_port *port,
  	baud = uart_get_baud_rate(port, termios, old, 0, port->uartclk / 16);
  
@@ -5389,10 +5389,10 @@ index cc83b77..436cc6d 100644
  	if (priv_locked)
  		spin_unlock(&priv->lock);
  	local_irq_restore(flags);
-diff --git a/drivers/tty/serial/pic32_uart.c b/drivers/tty/serial/pic32_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/pic32_uart.c b/rc6-cachy-rt/drivers/tty/serial/pic32_uart.c
 index e308d50..3a95bf5 100644
---- a/drivers/tty/serial/pic32_uart.c
-+++ b/drivers/tty/serial/pic32_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/pic32_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/pic32_uart.c
 @@ -243,7 +243,7 @@ static void pic32_uart_break_ctl(struct uart_port *port, int ctl)
  	struct pic32_sport *sport = to_pic32_sport(port);
  	unsigned long flags;
@@ -5471,10 +5471,10 @@ index e308d50..3a95bf5 100644
  }
  
  /* serial core request to claim uart iomem */
-diff --git a/drivers/tty/serial/pmac_zilog.c b/drivers/tty/serial/pmac_zilog.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/pmac_zilog.c b/rc6-cachy-rt/drivers/tty/serial/pmac_zilog.c
 index 13668ff..c8bf08c 100644
---- a/drivers/tty/serial/pmac_zilog.c
-+++ b/drivers/tty/serial/pmac_zilog.c
+--- a/linux-6.6-rc6/drivers/tty/serial/pmac_zilog.c
++++ b/rc6-cachy-rt/drivers/tty/serial/pmac_zilog.c
 @@ -246,9 +246,9 @@ static bool pmz_receive_chars(struct uart_pmac_port *uap)
  #endif /* USE_CTRL_O_SYSRQ */
  		if (uap->port.sysrq) {
@@ -5667,10 +5667,10 @@ index 13668ff..c8bf08c 100644
  }
  
  /*
-diff --git a/drivers/tty/serial/pxa.c b/drivers/tty/serial/pxa.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/pxa.c b/rc6-cachy-rt/drivers/tty/serial/pxa.c
 index 73c60f5..46e70e1 100644
---- a/drivers/tty/serial/pxa.c
-+++ b/drivers/tty/serial/pxa.c
+--- a/linux-6.6-rc6/drivers/tty/serial/pxa.c
++++ b/rc6-cachy-rt/drivers/tty/serial/pxa.c
 @@ -225,14 +225,14 @@ static inline irqreturn_t serial_pxa_irq(int irq, void *dev_id)
  	iir = serial_in(up, UART_IIR);
  	if (iir & UART_IIR_NO_INT)
@@ -5781,10 +5781,10 @@ index 73c60f5..46e70e1 100644
  	local_irq_restore(flags);
  	clk_disable(up->clk);
  
-diff --git a/drivers/tty/serial/qcom_geni_serial.c b/drivers/tty/serial/qcom_geni_serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/qcom_geni_serial.c b/rc6-cachy-rt/drivers/tty/serial/qcom_geni_serial.c
 index b8aa4c1..7e78f97 100644
---- a/drivers/tty/serial/qcom_geni_serial.c
-+++ b/drivers/tty/serial/qcom_geni_serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/qcom_geni_serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/qcom_geni_serial.c
 @@ -482,9 +482,9 @@ static void qcom_geni_serial_console_write(struct console *co, const char *s,
  
  	uport = &port->uport;
@@ -5815,10 +5815,10 @@ index b8aa4c1..7e78f97 100644
  
  	m_irq_status = readl(uport->membase + SE_GENI_M_IRQ_STATUS);
  	s_irq_status = readl(uport->membase + SE_GENI_S_IRQ_STATUS);
-diff --git a/drivers/tty/serial/rda-uart.c b/drivers/tty/serial/rda-uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/rda-uart.c b/rc6-cachy-rt/drivers/tty/serial/rda-uart.c
 index be5c842..d824c83 100644
---- a/drivers/tty/serial/rda-uart.c
-+++ b/drivers/tty/serial/rda-uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/rda-uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/rda-uart.c
 @@ -139,12 +139,12 @@ static unsigned int rda_uart_tx_empty(struct uart_port *port)
  	unsigned int ret;
  	u32 val;
@@ -5956,10 +5956,10 @@ index be5c842..d824c83 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/drivers/tty/serial/rp2.c b/drivers/tty/serial/rp2.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/rp2.c b/rc6-cachy-rt/drivers/tty/serial/rp2.c
 index de220ac..d46a81c 100644
---- a/drivers/tty/serial/rp2.c
-+++ b/drivers/tty/serial/rp2.c
+--- a/linux-6.6-rc6/drivers/tty/serial/rp2.c
++++ b/rc6-cachy-rt/drivers/tty/serial/rp2.c
 @@ -276,9 +276,9 @@ static unsigned int rp2_uart_tx_empty(struct uart_port *port)
  	 * But the TXEMPTY bit doesn't seem to work unless the TX IRQ is
  	 * enabled.
@@ -6034,10 +6034,10 @@ index de220ac..d46a81c 100644
  }
  
  static const char *rp2_uart_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/sa1100.c b/drivers/tty/serial/sa1100.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sa1100.c b/rc6-cachy-rt/drivers/tty/serial/sa1100.c
 index ad011f1..be7bcd7 100644
---- a/drivers/tty/serial/sa1100.c
-+++ b/drivers/tty/serial/sa1100.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sa1100.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sa1100.c
 @@ -115,9 +115,9 @@ static void sa1100_timeout(struct timer_list *t)
  	unsigned long flags;
  
@@ -6115,10 +6115,10 @@ index ad011f1..be7bcd7 100644
  }
  
  static const char *sa1100_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/samsung_tty.c b/drivers/tty/serial/samsung_tty.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/samsung_tty.c b/rc6-cachy-rt/drivers/tty/serial/samsung_tty.c
 index 07fb8a9..ee51a03 100644
---- a/drivers/tty/serial/samsung_tty.c
-+++ b/drivers/tty/serial/samsung_tty.c
+--- a/linux-6.6-rc6/drivers/tty/serial/samsung_tty.c
++++ b/rc6-cachy-rt/drivers/tty/serial/samsung_tty.c
 @@ -248,7 +248,7 @@ static void s3c24xx_serial_rx_enable(struct uart_port *port)
  	unsigned int ucon, ufcon;
  	int count = 10000;
@@ -6324,10 +6324,10 @@ index 07fb8a9..ee51a03 100644
  }
  
  /* Shouldn't be __init, as it can be instantiated from other module */
-diff --git a/drivers/tty/serial/sb1250-duart.c b/drivers/tty/serial/sb1250-duart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sb1250-duart.c b/rc6-cachy-rt/drivers/tty/serial/sb1250-duart.c
 index f3cd693..dbec29d 100644
---- a/drivers/tty/serial/sb1250-duart.c
-+++ b/drivers/tty/serial/sb1250-duart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sb1250-duart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sb1250-duart.c
 @@ -610,7 +610,7 @@ static void sbd_set_termios(struct uart_port *uport, struct ktermios *termios,
  	else
  		aux &= ~M_DUART_CTS_CHNG_ENA;
@@ -6373,10 +6373,10 @@ index f3cd693..dbec29d 100644
  }
  
  static int __init sbd_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/sc16is7xx.c b/drivers/tty/serial/sc16is7xx.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sc16is7xx.c b/rc6-cachy-rt/drivers/tty/serial/sc16is7xx.c
 index f61d98e..9d8307f 100644
---- a/drivers/tty/serial/sc16is7xx.c
-+++ b/drivers/tty/serial/sc16is7xx.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sc16is7xx.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sc16is7xx.c
 @@ -667,9 +667,9 @@ static void sc16is7xx_handle_tx(struct uart_port *port)
  	}
  
@@ -6518,10 +6518,10 @@ index f61d98e..9d8307f 100644
  
  	return 0;
  }
-diff --git a/drivers/tty/serial/serial-tegra.c b/drivers/tty/serial/serial-tegra.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/serial-tegra.c b/rc6-cachy-rt/drivers/tty/serial/serial-tegra.c
 index d4ec943..6d4006b 100644
---- a/drivers/tty/serial/serial-tegra.c
-+++ b/drivers/tty/serial/serial-tegra.c
+--- a/linux-6.6-rc6/drivers/tty/serial/serial-tegra.c
++++ b/rc6-cachy-rt/drivers/tty/serial/serial-tegra.c
 @@ -411,7 +411,7 @@ static int tegra_set_baudrate(struct tegra_uart_port *tup, unsigned int baud)
  		divisor = DIV_ROUND_CLOSEST(rate, baud * 16);
  	}
@@ -6658,10 +6658,10 @@ index d4ec943..6d4006b 100644
  }
  
  static const char *tegra_uart_type(struct uart_port *u)
-diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
-index 7bdc21d..b32bbd7 100644
---- a/drivers/tty/serial/serial_core.c
-+++ b/drivers/tty/serial/serial_core.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_core.c b/rc6-cachy-rt/drivers/tty/serial/serial_core.c
+index d5ba6e9..557796e 100644
+--- a/linux-6.6-rc6/drivers/tty/serial/serial_core.c
++++ b/rc6-cachy-rt/drivers/tty/serial/serial_core.c
 @@ -79,7 +79,7 @@ static inline void uart_port_deref(struct uart_port *uport)
  	({								\
  		struct uart_port *__uport = uart_port_ref(state);	\
@@ -6772,7 +6772,19 @@ index 7bdc21d..b32bbd7 100644
  	uart_port_deref(uport);
  
  	icount->cts         = cnow.cts;
-@@ -1422,9 +1422,9 @@ static int uart_get_rs485_config(struct uart_port *port,
+@@ -1413,9 +1413,9 @@ static int uart_rs485_config(struct uart_port *port)
+ 	uart_sanitize_serial_rs485(port, rs485);
+ 	uart_set_rs485_termination(port, rs485);
+ 
+-	spin_lock_irqsave(&port->lock, flags);
++	uart_port_lock_irqsave(port, &flags);
+ 	ret = port->rs485_config(port, NULL, rs485);
+-	spin_unlock_irqrestore(&port->lock, flags);
++	uart_port_unlock_irqrestore(port, flags);
+ 	if (ret)
+ 		memset(rs485, 0, sizeof(*rs485));
+ 
+@@ -1428,9 +1428,9 @@ static int uart_get_rs485_config(struct uart_port *port,
  	unsigned long flags;
  	struct serial_rs485 aux;
  
@@ -6784,7 +6796,7 @@ index 7bdc21d..b32bbd7 100644
  
  	if (copy_to_user(rs485, &aux, sizeof(aux)))
  		return -EFAULT;
-@@ -1451,7 +1451,7 @@ static int uart_set_rs485_config(struct tty_struct *tty, struct uart_port *port,
+@@ -1457,7 +1457,7 @@ static int uart_set_rs485_config(struct tty_struct *tty, struct uart_port *port,
  	uart_sanitize_serial_rs485(port, &rs485);
  	uart_set_rs485_termination(port, &rs485);
  
@@ -6793,7 +6805,7 @@ index 7bdc21d..b32bbd7 100644
  	ret = port->rs485_config(port, &tty->termios, &rs485);
  	if (!ret) {
  		port->rs485 = rs485;
-@@ -1460,7 +1460,7 @@ static int uart_set_rs485_config(struct tty_struct *tty, struct uart_port *port,
+@@ -1466,7 +1466,7 @@ static int uart_set_rs485_config(struct tty_struct *tty, struct uart_port *port,
  		if (!(rs485.flags & SER_RS485_ENABLED))
  			port->ops->set_mctrl(port, port->mctrl);
  	}
@@ -6802,7 +6814,7 @@ index 7bdc21d..b32bbd7 100644
  	if (ret)
  		return ret;
  
-@@ -1479,9 +1479,9 @@ static int uart_get_iso7816_config(struct uart_port *port,
+@@ -1485,9 +1485,9 @@ static int uart_get_iso7816_config(struct uart_port *port,
  	if (!port->iso7816_config)
  		return -ENOTTY;
  
@@ -6814,7 +6826,7 @@ index 7bdc21d..b32bbd7 100644
  
  	if (copy_to_user(iso7816, &aux, sizeof(aux)))
  		return -EFAULT;
-@@ -1510,9 +1510,9 @@ static int uart_set_iso7816_config(struct uart_port *port,
+@@ -1516,9 +1516,9 @@ static int uart_set_iso7816_config(struct uart_port *port,
  		if (iso7816.reserved[i])
  			return -EINVAL;
  
@@ -6826,7 +6838,7 @@ index 7bdc21d..b32bbd7 100644
  	if (ret)
  		return ret;
  
-@@ -1729,9 +1729,9 @@ static void uart_tty_port_shutdown(struct tty_port *port)
+@@ -1735,9 +1735,9 @@ static void uart_tty_port_shutdown(struct tty_port *port)
  	if (WARN(!uport, "detached port still initialized!\n"))
  		return;
  
@@ -6838,7 +6850,7 @@ index 7bdc21d..b32bbd7 100644
  
  	uart_port_shutdown(port);
  
-@@ -1745,10 +1745,10 @@ static void uart_tty_port_shutdown(struct tty_port *port)
+@@ -1751,10 +1751,10 @@ static void uart_tty_port_shutdown(struct tty_port *port)
  	/*
  	 * Free the transmit buffer.
  	 */
@@ -6851,7 +6863,7 @@ index 7bdc21d..b32bbd7 100644
  
  	free_page((unsigned long)buf);
  
-@@ -1891,10 +1891,10 @@ static bool uart_carrier_raised(struct tty_port *port)
+@@ -1897,10 +1897,10 @@ static bool uart_carrier_raised(struct tty_port *port)
  	 */
  	if (WARN_ON(!uport))
  		return true;
@@ -6864,7 +6876,7 @@ index 7bdc21d..b32bbd7 100644
  	uart_port_deref(uport);
  
  	return mctrl & TIOCM_CAR;
-@@ -2011,9 +2011,9 @@ static void uart_line_info(struct seq_file *m, struct uart_driver *drv, int i)
+@@ -2017,9 +2017,9 @@ static void uart_line_info(struct seq_file *m, struct uart_driver *drv, int i)
  		pm_state = state->pm_state;
  		if (pm_state != UART_PM_STATE_ON)
  			uart_change_pm(state, UART_PM_STATE_ON);
@@ -6876,7 +6888,7 @@ index 7bdc21d..b32bbd7 100644
  		if (pm_state != UART_PM_STATE_ON)
  			uart_change_pm(state, pm_state);
  
-@@ -2352,9 +2352,9 @@ int uart_suspend_port(struct uart_driver *drv, struct uart_port *uport)
+@@ -2358,9 +2358,9 @@ int uart_suspend_port(struct uart_driver *drv, struct uart_port *uport)
  	 */
  	if (!console_suspend_enabled && uart_console(uport)) {
  		if (uport->ops->start_rx) {
@@ -6888,7 +6900,7 @@ index 7bdc21d..b32bbd7 100644
  		}
  		goto unlock;
  	}
-@@ -2369,7 +2369,7 @@ int uart_suspend_port(struct uart_driver *drv, struct uart_port *uport)
+@@ -2375,7 +2375,7 @@ int uart_suspend_port(struct uart_driver *drv, struct uart_port *uport)
  		tty_port_set_suspended(port, true);
  		tty_port_set_initialized(port, false);
  
@@ -6897,7 +6909,7 @@ index 7bdc21d..b32bbd7 100644
  		ops->stop_tx(uport);
  		if (!(uport->rs485.flags & SER_RS485_ENABLED))
  			ops->set_mctrl(uport, 0);
-@@ -2377,7 +2377,7 @@ int uart_suspend_port(struct uart_driver *drv, struct uart_port *uport)
+@@ -2383,7 +2383,7 @@ int uart_suspend_port(struct uart_driver *drv, struct uart_port *uport)
  		mctrl = uport->mctrl;
  		uport->mctrl = 0;
  		ops->stop_rx(uport);
@@ -6906,7 +6918,7 @@ index 7bdc21d..b32bbd7 100644
  
  		/*
  		 * Wait for the transmitter to empty.
-@@ -2449,9 +2449,9 @@ int uart_resume_port(struct uart_driver *drv, struct uart_port *uport)
+@@ -2455,9 +2455,9 @@ int uart_resume_port(struct uart_driver *drv, struct uart_port *uport)
  			uart_change_pm(state, UART_PM_STATE_ON);
  		uport->ops->set_termios(uport, &termios, NULL);
  		if (!console_suspend_enabled && uport->ops->start_rx) {
@@ -6918,7 +6930,7 @@ index 7bdc21d..b32bbd7 100644
  		}
  		if (console_suspend_enabled)
  			console_start(uport->cons);
-@@ -2462,10 +2462,10 @@ int uart_resume_port(struct uart_driver *drv, struct uart_port *uport)
+@@ -2468,10 +2468,10 @@ int uart_resume_port(struct uart_driver *drv, struct uart_port *uport)
  		int ret;
  
  		uart_change_pm(state, UART_PM_STATE_ON);
@@ -6931,23 +6943,21 @@ index 7bdc21d..b32bbd7 100644
  		if (console_suspend_enabled || !uart_console(uport)) {
  			/* Protected by port mutex for now */
  			struct tty_struct *tty = port->tty;
-@@ -2474,13 +2474,13 @@ int uart_resume_port(struct uart_driver *drv, struct uart_port *uport)
- 			if (ret == 0) {
+@@ -2481,11 +2481,11 @@ int uart_resume_port(struct uart_driver *drv, struct uart_port *uport)
  				if (tty)
  					uart_change_line_settings(tty, state, NULL);
+ 				uart_rs485_config(uport);
 -				spin_lock_irq(&uport->lock);
 +				uart_port_lock_irq(uport);
  				if (!(uport->rs485.flags & SER_RS485_ENABLED))
  					ops->set_mctrl(uport, uport->mctrl);
- 				else
- 					uart_rs485_config(uport);
  				ops->start_tx(uport);
 -				spin_unlock_irq(&uport->lock);
 +				uart_port_unlock_irq(uport);
  				tty_port_set_initialized(port, true);
  			} else {
  				/*
-@@ -2583,13 +2583,13 @@ uart_configure_port(struct uart_driver *drv, struct uart_state *state,
+@@ -2588,11 +2588,11 @@ uart_configure_port(struct uart_driver *drv, struct uart_state *state,
  		 * keep the DTR setting that is set in uart_set_options()
  		 * We probably don't need a spinlock around this, but
  		 */
@@ -6956,17 +6966,15 @@ index 7bdc21d..b32bbd7 100644
  		port->mctrl &= TIOCM_DTR;
  		if (!(port->rs485.flags & SER_RS485_ENABLED))
  			port->ops->set_mctrl(port, port->mctrl);
- 		else
- 			uart_rs485_config(port);
 -		spin_unlock_irqrestore(&port->lock, flags);
 +		uart_port_unlock_irqrestore(port, flags);
  
- 		/*
- 		 * If this driver supports console, and it hasn't been
-diff --git a/drivers/tty/serial/serial_mctrl_gpio.c b/drivers/tty/serial/serial_mctrl_gpio.c
+ 		uart_rs485_config(port);
+ 
+diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_mctrl_gpio.c b/rc6-cachy-rt/drivers/tty/serial/serial_mctrl_gpio.c
 index 7d5aaa8..e51ca59 100644
---- a/drivers/tty/serial/serial_mctrl_gpio.c
-+++ b/drivers/tty/serial/serial_mctrl_gpio.c
+--- a/linux-6.6-rc6/drivers/tty/serial/serial_mctrl_gpio.c
++++ b/rc6-cachy-rt/drivers/tty/serial/serial_mctrl_gpio.c
 @@ -184,7 +184,7 @@ static irqreturn_t mctrl_gpio_irq_handle(int irq, void *context)
  
  	mctrl_gpio_get(gpios, &mctrl);
@@ -6985,10 +6993,10 @@ index 7d5aaa8..e51ca59 100644
  
  	return IRQ_HANDLED;
  }
-diff --git a/drivers/tty/serial/serial_port.c b/drivers/tty/serial/serial_port.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_port.c b/rc6-cachy-rt/drivers/tty/serial/serial_port.c
 index 8624232..88975a4 100644
---- a/drivers/tty/serial/serial_port.c
-+++ b/drivers/tty/serial/serial_port.c
+--- a/linux-6.6-rc6/drivers/tty/serial/serial_port.c
++++ b/rc6-cachy-rt/drivers/tty/serial/serial_port.c
 @@ -35,10 +35,10 @@ static int serial_port_runtime_resume(struct device *dev)
  		goto out;
  
@@ -7002,10 +7010,10 @@ index 8624232..88975a4 100644
  
  out:
  	pm_runtime_mark_last_busy(dev);
-diff --git a/drivers/tty/serial/serial_txx9.c b/drivers/tty/serial/serial_txx9.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_txx9.c b/rc6-cachy-rt/drivers/tty/serial/serial_txx9.c
 index be08fb6..eaa9807 100644
---- a/drivers/tty/serial/serial_txx9.c
-+++ b/drivers/tty/serial/serial_txx9.c
+--- a/linux-6.6-rc6/drivers/tty/serial/serial_txx9.c
++++ b/rc6-cachy-rt/drivers/tty/serial/serial_txx9.c
 @@ -335,13 +335,13 @@ static irqreturn_t serial_txx9_interrupt(int irq, void *dev_id)
  	unsigned int status;
  
@@ -7100,10 +7108,10 @@ index be08fb6..eaa9807 100644
  }
  
  static void
-diff --git a/drivers/tty/serial/sh-sci.c b/drivers/tty/serial/sh-sci.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sh-sci.c b/rc6-cachy-rt/drivers/tty/serial/sh-sci.c
 index a560b72..84ab434 100644
---- a/drivers/tty/serial/sh-sci.c
-+++ b/drivers/tty/serial/sh-sci.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sh-sci.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sh-sci.c
 @@ -1205,7 +1205,7 @@ static void sci_dma_tx_complete(void *arg)
  
  	dev_dbg(port->dev, "%s(%d)\n", __func__, port->line);
@@ -7366,10 +7374,10 @@ index a560b72..84ab434 100644
  }
  
  static int serial_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/sifive.c b/drivers/tty/serial/sifive.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sifive.c b/rc6-cachy-rt/drivers/tty/serial/sifive.c
 index d195c5d..b296e57 100644
---- a/drivers/tty/serial/sifive.c
-+++ b/drivers/tty/serial/sifive.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sifive.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sifive.c
 @@ -521,11 +521,11 @@ static irqreturn_t sifive_serial_irq(int irq, void *dev_id)
  	struct sifive_serial_port *ssp = dev_id;
  	u32 ip;
@@ -7432,10 +7440,10 @@ index d195c5d..b296e57 100644
  	local_irq_restore(flags);
  }
  
-diff --git a/drivers/tty/serial/sprd_serial.c b/drivers/tty/serial/sprd_serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sprd_serial.c b/rc6-cachy-rt/drivers/tty/serial/sprd_serial.c
 index f328fa5..f257525 100644
---- a/drivers/tty/serial/sprd_serial.c
-+++ b/drivers/tty/serial/sprd_serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sprd_serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sprd_serial.c
 @@ -247,7 +247,7 @@ static void sprd_complete_tx_dma(void *data)
  	struct circ_buf *xmit = &port->state->xmit;
  	unsigned long flags;
@@ -7558,10 +7566,10 @@ index f328fa5..f257525 100644
  }
  
  static int sprd_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/st-asc.c b/drivers/tty/serial/st-asc.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/st-asc.c b/rc6-cachy-rt/drivers/tty/serial/st-asc.c
 index 92b9f68..a821f5d 100644
---- a/drivers/tty/serial/st-asc.c
-+++ b/drivers/tty/serial/st-asc.c
+--- a/linux-6.6-rc6/drivers/tty/serial/st-asc.c
++++ b/rc6-cachy-rt/drivers/tty/serial/st-asc.c
 @@ -319,7 +319,7 @@ static irqreturn_t asc_interrupt(int irq, void *ptr)
  	struct uart_port *port = ptr;
  	u32 status;
@@ -7632,10 +7640,10 @@ index 92b9f68..a821f5d 100644
  }
  
  static int asc_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/stm32-usart.c b/drivers/tty/serial/stm32-usart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/stm32-usart.c b/rc6-cachy-rt/drivers/tty/serial/stm32-usart.c
 index 5e9cf0c..8c51ec9 100644
---- a/drivers/tty/serial/stm32-usart.c
-+++ b/drivers/tty/serial/stm32-usart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/stm32-usart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/stm32-usart.c
 @@ -537,7 +537,7 @@ static void stm32_usart_rx_dma_complete(void *arg)
  	unsigned int size;
  	unsigned long flags;
@@ -7780,10 +7788,10 @@ index 5e9cf0c..8c51ec9 100644
  			/* Poll data from DMA RX buffer if any */
  			if (!stm32_usart_rx_dma_pause(stm32_port))
  				size += stm32_usart_receive_chars(port, true);
-diff --git a/drivers/tty/serial/sunhv.c b/drivers/tty/serial/sunhv.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sunhv.c b/rc6-cachy-rt/drivers/tty/serial/sunhv.c
 index c671d67..5bfc004 100644
---- a/drivers/tty/serial/sunhv.c
-+++ b/drivers/tty/serial/sunhv.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sunhv.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sunhv.c
 @@ -217,10 +217,10 @@ static irqreturn_t sunhv_interrupt(int irq, void *dev_id)
  	struct tty_port *tport;
  	unsigned long flags;
@@ -7893,10 +7901,10 @@ index c671d67..5bfc004 100644
  }
  
  static struct console sunhv_console = {
-diff --git a/drivers/tty/serial/sunplus-uart.c b/drivers/tty/serial/sunplus-uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sunplus-uart.c b/rc6-cachy-rt/drivers/tty/serial/sunplus-uart.c
 index 3aacd5e..4251f4e 100644
---- a/drivers/tty/serial/sunplus-uart.c
-+++ b/drivers/tty/serial/sunplus-uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sunplus-uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sunplus-uart.c
 @@ -184,7 +184,7 @@ static void sunplus_break_ctl(struct uart_port *port, int ctl)
  	unsigned long flags;
  	unsigned int lcr;
@@ -8003,10 +8011,10 @@ index 3aacd5e..4251f4e 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/drivers/tty/serial/sunsab.c b/drivers/tty/serial/sunsab.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sunsab.c b/rc6-cachy-rt/drivers/tty/serial/sunsab.c
 index 40eeaf8..6aa51a6 100644
---- a/drivers/tty/serial/sunsab.c
-+++ b/drivers/tty/serial/sunsab.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sunsab.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sunsab.c
 @@ -310,7 +310,7 @@ static irqreturn_t sunsab_interrupt(int irq, void *dev_id)
  	unsigned long flags;
  	unsigned char gis;
@@ -8143,10 +8151,10 @@ index 40eeaf8..6aa51a6 100644
  	
  	return 0;
  }
-diff --git a/drivers/tty/serial/sunsu.c b/drivers/tty/serial/sunsu.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sunsu.c b/rc6-cachy-rt/drivers/tty/serial/sunsu.c
 index 58a4342..1e051cc 100644
---- a/drivers/tty/serial/sunsu.c
-+++ b/drivers/tty/serial/sunsu.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sunsu.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sunsu.c
 @@ -212,9 +212,9 @@ static void enable_rsa(struct uart_sunsu_port *up)
  {
  	if (up->port.type == PORT_RSA) {
@@ -8326,10 +8334,10 @@ index 58a4342..1e051cc 100644
  }
  
  /*
-diff --git a/drivers/tty/serial/sunzilog.c b/drivers/tty/serial/sunzilog.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/sunzilog.c b/rc6-cachy-rt/drivers/tty/serial/sunzilog.c
 index c8c71c5..d3b5e86 100644
---- a/drivers/tty/serial/sunzilog.c
-+++ b/drivers/tty/serial/sunzilog.c
+--- a/linux-6.6-rc6/drivers/tty/serial/sunzilog.c
++++ b/rc6-cachy-rt/drivers/tty/serial/sunzilog.c
 @@ -531,7 +531,7 @@ static irqreturn_t sunzilog_interrupt(int irq, void *dev_id)
  		struct tty_port *port;
  		unsigned char r3;
@@ -8501,10 +8509,10 @@ index c8c71c5..d3b5e86 100644
  
  #ifdef CONFIG_SERIO
  	if (up->flags & (SUNZILOG_FLAG_CONS_KEYB |
-diff --git a/drivers/tty/serial/timbuart.c b/drivers/tty/serial/timbuart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/timbuart.c b/rc6-cachy-rt/drivers/tty/serial/timbuart.c
 index 0859394..0cc6524 100644
---- a/drivers/tty/serial/timbuart.c
-+++ b/drivers/tty/serial/timbuart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/timbuart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/timbuart.c
 @@ -174,7 +174,7 @@ static void timbuart_tasklet(struct tasklet_struct *t)
  	struct timbuart_port *uart = from_tasklet(uart, t, tasklet);
  	u32 isr, ier = 0;
@@ -8536,10 +8544,10 @@ index 0859394..0cc6524 100644
  }
  
  static const char *timbuart_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/uartlite.c b/drivers/tty/serial/uartlite.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/uartlite.c b/rc6-cachy-rt/drivers/tty/serial/uartlite.c
 index b225a78..404c14a 100644
---- a/drivers/tty/serial/uartlite.c
-+++ b/drivers/tty/serial/uartlite.c
+--- a/linux-6.6-rc6/drivers/tty/serial/uartlite.c
++++ b/rc6-cachy-rt/drivers/tty/serial/uartlite.c
 @@ -216,11 +216,11 @@ static irqreturn_t ulite_isr(int irq, void *dev_id)
  	unsigned long flags;
  
@@ -8605,10 +8613,10 @@ index b225a78..404c14a 100644
  }
  
  static int ulite_console_setup(struct console *co, char *options)
-diff --git a/drivers/tty/serial/ucc_uart.c b/drivers/tty/serial/ucc_uart.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/ucc_uart.c b/rc6-cachy-rt/drivers/tty/serial/ucc_uart.c
 index b06661b..ed7a6bb 100644
---- a/drivers/tty/serial/ucc_uart.c
-+++ b/drivers/tty/serial/ucc_uart.c
+--- a/linux-6.6-rc6/drivers/tty/serial/ucc_uart.c
++++ b/rc6-cachy-rt/drivers/tty/serial/ucc_uart.c
 @@ -931,7 +931,7 @@ static void qe_uart_set_termios(struct uart_port *port,
  	baud = uart_get_baud_rate(port, termios, old, 0, port->uartclk / 16);
  
@@ -8627,10 +8635,10 @@ index b06661b..ed7a6bb 100644
  }
  
  /*
-diff --git a/drivers/tty/serial/vt8500_serial.c b/drivers/tty/serial/vt8500_serial.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/vt8500_serial.c b/rc6-cachy-rt/drivers/tty/serial/vt8500_serial.c
 index c5d5c27..78a1c1e 100644
---- a/drivers/tty/serial/vt8500_serial.c
-+++ b/drivers/tty/serial/vt8500_serial.c
+--- a/linux-6.6-rc6/drivers/tty/serial/vt8500_serial.c
++++ b/rc6-cachy-rt/drivers/tty/serial/vt8500_serial.c
 @@ -227,7 +227,7 @@ static irqreturn_t vt8500_irq(int irq, void *dev_id)
  	struct uart_port *port = dev_id;
  	unsigned long isr;
@@ -8667,10 +8675,10 @@ index c5d5c27..78a1c1e 100644
  }
  
  static const char *vt8500_type(struct uart_port *port)
-diff --git a/drivers/tty/serial/xilinx_uartps.c b/drivers/tty/serial/xilinx_uartps.c
+diff --git a/linux-6.6-rc6/drivers/tty/serial/xilinx_uartps.c b/rc6-cachy-rt/drivers/tty/serial/xilinx_uartps.c
 index 2e5e86a..9c13dac 100644
---- a/drivers/tty/serial/xilinx_uartps.c
-+++ b/drivers/tty/serial/xilinx_uartps.c
+--- a/linux-6.6-rc6/drivers/tty/serial/xilinx_uartps.c
++++ b/rc6-cachy-rt/drivers/tty/serial/xilinx_uartps.c
 @@ -346,7 +346,7 @@ static irqreturn_t cdns_uart_isr(int irq, void *dev_id)
  	struct uart_port *port = (struct uart_port *)dev_id;
  	unsigned int isrstatus;
@@ -8907,10 +8915,10 @@ index 2e5e86a..9c13dac 100644
  	}
  
  	return uart_resume_port(cdns_uart->cdns_uart_driver, port);
-diff --git a/drivers/tty/tty_io.c b/drivers/tty/tty_io.c
+diff --git a/linux-6.6-rc6/drivers/tty/tty_io.c b/rc6-cachy-rt/drivers/tty/tty_io.c
 index 8a94e5a..3831596 100644
---- a/drivers/tty/tty_io.c
-+++ b/drivers/tty/tty_io.c
+--- a/linux-6.6-rc6/drivers/tty/tty_io.c
++++ b/rc6-cachy-rt/drivers/tty/tty_io.c
 @@ -3540,8 +3540,15 @@ static ssize_t show_cons_active(struct device *dev,
  	for_each_console(c) {
  		if (!c->device)
@@ -8929,10 +8937,10 @@ index 8a94e5a..3831596 100644
  		if ((c->flags & CON_ENABLED) == 0)
  			continue;
  		cs[i++] = c;
-diff --git a/fs/proc/consoles.c b/fs/proc/consoles.c
+diff --git a/linux-6.6-rc6/fs/proc/consoles.c b/rc6-cachy-rt/fs/proc/consoles.c
 index e0758fe..2703676 100644
---- a/fs/proc/consoles.c
-+++ b/fs/proc/consoles.c
+--- a/linux-6.6-rc6/fs/proc/consoles.c
++++ b/rc6-cachy-rt/fs/proc/consoles.c
 @@ -21,12 +21,14 @@ static int show_console_dev(struct seq_file *m, void *v)
  		{ CON_ENABLED,		'E' },
  		{ CON_CONSDEV,		'C' },
@@ -8967,10 +8975,10 @@ index e0758fe..2703676 100644
  	if (dev)
  		seq_printf(m, " %4d:%d", MAJOR(dev), MINOR(dev));
  
-diff --git a/include/linux/bottom_half.h b/include/linux/bottom_half.h
+diff --git a/linux-6.6-rc6/include/linux/bottom_half.h b/rc6-cachy-rt/include/linux/bottom_half.h
 index fc53e0a..448bbef 100644
---- a/include/linux/bottom_half.h
-+++ b/include/linux/bottom_half.h
+--- a/linux-6.6-rc6/include/linux/bottom_half.h
++++ b/rc6-cachy-rt/include/linux/bottom_half.h
 @@ -35,8 +35,10 @@ static inline void local_bh_enable(void)
  
  #ifdef CONFIG_PREEMPT_RT
@@ -8982,10 +8990,10 @@ index fc53e0a..448bbef 100644
  #endif
  
  #endif /* _LINUX_BH_H */
-diff --git a/include/linux/console.h b/include/linux/console.h
+diff --git a/linux-6.6-rc6/include/linux/console.h b/rc6-cachy-rt/include/linux/console.h
 index 7de11c7..6bbb898 100644
---- a/include/linux/console.h
-+++ b/include/linux/console.h
+--- a/linux-6.6-rc6/include/linux/console.h
++++ b/rc6-cachy-rt/include/linux/console.h
 @@ -16,7 +16,9 @@
  
  #include <linux/atomic.h>
@@ -9177,10 +9185,10 @@ index 7de11c7..6bbb898 100644
  extern int console_set_on_cmdline;
  extern struct console *early_console;
  
-diff --git a/include/linux/entry-common.h b/include/linux/entry-common.h
+diff --git a/linux-6.6-rc6/include/linux/entry-common.h b/rc6-cachy-rt/include/linux/entry-common.h
 index d95ab85..3dc3704 100644
---- a/include/linux/entry-common.h
-+++ b/include/linux/entry-common.h
+--- a/linux-6.6-rc6/include/linux/entry-common.h
++++ b/rc6-cachy-rt/include/linux/entry-common.h
 @@ -57,9 +57,15 @@
  # define ARCH_EXIT_TO_USER_MODE_WORK		(0)
  #endif
@@ -9198,10 +9206,10 @@ index d95ab85..3dc3704 100644
  	 ARCH_EXIT_TO_USER_MODE_WORK)
  
  /**
-diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
+diff --git a/linux-6.6-rc6/include/linux/interrupt.h b/rc6-cachy-rt/include/linux/interrupt.h
 index 4a1dc88..a5091ac 100644
---- a/include/linux/interrupt.h
-+++ b/include/linux/interrupt.h
+--- a/linux-6.6-rc6/include/linux/interrupt.h
++++ b/rc6-cachy-rt/include/linux/interrupt.h
 @@ -609,6 +609,35 @@ extern void __raise_softirq_irqoff(unsigned int nr);
  extern void raise_softirq_irqoff(unsigned int nr);
  extern void raise_softirq(unsigned int nr);
@@ -9238,10 +9246,10 @@ index 4a1dc88..a5091ac 100644
  DECLARE_PER_CPU(struct task_struct *, ksoftirqd);
  
  static inline struct task_struct *this_cpu_ksoftirqd(void)
-diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
+diff --git a/linux-6.6-rc6/include/linux/netdevice.h b/rc6-cachy-rt/include/linux/netdevice.h
 index 0896aaa..a7a3ba1 100644
---- a/include/linux/netdevice.h
-+++ b/include/linux/netdevice.h
+--- a/linux-6.6-rc6/include/linux/netdevice.h
++++ b/rc6-cachy-rt/include/linux/netdevice.h
 @@ -3236,7 +3236,11 @@ struct softnet_data {
  	int			defer_count;
  	int			defer_ipi_scheduled;
@@ -9254,10 +9262,10 @@ index 0896aaa..a7a3ba1 100644
  };
  
  static inline void input_queue_head_incr(struct softnet_data *sd)
-diff --git a/include/linux/preempt.h b/include/linux/preempt.h
+diff --git a/linux-6.6-rc6/include/linux/preempt.h b/rc6-cachy-rt/include/linux/preempt.h
 index 1424670..3c56b6f 100644
---- a/include/linux/preempt.h
-+++ b/include/linux/preempt.h
+--- a/linux-6.6-rc6/include/linux/preempt.h
++++ b/rc6-cachy-rt/include/linux/preempt.h
 @@ -197,6 +197,20 @@ extern void preempt_count_sub(int val);
  #define preempt_count_inc() preempt_count_add(1)
  #define preempt_count_dec() preempt_count_sub(1)
@@ -9385,10 +9393,10 @@ index 1424670..3c56b6f 100644
  
  #endif /* CONFIG_SMP */
  
-diff --git a/include/linux/printk.h b/include/linux/printk.h
+diff --git a/linux-6.6-rc6/include/linux/printk.h b/rc6-cachy-rt/include/linux/printk.h
 index 8ef499a..d77e13f 100644
---- a/include/linux/printk.h
-+++ b/include/linux/printk.h
+--- a/linux-6.6-rc6/include/linux/printk.h
++++ b/rc6-cachy-rt/include/linux/printk.h
 @@ -9,6 +9,8 @@
  #include <linux/ratelimit_types.h>
  #include <linux/once_lite.h>
@@ -9447,10 +9455,10 @@ index 8ef499a..d77e13f 100644
  #endif
  
  #ifdef CONFIG_SMP
-diff --git a/include/linux/rcupdate.h b/include/linux/rcupdate.h
+diff --git a/linux-6.6-rc6/include/linux/rcupdate.h b/rc6-cachy-rt/include/linux/rcupdate.h
 index 5e5f920..44aab5c 100644
---- a/include/linux/rcupdate.h
-+++ b/include/linux/rcupdate.h
+--- a/linux-6.6-rc6/include/linux/rcupdate.h
++++ b/rc6-cachy-rt/include/linux/rcupdate.h
 @@ -303,6 +303,11 @@ static inline void rcu_lock_acquire(struct lockdep_map *map)
  	lock_acquire(map, 0, 0, 2, 0, NULL, _THIS_IP_);
  }
@@ -9471,10 +9479,10 @@ index 5e5f920..44aab5c 100644
  # define rcu_lock_release(a)		do { } while (0)
  
  static inline int rcu_read_lock_held(void)
-diff --git a/include/linux/sched/rt.h b/include/linux/sched/rt.h
+diff --git a/linux-6.6-rc6/include/linux/sched/rt.h b/rc6-cachy-rt/include/linux/sched/rt.h
 index 994c256..b2b9e6e 100644
---- a/include/linux/sched/rt.h
-+++ b/include/linux/sched/rt.h
+--- a/linux-6.6-rc6/include/linux/sched/rt.h
++++ b/rc6-cachy-rt/include/linux/sched/rt.h
 @@ -30,6 +30,10 @@ static inline bool task_is_realtime(struct task_struct *tsk)
  }
  
@@ -9486,10 +9494,10 @@ index 994c256..b2b9e6e 100644
  /*
   * Must hold either p->pi_lock or task_rq(p)->lock.
   */
-diff --git a/include/linux/sched.h b/include/linux/sched.h
+diff --git a/linux-6.6-rc6/include/linux/sched.h b/rc6-cachy-rt/include/linux/sched.h
 index 77f01ac..4d49243 100644
---- a/include/linux/sched.h
-+++ b/include/linux/sched.h
+--- a/linux-6.6-rc6/include/linux/sched.h
++++ b/rc6-cachy-rt/include/linux/sched.h
 @@ -911,6 +911,9 @@ struct task_struct {
  	 * ->sched_remote_wakeup gets used, so it can be in this word.
  	 */
@@ -9552,10 +9560,10 @@ index 77f01ac..4d49243 100644
  /*
   * cond_resched() and cond_resched_lock(): latency reduction via
   * explicit rescheduling in places that are safe. The return
-diff --git a/include/linux/serial_8250.h b/include/linux/serial_8250.h
+diff --git a/linux-6.6-rc6/include/linux/serial_8250.h b/rc6-cachy-rt/include/linux/serial_8250.h
 index be65de6..dab5e82 100644
---- a/include/linux/serial_8250.h
-+++ b/include/linux/serial_8250.h
+--- a/linux-6.6-rc6/include/linux/serial_8250.h
++++ b/rc6-cachy-rt/include/linux/serial_8250.h
 @@ -204,6 +204,8 @@ void serial8250_init_port(struct uart_8250_port *up);
  void serial8250_set_defaults(struct uart_8250_port *up);
  void serial8250_console_write(struct uart_8250_port *up, const char *s,
@@ -9565,10 +9573,10 @@ index be65de6..dab5e82 100644
  int serial8250_console_setup(struct uart_port *port, char *options, bool probe);
  int serial8250_console_exit(struct uart_port *port);
  
-diff --git a/include/linux/serial_core.h b/include/linux/serial_core.h
+diff --git a/linux-6.6-rc6/include/linux/serial_core.h b/rc6-cachy-rt/include/linux/serial_core.h
 index bb6f073..18ce60b 100644
---- a/include/linux/serial_core.h
-+++ b/include/linux/serial_core.h
+--- a/linux-6.6-rc6/include/linux/serial_core.h
++++ b/rc6-cachy-rt/include/linux/serial_core.h
 @@ -588,6 +588,99 @@ struct uart_port {
  	void			*private_data;		/* generic platform data pointer */
  };
@@ -9718,10 +9726,10 @@ index bb6f073..18ce60b 100644
  }
  #endif	/* CONFIG_MAGIC_SYSRQ_SERIAL */
  
-diff --git a/include/linux/srcu.h b/include/linux/srcu.h
+diff --git a/linux-6.6-rc6/include/linux/srcu.h b/rc6-cachy-rt/include/linux/srcu.h
 index 127ef3b..236610e 100644
---- a/include/linux/srcu.h
-+++ b/include/linux/srcu.h
+--- a/linux-6.6-rc6/include/linux/srcu.h
++++ b/rc6-cachy-rt/include/linux/srcu.h
 @@ -229,7 +229,7 @@ static inline int srcu_read_lock_nmisafe(struct srcu_struct *ssp) __acquires(ssp
  
  	srcu_check_nmi_safety(ssp, true);
@@ -9731,10 +9739,10 @@ index 127ef3b..236610e 100644
  	return retval;
  }
  
-diff --git a/include/linux/thread_info.h b/include/linux/thread_info.h
+diff --git a/linux-6.6-rc6/include/linux/thread_info.h b/rc6-cachy-rt/include/linux/thread_info.h
 index 9ea0b28..00a01d5 100644
---- a/include/linux/thread_info.h
-+++ b/include/linux/thread_info.h
+--- a/linux-6.6-rc6/include/linux/thread_info.h
++++ b/rc6-cachy-rt/include/linux/thread_info.h
 @@ -178,14 +178,65 @@ static __always_inline unsigned long read_ti_thread_flags(struct thread_info *ti
  #endif /* !CONFIG_GENERIC_ENTRY */
  
@@ -9820,10 +9828,10 @@ index 9ea0b28..00a01d5 100644
  #endif /* _ASM_GENERIC_BITOPS_INSTRUMENTED_NON_ATOMIC_H */
  
  #ifndef CONFIG_HAVE_ARCH_WITHIN_STACK_FRAMES
-diff --git a/include/linux/trace_events.h b/include/linux/trace_events.h
+diff --git a/linux-6.6-rc6/include/linux/trace_events.h b/rc6-cachy-rt/include/linux/trace_events.h
 index 21ae37e..206625a 100644
---- a/include/linux/trace_events.h
-+++ b/include/linux/trace_events.h
+--- a/linux-6.6-rc6/include/linux/trace_events.h
++++ b/rc6-cachy-rt/include/linux/trace_events.h
 @@ -81,6 +81,7 @@ struct trace_entry {
  	unsigned char		flags;
  	unsigned char		preempt_count;
@@ -9858,10 +9866,10 @@ index 21ae37e..206625a 100644
  	TRACE_FLAG_NMI			= 0x40,
  	TRACE_FLAG_BH_OFF		= 0x80,
  };
-diff --git a/kernel/Kconfig.preempt b/kernel/Kconfig.preempt
+diff --git a/linux-6.6-rc6/kernel/Kconfig.preempt b/rc6-cachy-rt/kernel/Kconfig.preempt
 index c2f1fd9..b787bb9 100644
---- a/kernel/Kconfig.preempt
-+++ b/kernel/Kconfig.preempt
+--- a/linux-6.6-rc6/kernel/Kconfig.preempt
++++ b/rc6-cachy-rt/kernel/Kconfig.preempt
 @@ -1,5 +1,11 @@
  # SPDX-License-Identifier: GPL-2.0-only
  
@@ -9883,10 +9891,10 @@ index c2f1fd9..b787bb9 100644
  	select PREEMPTION
  	help
  	  This option turns the kernel into a real-time kernel by replacing
-diff --git a/kernel/entry/common.c b/kernel/entry/common.c
+diff --git a/linux-6.6-rc6/kernel/entry/common.c b/rc6-cachy-rt/kernel/entry/common.c
 index d7ee4bc..b9f08f6 100644
---- a/kernel/entry/common.c
-+++ b/kernel/entry/common.c
+--- a/linux-6.6-rc6/kernel/entry/common.c
++++ b/rc6-cachy-rt/kernel/entry/common.c
 @@ -155,7 +155,7 @@ static unsigned long exit_to_user_mode_loop(struct pt_regs *regs,
  
  		local_irq_enable_exit_to_user(ti_work);
@@ -9905,10 +9913,10 @@ index d7ee4bc..b9f08f6 100644
  			preempt_schedule_irq();
  	}
  }
-diff --git a/kernel/futex/pi.c b/kernel/futex/pi.c
+diff --git a/linux-6.6-rc6/kernel/futex/pi.c b/rc6-cachy-rt/kernel/futex/pi.c
 index ce2889f..d636a1b 100644
---- a/kernel/futex/pi.c
-+++ b/kernel/futex/pi.c
+--- a/linux-6.6-rc6/kernel/futex/pi.c
++++ b/rc6-cachy-rt/kernel/futex/pi.c
 @@ -1,6 +1,7 @@
  // SPDX-License-Identifier: GPL-2.0-or-later
  
@@ -10069,10 +10077,10 @@ index ce2889f..d636a1b 100644
  	/*
  	 * We have no kernel internal state, i.e. no waiters in the
  	 * kernel. Waiters which are about to queue themselves are stuck
-diff --git a/kernel/futex/requeue.c b/kernel/futex/requeue.c
+diff --git a/linux-6.6-rc6/kernel/futex/requeue.c b/rc6-cachy-rt/kernel/futex/requeue.c
 index cba8b1a..4c73e0b 100644
---- a/kernel/futex/requeue.c
-+++ b/kernel/futex/requeue.c
+--- a/linux-6.6-rc6/kernel/futex/requeue.c
++++ b/rc6-cachy-rt/kernel/futex/requeue.c
 @@ -850,11 +850,13 @@ int futex_wait_requeue_pi(u32 __user *uaddr, unsigned int flags,
  		pi_mutex = &q.pi_state->pi_mutex;
  		ret = rt_mutex_wait_proxy_lock(pi_mutex, to, &rt_waiter);
@@ -10089,10 +10097,10 @@ index cba8b1a..4c73e0b 100644
  		debug_rt_mutex_free_waiter(&rt_waiter);
  		/*
  		 * Fixup the pi_state owner and possibly acquire the lock if we
-diff --git a/kernel/ksysfs.c b/kernel/ksysfs.c
+diff --git a/linux-6.6-rc6/kernel/ksysfs.c b/rc6-cachy-rt/kernel/ksysfs.c
 index 1d4bc49..486c68c 100644
---- a/kernel/ksysfs.c
-+++ b/kernel/ksysfs.c
+--- a/linux-6.6-rc6/kernel/ksysfs.c
++++ b/rc6-cachy-rt/kernel/ksysfs.c
 @@ -179,6 +179,15 @@ KERNEL_ATTR_RO(crash_elfcorehdr_size);
  
  #endif /* CONFIG_CRASH_CORE */
@@ -10119,10 +10127,10 @@ index 1d4bc49..486c68c 100644
  #endif
  	NULL
  };
-diff --git a/kernel/locking/lockdep.c b/kernel/locking/lockdep.c
+diff --git a/linux-6.6-rc6/kernel/locking/lockdep.c b/rc6-cachy-rt/kernel/locking/lockdep.c
 index e85b5ad..5310a94 100644
---- a/kernel/locking/lockdep.c
-+++ b/kernel/locking/lockdep.c
+--- a/linux-6.6-rc6/kernel/locking/lockdep.c
++++ b/rc6-cachy-rt/kernel/locking/lockdep.c
 @@ -56,6 +56,7 @@
  #include <linux/kprobes.h>
  #include <linux/lockdep.h>
@@ -10154,10 +10162,10 @@ index e85b5ad..5310a94 100644
  }
  
  /*
-diff --git a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
+diff --git a/linux-6.6-rc6/kernel/locking/rtmutex.c b/rc6-cachy-rt/kernel/locking/rtmutex.c
 index 21db0df..4a10e8c 100644
---- a/kernel/locking/rtmutex.c
-+++ b/kernel/locking/rtmutex.c
+--- a/linux-6.6-rc6/kernel/locking/rtmutex.c
++++ b/rc6-cachy-rt/kernel/locking/rtmutex.c
 @@ -218,6 +218,11 @@ static __always_inline bool rt_mutex_cmpxchg_acquire(struct rt_mutex_base *lock,
  	return try_cmpxchg_acquire(&lock->owner, &old, new);
  }
@@ -10244,10 +10252,10 @@ index 21db0df..4a10e8c 100644
  		return 0;
  
  	return rt_mutex_slowlock(lock, NULL, state);
-diff --git a/kernel/locking/rwbase_rt.c b/kernel/locking/rwbase_rt.c
+diff --git a/linux-6.6-rc6/kernel/locking/rwbase_rt.c b/rc6-cachy-rt/kernel/locking/rwbase_rt.c
 index 25ec023..34a5956 100644
---- a/kernel/locking/rwbase_rt.c
-+++ b/kernel/locking/rwbase_rt.c
+--- a/linux-6.6-rc6/kernel/locking/rwbase_rt.c
++++ b/rc6-cachy-rt/kernel/locking/rwbase_rt.c
 @@ -71,6 +71,7 @@ static int __sched __rwbase_read_lock(struct rwbase_rt *rwb,
  	struct rt_mutex_base *rtm = &rwb->rtmutex;
  	int ret;
@@ -10297,10 +10305,10 @@ index 25ec023..34a5956 100644
  	return 0;
  }
  
-diff --git a/kernel/locking/rwsem.c b/kernel/locking/rwsem.c
+diff --git a/linux-6.6-rc6/kernel/locking/rwsem.c b/rc6-cachy-rt/kernel/locking/rwsem.c
 index 9eabd58..2340b6d 100644
---- a/kernel/locking/rwsem.c
-+++ b/kernel/locking/rwsem.c
+--- a/linux-6.6-rc6/kernel/locking/rwsem.c
++++ b/rc6-cachy-rt/kernel/locking/rwsem.c
 @@ -1427,8 +1427,14 @@ static inline void __downgrade_write(struct rw_semaphore *sem)
  #define rwbase_signal_pending_state(state, current)	\
  	signal_pending_state(state, current)
@@ -10317,10 +10325,10 @@ index 9eabd58..2340b6d 100644
  
  #include "rwbase_rt.c"
  
-diff --git a/kernel/locking/spinlock_rt.c b/kernel/locking/spinlock_rt.c
+diff --git a/linux-6.6-rc6/kernel/locking/spinlock_rt.c b/rc6-cachy-rt/kernel/locking/spinlock_rt.c
 index 48a19ed..38e2924 100644
---- a/kernel/locking/spinlock_rt.c
-+++ b/kernel/locking/spinlock_rt.c
+--- a/linux-6.6-rc6/kernel/locking/spinlock_rt.c
++++ b/rc6-cachy-rt/kernel/locking/spinlock_rt.c
 @@ -37,6 +37,8 @@
  
  static __always_inline void rtlock_lock(struct rt_mutex_base *rtm)
@@ -10344,10 +10352,10 @@ index 48a19ed..38e2924 100644
  #include "rwbase_rt.c"
  /*
   * The common functions which get wrapped into the rwlock API.
-diff --git a/kernel/locking/ww_rt_mutex.c b/kernel/locking/ww_rt_mutex.c
+diff --git a/linux-6.6-rc6/kernel/locking/ww_rt_mutex.c b/rc6-cachy-rt/kernel/locking/ww_rt_mutex.c
 index d1473c6..c7196de 100644
---- a/kernel/locking/ww_rt_mutex.c
-+++ b/kernel/locking/ww_rt_mutex.c
+--- a/linux-6.6-rc6/kernel/locking/ww_rt_mutex.c
++++ b/rc6-cachy-rt/kernel/locking/ww_rt_mutex.c
 @@ -62,7 +62,7 @@ __ww_rt_mutex_lock(struct ww_mutex *lock, struct ww_acquire_ctx *ww_ctx,
  	}
  	mutex_acquire_nest(&rtm->dep_map, 0, 0, nest_lock, ip);
@@ -10357,10 +10365,10 @@ index d1473c6..c7196de 100644
  		if (ww_ctx)
  			ww_mutex_set_context_fastpath(lock, ww_ctx);
  		return 0;
-diff --git a/kernel/panic.c b/kernel/panic.c
+diff --git a/linux-6.6-rc6/kernel/panic.c b/rc6-cachy-rt/kernel/panic.c
 index ffa037f..b4c3640 100644
---- a/kernel/panic.c
-+++ b/kernel/panic.c
+--- a/linux-6.6-rc6/kernel/panic.c
++++ b/rc6-cachy-rt/kernel/panic.c
 @@ -275,6 +275,7 @@ static void panic_other_cpus_shutdown(bool crash_kexec)
   */
  void panic(const char *fmt, ...)
@@ -10524,10 +10532,10 @@ index ffa037f..b4c3640 100644
  }
  
  #ifdef CONFIG_BUG
-diff --git a/kernel/printk/Makefile b/kernel/printk/Makefile
+diff --git a/linux-6.6-rc6/kernel/printk/Makefile b/rc6-cachy-rt/kernel/printk/Makefile
 index f5b388e..39a2b61 100644
---- a/kernel/printk/Makefile
-+++ b/kernel/printk/Makefile
+--- a/linux-6.6-rc6/kernel/printk/Makefile
++++ b/rc6-cachy-rt/kernel/printk/Makefile
 @@ -1,6 +1,6 @@
  # SPDX-License-Identifier: GPL-2.0-only
  obj-y	= printk.o
@@ -10536,10 +10544,10 @@ index f5b388e..39a2b61 100644
  obj-$(CONFIG_A11Y_BRAILLE_CONSOLE)	+= braille.o
  obj-$(CONFIG_PRINTK_INDEX)	+= index.o
  
-diff --git a/kernel/printk/internal.h b/kernel/printk/internal.h
+diff --git a/linux-6.6-rc6/kernel/printk/internal.h b/rc6-cachy-rt/kernel/printk/internal.h
 index 7d4979d..654a9bf 100644
---- a/kernel/printk/internal.h
-+++ b/kernel/printk/internal.h
+--- a/linux-6.6-rc6/kernel/printk/internal.h
++++ b/rc6-cachy-rt/kernel/printk/internal.h
 @@ -3,6 +3,8 @@
   * internal.h - printk internal definitions
   */
@@ -10699,11 +10707,11 @@ index 7d4979d..654a9bf 100644
 +#ifdef CONFIG_PRINTK
 +void console_prepend_dropped(struct printk_message *pmsg, unsigned long dropped);
 +#endif
-diff --git a/kernel/printk/nbcon.c b/kernel/printk/nbcon.c
+diff --git a/rc6-cachy-rt/kernel/printk/nbcon.c b/rc6-cachy-rt/kernel/printk/nbcon.c
 new file mode 100644
 index 0000000..4cd2365
 --- /dev/null
-+++ b/kernel/printk/nbcon.c
++++ b/rc6-cachy-rt/kernel/printk/nbcon.c
 @@ -0,0 +1,1677 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +// Copyright (C) 2022 Linutronix GmbH, John Ogness
@@ -12382,10 +12390,10 @@ index 0000000..4cd2365
 +	return 0;
 +}
 +device_initcall(printk_init_ops);
-diff --git a/kernel/printk/printk.c b/kernel/printk/printk.c
-index 7e0b4dd..81ecec9 100644
---- a/kernel/printk/printk.c
-+++ b/kernel/printk/printk.c
+diff --git a/linux-6.6-rc6/kernel/printk/printk.c b/rc6-cachy-rt/kernel/printk/printk.c
+index 0b3af15..81ecec9 100644
+--- a/linux-6.6-rc6/kernel/printk/printk.c
++++ b/rc6-cachy-rt/kernel/printk/printk.c
 @@ -102,12 +102,6 @@ DEFINE_STATIC_SRCU(console_srcu);
   */
  int __read_mostly suppress_printk;
@@ -13139,10 +13147,13 @@ index 7e0b4dd..81ecec9 100644
  	int cookie;
  	u64 diff;
  	u64 seq;
-@@ -3740,27 +3952,55 @@ static bool __pr_flush(struct console *con, int timeout_ms, bool reset_on_progre
+@@ -3740,33 +3952,55 @@ static bool __pr_flush(struct console *con, int timeout_ms, bool reset_on_progre
  
  	seq = prb_next_seq(prb);
  
+-	/* Flush the consoles so that records up to @seq are printed. */
+-	console_lock();
+-	console_unlock();
 +	/*
 +	 * Flush the consoles so that records up to @seq are printed.
 +	 * Otherwise this function will just wait for the threaded printers
@@ -13152,14 +13163,16 @@ index 7e0b4dd..81ecec9 100644
 +		console_lock();
 +		console_unlock();
 +	}
-+
+ 
  	for (;;) {
 +		locked = false;
  		diff = 0;
  
 -		/*
 -		 * Hold the console_lock to guarantee safe access to
--		 * console->seq.
+-		 * console->seq. Releasing console_lock flushes more
+-		 * records in case @seq is still not printed on all
+-		 * usable consoles.
 -		 */
 -		console_lock();
 +		if (serialized_printing) {
@@ -13202,7 +13215,7 @@ index 7e0b4dd..81ecec9 100644
  			if (printk_seq < seq)
  				diff += seq - printk_seq;
  		}
-@@ -3769,22 +4009,18 @@ static bool __pr_flush(struct console *con, int timeout_ms, bool reset_on_progre
+@@ -3775,22 +4009,18 @@ static bool __pr_flush(struct console *con, int timeout_ms, bool reset_on_progre
  		if (diff != last_diff && reset_on_progress)
  			remaining = timeout_ms;
  
@@ -13232,7 +13245,7 @@ index 7e0b4dd..81ecec9 100644
  
  		last_diff = diff;
  	}
-@@ -3825,9 +4061,16 @@ static void wake_up_klogd_work_func(struct irq_work *irq_work)
+@@ -3831,9 +4061,16 @@ static void wake_up_klogd_work_func(struct irq_work *irq_work)
  	int pending = this_cpu_xchg(printk_pending, 0);
  
  	if (pending & PRINTK_PENDING_OUTPUT) {
@@ -13252,7 +13265,7 @@ index 7e0b4dd..81ecec9 100644
  	}
  
  	if (pending & PRINTK_PENDING_WAKEUP)
-@@ -3895,11 +4138,20 @@ void defer_console_output(void)
+@@ -3901,11 +4138,20 @@ void defer_console_output(void)
  	 * New messages may have been added directly to the ringbuffer
  	 * using vprintk_store(), so wake any waiters as well.
  	 */
@@ -13274,10 +13287,10 @@ index 7e0b4dd..81ecec9 100644
  	defer_console_output();
  }
  
-diff --git a/kernel/printk/printk_safe.c b/kernel/printk/printk_safe.c
+diff --git a/linux-6.6-rc6/kernel/printk/printk_safe.c b/rc6-cachy-rt/kernel/printk/printk_safe.c
 index 6d10927..8d9408d 100644
---- a/kernel/printk/printk_safe.c
-+++ b/kernel/printk/printk_safe.c
+--- a/linux-6.6-rc6/kernel/printk/printk_safe.c
++++ b/rc6-cachy-rt/kernel/printk/printk_safe.c
 @@ -26,6 +26,18 @@ void __printk_safe_exit(void)
  	this_cpu_dec(printk_context);
  }
@@ -13297,10 +13310,10 @@ index 6d10927..8d9408d 100644
  asmlinkage int vprintk(const char *fmt, va_list args)
  {
  #ifdef CONFIG_KGDB_KDB
-diff --git a/kernel/rcu/rcutorture.c b/kernel/rcu/rcutorture.c
+diff --git a/linux-6.6-rc6/kernel/rcu/rcutorture.c b/rc6-cachy-rt/kernel/rcu/rcutorture.c
 index ade42d6..eebb9b4 100644
---- a/kernel/rcu/rcutorture.c
-+++ b/kernel/rcu/rcutorture.c
+--- a/linux-6.6-rc6/kernel/rcu/rcutorture.c
++++ b/rc6-cachy-rt/kernel/rcu/rcutorture.c
 @@ -2408,6 +2408,12 @@ static int rcutorture_booster_init(unsigned int cpu)
  		WARN_ON_ONCE(!t);
  		sp.sched_priority = 2;
@@ -13314,10 +13327,10 @@ index ade42d6..eebb9b4 100644
  	}
  
  	/* Don't allow time recalculation while creating a new task. */
-diff --git a/kernel/rcu/tree_stall.h b/kernel/rcu/tree_stall.h
+diff --git a/linux-6.6-rc6/kernel/rcu/tree_stall.h b/rc6-cachy-rt/kernel/rcu/tree_stall.h
 index 6f06dc1..0a58f8b 100644
---- a/kernel/rcu/tree_stall.h
-+++ b/kernel/rcu/tree_stall.h
+--- a/linux-6.6-rc6/kernel/rcu/tree_stall.h
++++ b/rc6-cachy-rt/kernel/rcu/tree_stall.h
 @@ -8,6 +8,7 @@
   */
  
@@ -13352,10 +13365,10 @@ index 6f06dc1..0a58f8b 100644
  }
  
  static void print_cpu_stall(unsigned long gps)
-diff --git a/kernel/sched/core.c b/kernel/sched/core.c
+diff --git a/linux-6.6-rc6/kernel/sched/core.c b/rc6-cachy-rt/kernel/sched/core.c
 index 802551e..a9c755e 100644
---- a/kernel/sched/core.c
-+++ b/kernel/sched/core.c
+--- a/linux-6.6-rc6/kernel/sched/core.c
++++ b/rc6-cachy-rt/kernel/sched/core.c
 @@ -1062,6 +1062,46 @@ void resched_curr(struct rq *rq)
  		trace_sched_wake_idle_without_ipi(cpu);
  }
@@ -13624,11 +13637,11 @@ index 802551e..a9c755e 100644
  	/*
  	 * The idle tasks have their own, simple scheduling class:
  	 */
-diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index cb22592..0d0353d 100644
---- a/kernel/sched/fair.c
-+++ b/kernel/sched/fair.c
-@@ -985,7 +985,7 @@ static void update_deadline(struct cfs_rq *cfs_rq, struct sched_entity *se)
+diff --git a/linux-6.6-rc6/kernel/sched/fair.c b/rc6-cachy-rt/kernel/sched/fair.c
+index 061a30a..205346f 100644
+--- a/linux-6.6-rc6/kernel/sched/fair.c
++++ b/rc6-cachy-rt/kernel/sched/fair.c
+@@ -1037,7 +1037,7 @@ static void update_deadline(struct cfs_rq *cfs_rq, struct sched_entity *se)
  	 * The task has consumed its request, reschedule.
  	 */
  	if (cfs_rq->nr_running > 1) {
@@ -13637,7 +13650,7 @@ index cb22592..0d0353d 100644
  		clear_buddies(cfs_rq, se);
  	}
  }
-@@ -5267,7 +5267,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
+@@ -5322,7 +5322,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
  	 * validating it and just reschedule.
  	 */
  	if (queued) {
@@ -13646,7 +13659,7 @@ index cb22592..0d0353d 100644
  		return;
  	}
  	/*
-@@ -5413,7 +5413,7 @@ static void __account_cfs_rq_runtime(struct cfs_rq *cfs_rq, u64 delta_exec)
+@@ -5468,7 +5468,7 @@ static void __account_cfs_rq_runtime(struct cfs_rq *cfs_rq, u64 delta_exec)
  	 * hierarchy can be throttled
  	 */
  	if (!assign_cfs_rq_runtime(cfs_rq) && likely(cfs_rq->curr))
@@ -13655,7 +13668,7 @@ index cb22592..0d0353d 100644
  }
  
  static __always_inline
-@@ -6378,7 +6378,7 @@ static void hrtick_start_fair(struct rq *rq, struct task_struct *p)
+@@ -6433,7 +6433,7 @@ static void hrtick_start_fair(struct rq *rq, struct task_struct *p)
  
  		if (delta < 0) {
  			if (task_current(rq, p))
@@ -13664,7 +13677,7 @@ index cb22592..0d0353d 100644
  			return;
  		}
  		hrtick_start(rq, delta);
-@@ -8073,7 +8073,7 @@ static void check_preempt_wakeup(struct rq *rq, struct task_struct *p, int wake_
+@@ -8128,7 +8128,7 @@ static void check_preempt_wakeup(struct rq *rq, struct task_struct *p, int wake_
  	return;
  
  preempt:
@@ -13673,7 +13686,7 @@ index cb22592..0d0353d 100644
  }
  
  #ifdef CONFIG_SMP
-@@ -12389,7 +12389,7 @@ prio_changed_fair(struct rq *rq, struct task_struct *p, int oldprio)
+@@ -12444,7 +12444,7 @@ prio_changed_fair(struct rq *rq, struct task_struct *p, int oldprio)
  	 */
  	if (task_current(rq, p)) {
  		if (p->prio > oldprio)
@@ -13682,10 +13695,10 @@ index cb22592..0d0353d 100644
  	} else
  		check_preempt_curr(rq, p, 0);
  }
-diff --git a/kernel/sched/features.h b/kernel/sched/features.h
+diff --git a/linux-6.6-rc6/kernel/sched/features.h b/rc6-cachy-rt/kernel/sched/features.h
 index f770168..2c0ffe1 100644
---- a/kernel/sched/features.h
-+++ b/kernel/sched/features.h
+--- a/linux-6.6-rc6/kernel/sched/features.h
++++ b/rc6-cachy-rt/kernel/sched/features.h
 @@ -37,6 +37,9 @@ SCHED_FEAT(NONTASK_CAPACITY, true)
  
  #ifdef CONFIG_PREEMPT_RT
@@ -13696,10 +13709,10 @@ index f770168..2c0ffe1 100644
  #else
  
  /*
-diff --git a/kernel/sched/rt.c b/kernel/sched/rt.c
+diff --git a/linux-6.6-rc6/kernel/sched/rt.c b/rc6-cachy-rt/kernel/sched/rt.c
 index 0597ba0..716b9f0 100644
---- a/kernel/sched/rt.c
-+++ b/kernel/sched/rt.c
+--- a/linux-6.6-rc6/kernel/sched/rt.c
++++ b/rc6-cachy-rt/kernel/sched/rt.c
 @@ -2247,8 +2247,11 @@ static int rto_next_cpu(struct root_domain *rd)
  
  		rd->rto_cpu = cpu;
@@ -13713,10 +13726,10 @@ index 0597ba0..716b9f0 100644
  
  		rd->rto_cpu = -1;
  
-diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
+diff --git a/linux-6.6-rc6/kernel/sched/sched.h b/rc6-cachy-rt/kernel/sched/sched.h
 index 0484627..e9cf4da 100644
---- a/kernel/sched/sched.h
-+++ b/kernel/sched/sched.h
+--- a/linux-6.6-rc6/kernel/sched/sched.h
++++ b/rc6-cachy-rt/kernel/sched/sched.h
 @@ -2437,6 +2437,15 @@ extern void reweight_task(struct task_struct *p, int prio);
  extern void resched_curr(struct rq *rq);
  extern void resched_cpu(int cpu);
@@ -13733,10 +13746,10 @@ index 0484627..e9cf4da 100644
  extern struct rt_bandwidth def_rt_bandwidth;
  extern void init_rt_bandwidth(struct rt_bandwidth *rt_b, u64 period, u64 runtime);
  extern bool sched_rt_bandwidth_account(struct rt_rq *rt_rq);
-diff --git a/kernel/signal.c b/kernel/signal.c
+diff --git a/linux-6.6-rc6/kernel/signal.c b/rc6-cachy-rt/kernel/signal.c
 index 0901901..b710263 100644
---- a/kernel/signal.c
-+++ b/kernel/signal.c
+--- a/linux-6.6-rc6/kernel/signal.c
++++ b/rc6-cachy-rt/kernel/signal.c
 @@ -2329,15 +2329,35 @@ static int ptrace_stop(int exit_code, int why, unsigned long message,
  		do_notify_parent_cldstop(current, false, why);
  
@@ -13778,10 +13791,10 @@ index 0901901..b710263 100644
  	schedule();
  	cgroup_leave_frozen(true);
  
-diff --git a/kernel/softirq.c b/kernel/softirq.c
+diff --git a/linux-6.6-rc6/kernel/softirq.c b/rc6-cachy-rt/kernel/softirq.c
 index 210cf5f..cae0ae2 100644
---- a/kernel/softirq.c
-+++ b/kernel/softirq.c
+--- a/linux-6.6-rc6/kernel/softirq.c
++++ b/rc6-cachy-rt/kernel/softirq.c
 @@ -247,6 +247,19 @@ out:
  }
  EXPORT_SYMBOL(__local_bh_enable_ip);
@@ -13910,10 +13923,10 @@ index 210cf5f..cae0ae2 100644
  	return 0;
  }
  early_initcall(spawn_ksoftirqd);
-diff --git a/kernel/time/hrtimer.c b/kernel/time/hrtimer.c
+diff --git a/linux-6.6-rc6/kernel/time/hrtimer.c b/rc6-cachy-rt/kernel/time/hrtimer.c
 index 238262e..be97b23 100644
---- a/kernel/time/hrtimer.c
-+++ b/kernel/time/hrtimer.c
+--- a/linux-6.6-rc6/kernel/time/hrtimer.c
++++ b/rc6-cachy-rt/kernel/time/hrtimer.c
 @@ -1808,7 +1808,7 @@ retry:
  	if (!ktime_before(now, cpu_base->softirq_expires_next)) {
  		cpu_base->softirq_expires_next = KTIME_MAX;
@@ -13932,10 +13945,10 @@ index 238262e..be97b23 100644
  	}
  
  	__hrtimer_run_queues(cpu_base, now, flags, HRTIMER_ACTIVE_HARD);
-diff --git a/kernel/time/tick-sched.c b/kernel/time/tick-sched.c
+diff --git a/linux-6.6-rc6/kernel/time/tick-sched.c b/rc6-cachy-rt/kernel/time/tick-sched.c
 index 87015e9..3bea1d0 100644
---- a/kernel/time/tick-sched.c
-+++ b/kernel/time/tick-sched.c
+--- a/linux-6.6-rc6/kernel/time/tick-sched.c
++++ b/rc6-cachy-rt/kernel/time/tick-sched.c
 @@ -795,7 +795,7 @@ static void tick_nohz_restart(struct tick_sched *ts, ktime_t now)
  
  static inline bool local_timer_softirq_pending(void)
@@ -13945,10 +13958,10 @@ index 87015e9..3bea1d0 100644
  }
  
  static ktime_t tick_nohz_next_event(struct tick_sched *ts, int cpu)
-diff --git a/kernel/time/timer.c b/kernel/time/timer.c
+diff --git a/linux-6.6-rc6/kernel/time/timer.c b/rc6-cachy-rt/kernel/time/timer.c
 index 63a8ce7..b3fbe97 100644
---- a/kernel/time/timer.c
-+++ b/kernel/time/timer.c
+--- a/linux-6.6-rc6/kernel/time/timer.c
++++ b/rc6-cachy-rt/kernel/time/timer.c
 @@ -1470,9 +1470,16 @@ static inline void timer_base_unlock_expiry(struct timer_base *base)
   */
  static void timer_sync_wait_running(struct timer_base *base)
@@ -13976,10 +13989,10 @@ index 63a8ce7..b3fbe97 100644
  }
  
  /*
-diff --git a/kernel/trace/trace.c b/kernel/trace/trace.c
+diff --git a/linux-6.6-rc6/kernel/trace/trace.c b/rc6-cachy-rt/kernel/trace/trace.c
 index abaaf51..f00ad98 100644
---- a/kernel/trace/trace.c
-+++ b/kernel/trace/trace.c
+--- a/linux-6.6-rc6/kernel/trace/trace.c
++++ b/rc6-cachy-rt/kernel/trace/trace.c
 @@ -2720,11 +2720,19 @@ unsigned int tracing_gen_ctx_irq_test(unsigned int irqs_status)
  	if (softirq_count() >> (SOFTIRQ_SHIFT + 1))
  		trace_flags |= TRACE_FLAG_BH_OFF;
@@ -14054,10 +14067,10 @@ index abaaf51..f00ad98 100644
  }
  
  void
-diff --git a/kernel/trace/trace_events.c b/kernel/trace/trace_events.c
+diff --git a/linux-6.6-rc6/kernel/trace/trace_events.c b/rc6-cachy-rt/kernel/trace/trace_events.c
 index f49d6dd..4999ddf 100644
---- a/kernel/trace/trace_events.c
-+++ b/kernel/trace/trace_events.c
+--- a/linux-6.6-rc6/kernel/trace/trace_events.c
++++ b/rc6-cachy-rt/kernel/trace/trace_events.c
 @@ -210,6 +210,7 @@ static int trace_define_common_fields(void)
  	/* Holds both preempt_count and migrate_disable */
  	__common_field(unsigned char, preempt_count);
@@ -14066,10 +14079,10 @@ index f49d6dd..4999ddf 100644
  
  	return ret;
  }
-diff --git a/kernel/trace/trace_output.c b/kernel/trace/trace_output.c
+diff --git a/linux-6.6-rc6/kernel/trace/trace_output.c b/rc6-cachy-rt/kernel/trace/trace_output.c
 index db57509..6e1b552 100644
---- a/kernel/trace/trace_output.c
-+++ b/kernel/trace/trace_output.c
+--- a/linux-6.6-rc6/kernel/trace/trace_output.c
++++ b/rc6-cachy-rt/kernel/trace/trace_output.c
 @@ -445,6 +445,7 @@ int trace_print_lat_fmt(struct trace_seq *s, struct trace_entry *entry)
  {
  	char hardsoft_irq;
@@ -14129,11 +14142,11 @@ index db57509..6e1b552 100644
  	if (entry->preempt_count & 0xf0)
  		trace_seq_printf(s, "%x", entry->preempt_count >> 4);
  	else
-diff --git a/net/core/dev.c b/net/core/dev.c
-index 85df22f..4bb91a4 100644
---- a/net/core/dev.c
-+++ b/net/core/dev.c
-@@ -4673,15 +4673,6 @@ static void rps_trigger_softirq(void *data)
+diff --git a/linux-6.6-rc6/net/core/dev.c b/rc6-cachy-rt/net/core/dev.c
+index 5aaf575..26917a6 100644
+--- a/linux-6.6-rc6/net/core/dev.c
++++ b/rc6-cachy-rt/net/core/dev.c
+@@ -4677,15 +4677,6 @@ static void rps_trigger_softirq(void *data)
  
  #endif /* CONFIG_RPS */
  
@@ -14149,7 +14162,7 @@ index 85df22f..4bb91a4 100644
  /*
   * After we queued a packet into sd->input_pkt_queue,
   * we need to make sure this queue is serviced soon.
-@@ -6650,6 +6641,32 @@ static void skb_defer_free_flush(struct softnet_data *sd)
+@@ -6654,6 +6645,32 @@ static void skb_defer_free_flush(struct softnet_data *sd)
  	}
  }
  
@@ -14182,7 +14195,7 @@ index 85df22f..4bb91a4 100644
  static int napi_threaded_poll(void *data)
  {
  	struct napi_struct *napi = data;
-@@ -11509,7 +11526,11 @@ static int __init net_dev_init(void)
+@@ -11513,7 +11530,11 @@ static int __init net_dev_init(void)
  		INIT_CSD(&sd->csd, rps_trigger_softirq, sd);
  		sd->cpu = i;
  #endif
@@ -14194,10 +14207,10 @@ index 85df22f..4bb91a4 100644
  		spin_lock_init(&sd->defer_lock);
  
  		init_gro_hash(&sd->backlog);
-diff --git a/net/core/skbuff.c b/net/core/skbuff.c
+diff --git a/linux-6.6-rc6/net/core/skbuff.c b/rc6-cachy-rt/net/core/skbuff.c
 index 4eaf7ed..93fdd94 100644
---- a/net/core/skbuff.c
-+++ b/net/core/skbuff.c
+--- a/linux-6.6-rc6/net/core/skbuff.c
++++ b/rc6-cachy-rt/net/core/skbuff.c
 @@ -6840,8 +6840,13 @@ nodefer:	__kfree_skb(skb);
  	/* Make sure to trigger NET_RX_SOFTIRQ on the remote CPU
  	 * if we are unlucky enough (this seems very unlikely).

--- a/6.6/misc/0001-rt.patch
+++ b/6.6/misc/0001-rt.patch
@@ -1,7 +1,7 @@
-diff --git a/linux-6.6-rc6/arch/x86/Kconfig b/rc6-cachy-rt/arch/x86/Kconfig
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
 index a2e163a..4ac96d2 100644
---- a/linux-6.6-rc6/arch/x86/Kconfig
-+++ b/rc6-cachy-rt/arch/x86/Kconfig
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
 @@ -117,6 +117,7 @@ config X86
  	select ARCH_USES_CFI_TRAPS		if X86_64 && CFI_CLANG
  	select ARCH_SUPPORTS_LTO_CLANG
@@ -18,10 +18,10 @@ index a2e163a..4ac96d2 100644
  	select MMU_GATHER_RCU_TABLE_FREE	if PARAVIRT
  	select MMU_GATHER_MERGE_VMAS
  	select HAVE_POSIX_CPU_TIMERS_TASK_WORK
-diff --git a/linux-6.6-rc6/arch/x86/include/asm/preempt.h b/rc6-cachy-rt/arch/x86/include/asm/preempt.h
+diff --git a/arch/x86/include/asm/preempt.h b/arch/x86/include/asm/preempt.h
 index 2d13f25..5b09689 100644
---- a/linux-6.6-rc6/arch/x86/include/asm/preempt.h
-+++ b/rc6-cachy-rt/arch/x86/include/asm/preempt.h
+--- a/arch/x86/include/asm/preempt.h
++++ b/arch/x86/include/asm/preempt.h
 @@ -90,18 +90,49 @@ static __always_inline void __preempt_count_sub(int val)
   * a decrement which hits zero means we have no preempt_count and should
   * reschedule.
@@ -73,10 +73,10 @@ index 2d13f25..5b09689 100644
  }
  
  #ifdef CONFIG_PREEMPTION
-diff --git a/linux-6.6-rc6/arch/x86/include/asm/thread_info.h b/rc6-cachy-rt/arch/x86/include/asm/thread_info.h
+diff --git a/arch/x86/include/asm/thread_info.h b/arch/x86/include/asm/thread_info.h
 index d63b029..2de8ec3 100644
---- a/linux-6.6-rc6/arch/x86/include/asm/thread_info.h
-+++ b/rc6-cachy-rt/arch/x86/include/asm/thread_info.h
+--- a/arch/x86/include/asm/thread_info.h
++++ b/arch/x86/include/asm/thread_info.h
 @@ -57,6 +57,8 @@ struct thread_info {
  	unsigned long		flags;		/* low level flags */
  	unsigned long		syscall_work;	/* SYSCALL_WORK_ flags */
@@ -110,10 +110,10 @@ index d63b029..2de8ec3 100644
  #define _TIF_POLLING_NRFLAG	(1 << TIF_POLLING_NRFLAG)
  #define _TIF_IO_BITMAP		(1 << TIF_IO_BITMAP)
  #define _TIF_SPEC_FORCE_UPDATE	(1 << TIF_SPEC_FORCE_UPDATE)
-diff --git a/linux-6.6-rc6/drivers/block/zram/zram_drv.c b/rc6-cachy-rt/drivers/block/zram/zram_drv.c
+diff --git a/drivers/block/zram/zram_drv.c b/drivers/block/zram/zram_drv.c
 index 06673c6..a5d0f7c 100644
---- a/linux-6.6-rc6/drivers/block/zram/zram_drv.c
-+++ b/rc6-cachy-rt/drivers/block/zram/zram_drv.c
+--- a/drivers/block/zram/zram_drv.c
++++ b/drivers/block/zram/zram_drv.c
 @@ -57,6 +57,41 @@ static void zram_free_page(struct zram *zram, size_t index);
  static int zram_read_page(struct zram *zram, struct page *page, u32 index,
  			  struct bio *parent);
@@ -172,10 +172,10 @@ index 06673c6..a5d0f7c 100644
  	return true;
  }
  
-diff --git a/linux-6.6-rc6/drivers/block/zram/zram_drv.h b/rc6-cachy-rt/drivers/block/zram/zram_drv.h
+diff --git a/drivers/block/zram/zram_drv.h b/drivers/block/zram/zram_drv.h
 index ca7a15b..e64eb60 100644
---- a/linux-6.6-rc6/drivers/block/zram/zram_drv.h
-+++ b/rc6-cachy-rt/drivers/block/zram/zram_drv.h
+--- a/drivers/block/zram/zram_drv.h
++++ b/drivers/block/zram/zram_drv.h
 @@ -69,6 +69,9 @@ struct zram_table_entry {
  		unsigned long element;
  	};
@@ -186,10 +186,10 @@ index ca7a15b..e64eb60 100644
  #ifdef CONFIG_ZRAM_MEMORY_TRACKING
  	ktime_t ac_time;
  #endif
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c b/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
 index 172aa10..4ae4720 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/dc_fpu.c
 @@ -60,11 +60,9 @@ static DEFINE_PER_CPU(int, fpu_recursion_depth);
   */
  inline void dc_assert_fp_enabled(void)
@@ -288,10 +288,10 @@ index 172aa10..4ae4720 100644
 +	TRACE_DCN_FPU(false, function_name, line, depth);
 +	preempt_enable();
  }
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
 index d587f80..5036a3e 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
 @@ -2141,9 +2141,17 @@ bool dcn20_validate_bandwidth(struct dc *dc, struct dc_state *context,
  		bool fast_validate)
  {
@@ -311,10 +311,10 @@ index d587f80..5036a3e 100644
  	return voltage_supported;
  }
  
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c b/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
 index d1a25fe..5674c34 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
+--- a/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn21/dcn21_resource.c
 @@ -953,9 +953,17 @@ static bool dcn21_validate_bandwidth(struct dc *dc, struct dc_state *context,
  		bool fast_validate)
  {
@@ -334,10 +334,10 @@ index d1a25fe..5674c34 100644
  	return voltage_supported;
  }
  
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
+diff --git a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
 index 5805fb0..2ad9249 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
+--- a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
++++ b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.c
 @@ -1923,7 +1923,7 @@ void dcn20_patch_bounding_box(struct dc *dc, struct _vcs_dpi_soc_bounding_box_st
  }
  
@@ -426,10 +426,10 @@ index 5805fb0..2ad9249 100644
  
  	BW_VAL_TRACE_FINISH();
  
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
+diff --git a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
 index c51badf..b6c3419 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
-+++ b/rc6-cachy-rt/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
+--- a/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
++++ b/drivers/gpu/drm/amd/display/dc/dml/dcn20/dcn20_fpu.h
 @@ -61,9 +61,8 @@ void dcn20_update_bounding_box(struct dc *dc,
  			       unsigned int num_states);
  void dcn20_patch_bounding_box(struct dc *dc,
@@ -454,10 +454,10 @@ index c51badf..b6c3419 100644
  void dcn21_update_bw_bounding_box(struct dc *dc, struct clk_bw_params *bw_params);
  
  void dcn21_clk_mgr_set_bw_params_wm_table(struct clk_bw_params *bw_params);
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/Kconfig b/rc6-cachy-rt/drivers/gpu/drm/i915/Kconfig
+diff --git a/drivers/gpu/drm/i915/Kconfig b/drivers/gpu/drm/i915/Kconfig
 index ce397a8..98c3f53 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/Kconfig
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/Kconfig
+--- a/drivers/gpu/drm/i915/Kconfig
++++ b/drivers/gpu/drm/i915/Kconfig
 @@ -3,7 +3,6 @@ config DRM_I915
  	tristate "Intel 8xx/9xx/G3x/G4x/HD Graphics"
  	depends on DRM
@@ -466,10 +466,10 @@ index ce397a8..98c3f53 100644
  	select INTEL_GTT if X86
  	select INTERVAL_TREE
  	# we need shmfs for the swappable backing store, and in particular
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_crtc.c b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_crtc.c
+diff --git a/drivers/gpu/drm/i915/display/intel_crtc.c b/drivers/gpu/drm/i915/display/intel_crtc.c
 index 182c6dd..e708368 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_crtc.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_crtc.c
+--- a/drivers/gpu/drm/i915/display/intel_crtc.c
++++ b/drivers/gpu/drm/i915/display/intel_crtc.c
 @@ -534,7 +534,8 @@ void intel_pipe_update_start(struct intel_crtc_state *new_crtc_state)
  	 */
  	intel_psr_wait_for_idle_locked(new_crtc_state);
@@ -516,10 +516,10 @@ index 182c6dd..e708368 100644
  
  	if (intel_vgpu_active(dev_priv))
  		return;
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_vblank.c b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_vblank.c
+diff --git a/drivers/gpu/drm/i915/display/intel_vblank.c b/drivers/gpu/drm/i915/display/intel_vblank.c
 index f5659eb..5b6d2f5 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/display/intel_vblank.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/display/intel_vblank.c
+--- a/drivers/gpu/drm/i915/display/intel_vblank.c
++++ b/drivers/gpu/drm/i915/display/intel_vblank.c
 @@ -294,7 +294,8 @@ static bool i915_get_crtc_scanoutpos(struct drm_crtc *_crtc,
  	 */
  	spin_lock_irqsave(&dev_priv->uncore.lock, irqflags);
@@ -540,10 +540,10 @@ index f5659eb..5b6d2f5 100644
  
  	spin_unlock_irqrestore(&dev_priv->uncore.lock, irqflags);
  
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
+diff --git a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
 index ecc990e..8d04b10 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
+--- a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
++++ b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
 @@ -312,10 +312,9 @@ void __intel_breadcrumbs_park(struct intel_breadcrumbs *b)
  	/* Kick the work once more to drain the signalers, and disarm the irq */
  	irq_work_sync(&b->irq_work);
@@ -557,10 +557,10 @@ index ecc990e..8d04b10 100644
  	}
  }
  
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_execlists_submission.c b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
+diff --git a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 index 3292524..00cb9fd 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
+--- a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
++++ b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 @@ -1303,7 +1303,7 @@ static void execlists_dequeue(struct intel_engine_cs *engine)
  	 * and context switches) submission.
  	 */
@@ -620,10 +620,10 @@ index 3292524..00cb9fd 100644
  		start_timeslice(engine);
  	}
  
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_reset.c b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_reset.c
+diff --git a/drivers/gpu/drm/i915/gt/intel_reset.c b/drivers/gpu/drm/i915/gt/intel_reset.c
 index cc6bd21..cdbc08d 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/intel_reset.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/intel_reset.c
+--- a/drivers/gpu/drm/i915/gt/intel_reset.c
++++ b/drivers/gpu/drm/i915/gt/intel_reset.c
 @@ -164,13 +164,13 @@ static int i915_do_reset(struct intel_gt *gt,
  	/* Assert reset for at least 20 usec, and wait for acknowledgement. */
  	pci_write_config_byte(pdev, I915_GDRST, GRDOM_RESET_ENABLE);
@@ -677,10 +677,10 @@ index cc6bd21..cdbc08d 100644
  
  		wa_14015076503_end(gt, reset_mask);
  	}
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/uc/intel_guc.h b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/uc/intel_guc.h
+diff --git a/drivers/gpu/drm/i915/gt/uc/intel_guc.h b/drivers/gpu/drm/i915/gt/uc/intel_guc.h
 index 8dc291f..5b8d084 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/gt/uc/intel_guc.h
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/gt/uc/intel_guc.h
+--- a/drivers/gpu/drm/i915/gt/uc/intel_guc.h
++++ b/drivers/gpu/drm/i915/gt/uc/intel_guc.h
 @@ -317,7 +317,7 @@ static inline int intel_guc_send_busy_loop(struct intel_guc *guc,
  {
  	int err;
@@ -690,10 +690,10 @@ index 8dc291f..5b8d084 100644
  
  	/*
  	 * FIXME: Have caller pass in if we are in an atomic context to avoid
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_request.c b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_request.c
+diff --git a/drivers/gpu/drm/i915/i915_request.c b/drivers/gpu/drm/i915/i915_request.c
 index f590810..014d020 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_request.c
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_request.c
+--- a/drivers/gpu/drm/i915/i915_request.c
++++ b/drivers/gpu/drm/i915/i915_request.c
 @@ -609,7 +609,6 @@ bool __i915_request_submit(struct i915_request *request)
  
  	RQ_TRACE(request, "\n");
@@ -710,10 +710,10 @@ index f590810..014d020 100644
  	lockdep_assert_held(&engine->sched_engine->lock);
  
  	/*
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_trace.h b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_trace.h
+diff --git a/drivers/gpu/drm/i915/i915_trace.h b/drivers/gpu/drm/i915/i915_trace.h
 index ce1cbee..3c51620 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_trace.h
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_trace.h
+--- a/drivers/gpu/drm/i915/i915_trace.h
++++ b/drivers/gpu/drm/i915/i915_trace.h
 @@ -6,6 +6,10 @@
  #if !defined(_I915_TRACE_H_) || defined(TRACE_HEADER_MULTI_READ)
  #define _I915_TRACE_H_
@@ -734,10 +734,10 @@ index ce1cbee..3c51620 100644
  DEFINE_EVENT(i915_request, i915_request_guc_submit,
  	     TP_PROTO(struct i915_request *rq),
  	     TP_ARGS(rq)
-diff --git a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_utils.h b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_utils.h
+diff --git a/drivers/gpu/drm/i915/i915_utils.h b/drivers/gpu/drm/i915/i915_utils.h
 index c610664..48e19e5 100644
---- a/linux-6.6-rc6/drivers/gpu/drm/i915/i915_utils.h
-+++ b/rc6-cachy-rt/drivers/gpu/drm/i915/i915_utils.h
+--- a/drivers/gpu/drm/i915/i915_utils.h
++++ b/drivers/gpu/drm/i915/i915_utils.h
 @@ -288,7 +288,7 @@ wait_remaining_ms_from_jiffies(unsigned long timestamp_jiffies, int to_wait_ms)
  #define wait_for(COND, MS)		_wait_for((COND), (MS) * 1000, 10, 1000)
  
@@ -747,10 +747,10 @@ index c610664..48e19e5 100644
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) WARN_ON_ONCE((ATOMIC) && !in_atomic())
  #else
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) do { } while (0)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/21285.c b/rc6-cachy-rt/drivers/tty/serial/21285.c
+diff --git a/drivers/tty/serial/21285.c b/drivers/tty/serial/21285.c
 index d756fcc..4de0c97 100644
---- a/linux-6.6-rc6/drivers/tty/serial/21285.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/21285.c
+--- a/drivers/tty/serial/21285.c
++++ b/drivers/tty/serial/21285.c
 @@ -185,14 +185,14 @@ static void serial21285_break_ctl(struct uart_port *port, int break_state)
  	unsigned long flags;
  	unsigned int h_lcr;
@@ -786,10 +786,10 @@ index d756fcc..4de0c97 100644
  }
  
  static const char *serial21285_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_aspeed_vuart.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_aspeed_vuart.c
+diff --git a/drivers/tty/serial/8250/8250_aspeed_vuart.c b/drivers/tty/serial/8250/8250_aspeed_vuart.c
 index 4a9e71b..021949f 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_aspeed_vuart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_aspeed_vuart.c
+--- a/drivers/tty/serial/8250/8250_aspeed_vuart.c
++++ b/drivers/tty/serial/8250/8250_aspeed_vuart.c
 @@ -288,9 +288,9 @@ static void aspeed_vuart_set_throttle(struct uart_port *port, bool throttle)
  	struct uart_8250_port *up = up_to_u8250p(port);
  	unsigned long flags;
@@ -811,10 +811,10 @@ index 4a9e71b..021949f 100644
  
  	lsr = serial_port_in(port, UART_LSR);
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_bcm7271.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_bcm7271.c
+diff --git a/drivers/tty/serial/8250/8250_bcm7271.c b/drivers/tty/serial/8250/8250_bcm7271.c
 index aa5aff0..ff0662c 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_bcm7271.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_bcm7271.c
+--- a/drivers/tty/serial/8250/8250_bcm7271.c
++++ b/drivers/tty/serial/8250/8250_bcm7271.c
 @@ -567,7 +567,7 @@ static irqreturn_t brcmuart_isr(int irq, void *dev_id)
  	if (interrupts == 0)
  		return IRQ_NONE;
@@ -926,10 +926,10 @@ index aa5aff0..ff0662c 100644
  	}
  
  	return 0;
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_core.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_core.c
+diff --git a/drivers/tty/serial/8250/8250_core.c b/drivers/tty/serial/8250/8250_core.c
 index 3449f87..0535e49 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_core.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_core.c
+--- a/drivers/tty/serial/8250/8250_core.c
++++ b/drivers/tty/serial/8250/8250_core.c
 @@ -259,7 +259,7 @@ static void serial8250_backup_timeout(struct timer_list *t)
  	unsigned int iir, ier = 0, lsr;
  	unsigned long flags;
@@ -1010,10 +1010,10 @@ index 3449f87..0535e49 100644
  	}
  
  	uart_remove_one_port(&serial8250_reg, &uart->port);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dma.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dma.c
+diff --git a/drivers/tty/serial/8250/8250_dma.c b/drivers/tty/serial/8250/8250_dma.c
 index 7fa6650..8b30ca8 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dma.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dma.c
+--- a/drivers/tty/serial/8250/8250_dma.c
++++ b/drivers/tty/serial/8250/8250_dma.c
 @@ -22,7 +22,7 @@ static void __dma_tx_complete(void *param)
  	dma_sync_single_for_cpu(dma->txchan->device->dev, dma->tx_addr,
  				UART_XMIT_SIZE, DMA_TO_DEVICE);
@@ -1050,10 +1050,10 @@ index 7fa6650..8b30ca8 100644
  }
  
  int serial8250_tx_dma(struct uart_8250_port *p)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dw.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dw.c
+diff --git a/drivers/tty/serial/8250/8250_dw.c b/drivers/tty/serial/8250/8250_dw.c
 index f4cafca..95d45dc 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_dw.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_dw.c
+--- a/drivers/tty/serial/8250/8250_dw.c
++++ b/drivers/tty/serial/8250/8250_dw.c
 @@ -263,20 +263,20 @@ static int dw8250_handle_irq(struct uart_port *p)
  	 * so we limit the workaround only to non-DMA mode.
  	 */
@@ -1079,10 +1079,10 @@ index f4cafca..95d45dc 100644
  
  		if (status & (UART_LSR_DR | UART_LSR_BI)) {
  			dw8250_writel_ext(p, RZN1_UART_RDMACR, 0);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_exar.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_exar.c
+diff --git a/drivers/tty/serial/8250/8250_exar.c b/drivers/tty/serial/8250/8250_exar.c
 index 077c3ba..07ad213 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_exar.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_exar.c
+--- a/drivers/tty/serial/8250/8250_exar.c
++++ b/drivers/tty/serial/8250/8250_exar.c
 @@ -201,9 +201,9 @@ static int xr17v35x_startup(struct uart_port *port)
  	 *
  	 * Synchronize UART_IER access against the console.
@@ -1095,10 +1095,10 @@ index 077c3ba..07ad213 100644
  
  	return serial8250_do_startup(port);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_fsl.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_fsl.c
+diff --git a/drivers/tty/serial/8250/8250_fsl.c b/drivers/tty/serial/8250/8250_fsl.c
 index 6af4e1c..f522eb5 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_fsl.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_fsl.c
+--- a/drivers/tty/serial/8250/8250_fsl.c
++++ b/drivers/tty/serial/8250/8250_fsl.c
 @@ -30,11 +30,11 @@ int fsl8250_handle_irq(struct uart_port *port)
  	unsigned int iir;
  	struct uart_8250_port *up = up_to_u8250p(port);
@@ -1122,10 +1122,10 @@ index 6af4e1c..f522eb5 100644
  		return 1;
  	}
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_mtk.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_mtk.c
+diff --git a/drivers/tty/serial/8250/8250_mtk.c b/drivers/tty/serial/8250/8250_mtk.c
 index 74da567..23457da 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_mtk.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_mtk.c
+--- a/drivers/tty/serial/8250/8250_mtk.c
++++ b/drivers/tty/serial/8250/8250_mtk.c
 @@ -102,7 +102,7 @@ static void mtk8250_dma_rx_complete(void *param)
  	if (data->rx_status == DMA_RX_SHUTDOWN)
  		return;
@@ -1162,10 +1162,10 @@ index 74da567..23457da 100644
  	/* Don't rewrite B0 */
  	if (tty_termios_baud_rate(termios))
  		tty_termios_encode_baud_rate(termios, baud, baud);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_omap.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_omap.c
+diff --git a/drivers/tty/serial/8250/8250_omap.c b/drivers/tty/serial/8250/8250_omap.c
 index ca972fd..999c660 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_omap.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_omap.c
+--- a/drivers/tty/serial/8250/8250_omap.c
++++ b/drivers/tty/serial/8250/8250_omap.c
 @@ -401,7 +401,7 @@ static void omap_8250_set_termios(struct uart_port *port,
  	 * interrupts disabled.
  	 */
@@ -1362,10 +1362,10 @@ index ca972fd..999c660 100644
  	}
  
  	priv->latency = priv->calc_latency;
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_pci1xxxx.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_pci1xxxx.c
+diff --git a/drivers/tty/serial/8250/8250_pci1xxxx.c b/drivers/tty/serial/8250/8250_pci1xxxx.c
 index a3b2577..53e238c 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_pci1xxxx.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_pci1xxxx.c
+--- a/drivers/tty/serial/8250/8250_pci1xxxx.c
++++ b/drivers/tty/serial/8250/8250_pci1xxxx.c
 @@ -225,10 +225,10 @@ static bool pci1xxxx_port_suspend(int line)
  	if (port->suspended == 0 && port->dev) {
  		wakeup_mask = readb(up->port.membase + UART_WAKE_MASK_REG);
@@ -1392,10 +1392,10 @@ index a3b2577..53e238c 100644
  	}
  	mutex_unlock(&tport->mutex);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/8250/8250_port.c b/rc6-cachy-rt/drivers/tty/serial/8250/8250_port.c
+diff --git a/drivers/tty/serial/8250/8250_port.c b/drivers/tty/serial/8250/8250_port.c
 index 1416273..ed29d84 100644
---- a/linux-6.6-rc6/drivers/tty/serial/8250/8250_port.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/8250/8250_port.c
+--- a/drivers/tty/serial/8250/8250_port.c
++++ b/drivers/tty/serial/8250/8250_port.c
 @@ -557,6 +557,9 @@ static int serial8250_em485_init(struct uart_8250_port *p)
  	if (!p->em485)
  		return -ENOMEM;
@@ -1852,10 +1852,10 @@ index 1416273..ed29d84 100644
  }
  
  static unsigned int probe_baud(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/altera_jtaguart.c b/rc6-cachy-rt/drivers/tty/serial/altera_jtaguart.c
+diff --git a/drivers/tty/serial/altera_jtaguart.c b/drivers/tty/serial/altera_jtaguart.c
 index 5fab4c9..7090b25 100644
---- a/linux-6.6-rc6/drivers/tty/serial/altera_jtaguart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/altera_jtaguart.c
+--- a/drivers/tty/serial/altera_jtaguart.c
++++ b/drivers/tty/serial/altera_jtaguart.c
 @@ -147,14 +147,14 @@ static irqreturn_t altera_jtaguart_interrupt(int irq, void *data)
  	isr = (readl(port->membase + ALTERA_JTAGUART_CONTROL_REG) >>
  	       ALTERA_JTAGUART_CONTROL_RI_OFF) & port->read_status_mask;
@@ -1949,10 +1949,10 @@ index 5fab4c9..7090b25 100644
  }
  #endif
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/altera_uart.c b/rc6-cachy-rt/drivers/tty/serial/altera_uart.c
+diff --git a/drivers/tty/serial/altera_uart.c b/drivers/tty/serial/altera_uart.c
 index a9c4194..77835ac 100644
---- a/linux-6.6-rc6/drivers/tty/serial/altera_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/altera_uart.c
+--- a/drivers/tty/serial/altera_uart.c
++++ b/drivers/tty/serial/altera_uart.c
 @@ -164,13 +164,13 @@ static void altera_uart_break_ctl(struct uart_port *port, int break_state)
  	struct altera_uart *pp = container_of(port, struct altera_uart, port);
  	unsigned long flags;
@@ -2029,10 +2029,10 @@ index a9c4194..77835ac 100644
  
  	if (port->irq)
  		free_irq(port->irq, port);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/amba-pl010.c b/rc6-cachy-rt/drivers/tty/serial/amba-pl010.c
+diff --git a/drivers/tty/serial/amba-pl010.c b/drivers/tty/serial/amba-pl010.c
 index b5a7404..eabbf8a 100644
---- a/linux-6.6-rc6/drivers/tty/serial/amba-pl010.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/amba-pl010.c
+--- a/drivers/tty/serial/amba-pl010.c
++++ b/drivers/tty/serial/amba-pl010.c
 @@ -207,7 +207,7 @@ static irqreturn_t pl010_int(int irq, void *dev_id)
  	unsigned int status, pass_counter = AMBA_ISR_PASS_LIMIT;
  	int handled = 0;
@@ -2105,10 +2105,10 @@ index b5a7404..eabbf8a 100644
  		}
  	}
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/amba-pl011.c b/rc6-cachy-rt/drivers/tty/serial/amba-pl011.c
+diff --git a/drivers/tty/serial/amba-pl011.c b/drivers/tty/serial/amba-pl011.c
 index 3dc9b0f..c6c2d3e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/amba-pl011.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/amba-pl011.c
+--- a/drivers/tty/serial/amba-pl011.c
++++ b/drivers/tty/serial/amba-pl011.c
 @@ -345,9 +345,9 @@ static int pl011_fifo_to_tty(struct uart_amba_port *uap)
  				flag = TTY_FRAME;
  		}
@@ -2402,10 +2402,10 @@ index 3dc9b0f..c6c2d3e 100644
  
  	clk_disable(uap->clk);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/apbuart.c b/rc6-cachy-rt/drivers/tty/serial/apbuart.c
+diff --git a/drivers/tty/serial/apbuart.c b/drivers/tty/serial/apbuart.c
 index d7658f3..716cb01 100644
---- a/linux-6.6-rc6/drivers/tty/serial/apbuart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/apbuart.c
+--- a/drivers/tty/serial/apbuart.c
++++ b/drivers/tty/serial/apbuart.c
 @@ -133,7 +133,7 @@ static irqreturn_t apbuart_int(int irq, void *dev_id)
  	struct uart_port *port = dev_id;
  	unsigned int status;
@@ -2442,10 +2442,10 @@ index d7658f3..716cb01 100644
  }
  
  static const char *apbuart_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/ar933x_uart.c b/rc6-cachy-rt/drivers/tty/serial/ar933x_uart.c
+diff --git a/drivers/tty/serial/ar933x_uart.c b/drivers/tty/serial/ar933x_uart.c
 index 924c1a8..ffd2346 100644
---- a/linux-6.6-rc6/drivers/tty/serial/ar933x_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/ar933x_uart.c
+--- a/drivers/tty/serial/ar933x_uart.c
++++ b/drivers/tty/serial/ar933x_uart.c
 @@ -133,9 +133,9 @@ static unsigned int ar933x_uart_tx_empty(struct uart_port *port)
  	unsigned long flags;
  	unsigned int rdata;
@@ -2550,10 +2550,10 @@ index 924c1a8..ffd2346 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/arc_uart.c b/rc6-cachy-rt/drivers/tty/serial/arc_uart.c
+diff --git a/drivers/tty/serial/arc_uart.c b/drivers/tty/serial/arc_uart.c
 index ad4ae19..1aa5b2b 100644
---- a/linux-6.6-rc6/drivers/tty/serial/arc_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/arc_uart.c
+--- a/drivers/tty/serial/arc_uart.c
++++ b/drivers/tty/serial/arc_uart.c
 @@ -279,9 +279,9 @@ static irqreturn_t arc_serial_isr(int irq, void *dev_id)
  	if (status & RXIENB) {
  
@@ -2611,10 +2611,10 @@ index ad4ae19..1aa5b2b 100644
  }
  
  static struct console arc_console = {
-diff --git a/linux-6.6-rc6/drivers/tty/serial/atmel_serial.c b/rc6-cachy-rt/drivers/tty/serial/atmel_serial.c
+diff --git a/drivers/tty/serial/atmel_serial.c b/drivers/tty/serial/atmel_serial.c
 index 88cdafa..1946faf 100644
---- a/linux-6.6-rc6/drivers/tty/serial/atmel_serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/atmel_serial.c
+--- a/drivers/tty/serial/atmel_serial.c
++++ b/drivers/tty/serial/atmel_serial.c
 @@ -861,7 +861,7 @@ static void atmel_complete_tx_dma(void *arg)
  	struct dma_chan *chan = atmel_port->chan_tx;
  	unsigned long flags;
@@ -2694,10 +2694,10 @@ index 88cdafa..1946faf 100644
  		}
  	}
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/bcm63xx_uart.c b/rc6-cachy-rt/drivers/tty/serial/bcm63xx_uart.c
+diff --git a/drivers/tty/serial/bcm63xx_uart.c b/drivers/tty/serial/bcm63xx_uart.c
 index 0dd8cce..4a08fd5 100644
---- a/linux-6.6-rc6/drivers/tty/serial/bcm63xx_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/bcm63xx_uart.c
+--- a/drivers/tty/serial/bcm63xx_uart.c
++++ b/drivers/tty/serial/bcm63xx_uart.c
 @@ -201,7 +201,7 @@ static void bcm_uart_break_ctl(struct uart_port *port, int ctl)
  	unsigned long flags;
  	unsigned int val;
@@ -2785,10 +2785,10 @@ index 0dd8cce..4a08fd5 100644
  	local_irq_restore(flags);
  }
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/cpm_uart.c b/rc6-cachy-rt/drivers/tty/serial/cpm_uart.c
+diff --git a/drivers/tty/serial/cpm_uart.c b/drivers/tty/serial/cpm_uart.c
 index 6264230..be4af6e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/cpm_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/cpm_uart.c
+--- a/drivers/tty/serial/cpm_uart.c
++++ b/drivers/tty/serial/cpm_uart.c
 @@ -569,7 +569,7 @@ static void cpm_uart_set_termios(struct uart_port *port,
  	if ((termios->c_cflag & CREAD) == 0)
  		port->read_status_mask &= ~BD_SC_EMPTY;
@@ -2819,10 +2819,10 @@ index 6264230..be4af6e 100644
  	}
  }
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/digicolor-usart.c b/rc6-cachy-rt/drivers/tty/serial/digicolor-usart.c
+diff --git a/drivers/tty/serial/digicolor-usart.c b/drivers/tty/serial/digicolor-usart.c
 index 128b547..5004125 100644
---- a/linux-6.6-rc6/drivers/tty/serial/digicolor-usart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/digicolor-usart.c
+--- a/drivers/tty/serial/digicolor-usart.c
++++ b/drivers/tty/serial/digicolor-usart.c
 @@ -133,7 +133,7 @@ static void digicolor_uart_rx(struct uart_port *port)
  {
  	unsigned long flags;
@@ -2895,10 +2895,10 @@ index 128b547..5004125 100644
  
  	/* Wait for transmitter to become empty */
  	do {
-diff --git a/linux-6.6-rc6/drivers/tty/serial/dz.c b/rc6-cachy-rt/drivers/tty/serial/dz.c
+diff --git a/drivers/tty/serial/dz.c b/drivers/tty/serial/dz.c
 index 667f52e..6df7af9 100644
---- a/linux-6.6-rc6/drivers/tty/serial/dz.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/dz.c
+--- a/drivers/tty/serial/dz.c
++++ b/drivers/tty/serial/dz.c
 @@ -268,9 +268,9 @@ static inline void dz_transmit_chars(struct dz_mux *mux)
  	}
  	/* If nothing to do or stopped or hardware stopped. */
@@ -3020,10 +3020,10 @@ index 667f52e..6df7af9 100644
  
  	do {
  		trdy = dz_in(dport, DZ_CSR);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/fsl_linflexuart.c b/rc6-cachy-rt/drivers/tty/serial/fsl_linflexuart.c
+diff --git a/drivers/tty/serial/fsl_linflexuart.c b/drivers/tty/serial/fsl_linflexuart.c
 index 249cb38..7fa809a 100644
---- a/linux-6.6-rc6/drivers/tty/serial/fsl_linflexuart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/fsl_linflexuart.c
+--- a/drivers/tty/serial/fsl_linflexuart.c
++++ b/drivers/tty/serial/fsl_linflexuart.c
 @@ -203,7 +203,7 @@ static irqreturn_t linflex_txint(int irq, void *dev_id)
  	struct circ_buf *xmit = &sport->state->xmit;
  	unsigned long flags;
@@ -3127,10 +3127,10 @@ index 249cb38..7fa809a 100644
  }
  
  /*
-diff --git a/linux-6.6-rc6/drivers/tty/serial/fsl_lpuart.c b/rc6-cachy-rt/drivers/tty/serial/fsl_lpuart.c
+diff --git a/drivers/tty/serial/fsl_lpuart.c b/drivers/tty/serial/fsl_lpuart.c
 index f72e134..6d0cfb2 100644
---- a/linux-6.6-rc6/drivers/tty/serial/fsl_lpuart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/fsl_lpuart.c
+--- a/drivers/tty/serial/fsl_lpuart.c
++++ b/drivers/tty/serial/fsl_lpuart.c
 @@ -532,9 +532,9 @@ static void lpuart_dma_tx_complete(void *arg)
  	struct dma_chan *chan = sport->dma_tx_chan;
  	unsigned long flags;
@@ -3480,10 +3480,10 @@ index f72e134..6d0cfb2 100644
  			sport->dma_tx_in_progress = false;
  			dmaengine_terminate_sync(sport->dma_tx_chan);
  		}
-diff --git a/linux-6.6-rc6/drivers/tty/serial/icom.c b/rc6-cachy-rt/drivers/tty/serial/icom.c
+diff --git a/drivers/tty/serial/icom.c b/drivers/tty/serial/icom.c
 index 819f957..a75eafb 100644
---- a/linux-6.6-rc6/drivers/tty/serial/icom.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/icom.c
+--- a/drivers/tty/serial/icom.c
++++ b/drivers/tty/serial/icom.c
 @@ -929,7 +929,7 @@ static inline void check_modem_status(struct icom_port *icom_port)
  	char delta_status;
  	unsigned char status;
@@ -3595,10 +3595,10 @@ index 819f957..a75eafb 100644
  }
  
  static const char *icom_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/imx.c b/rc6-cachy-rt/drivers/tty/serial/imx.c
+diff --git a/drivers/tty/serial/imx.c b/drivers/tty/serial/imx.c
 index 13cb783..0fb679c 100644
---- a/linux-6.6-rc6/drivers/tty/serial/imx.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/imx.c
+--- a/drivers/tty/serial/imx.c
++++ b/drivers/tty/serial/imx.c
 @@ -575,7 +575,7 @@ static void imx_uart_dma_tx_callback(void *data)
  	unsigned long flags;
  	u32 ucr1;
@@ -3913,10 +3913,10 @@ index 13cb783..0fb679c 100644
  }
  
  static void imx_uart_enable_wakeup(struct imx_port *sport, bool on)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/ip22zilog.c b/rc6-cachy-rt/drivers/tty/serial/ip22zilog.c
+diff --git a/drivers/tty/serial/ip22zilog.c b/drivers/tty/serial/ip22zilog.c
 index 845ff70..320b29c 100644
---- a/linux-6.6-rc6/drivers/tty/serial/ip22zilog.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/ip22zilog.c
+--- a/drivers/tty/serial/ip22zilog.c
++++ b/drivers/tty/serial/ip22zilog.c
 @@ -432,7 +432,7 @@ static irqreturn_t ip22zilog_interrupt(int irq, void *dev_id)
  		unsigned char r3;
  		bool push = false;
@@ -4062,10 +4062,10 @@ index 845ff70..320b29c 100644
  
  	if (options)
  		uart_parse_options(options, &baud, &parity, &bits, &flow);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_neo.c b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_neo.c
+diff --git a/drivers/tty/serial/jsm/jsm_neo.c b/drivers/tty/serial/jsm/jsm_neo.c
 index 0c78f66..2bd6404 100644
---- a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_neo.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_neo.c
+--- a/drivers/tty/serial/jsm/jsm_neo.c
++++ b/drivers/tty/serial/jsm/jsm_neo.c
 @@ -816,9 +816,9 @@ static void neo_parse_isr(struct jsm_board *brd, u32 port)
  		/* Parse any modem signal changes */
  		jsm_dbg(INTR, &ch->ch_bd->pci_dev,
@@ -4078,10 +4078,10 @@ index 0c78f66..2bd6404 100644
  	}
  }
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_tty.c b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_tty.c
+diff --git a/drivers/tty/serial/jsm/jsm_tty.c b/drivers/tty/serial/jsm/jsm_tty.c
 index 222afc2..ce0fef7 100644
---- a/linux-6.6-rc6/drivers/tty/serial/jsm/jsm_tty.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/jsm/jsm_tty.c
+--- a/drivers/tty/serial/jsm/jsm_tty.c
++++ b/drivers/tty/serial/jsm/jsm_tty.c
 @@ -152,14 +152,14 @@ static void jsm_tty_send_xchar(struct uart_port *port, char ch)
  		container_of(port, struct jsm_channel, uart_port);
  	struct ktermios *termios;
@@ -4151,10 +4151,10 @@ index 222afc2..ce0fef7 100644
  }
  
  static const char *jsm_tty_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/liteuart.c b/rc6-cachy-rt/drivers/tty/serial/liteuart.c
+diff --git a/drivers/tty/serial/liteuart.c b/drivers/tty/serial/liteuart.c
 index d881cdd..a25ab1e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/liteuart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/liteuart.c
+--- a/drivers/tty/serial/liteuart.c
++++ b/drivers/tty/serial/liteuart.c
 @@ -139,13 +139,13 @@ static irqreturn_t liteuart_interrupt(int irq, void *data)
  	 * if polling, the context would be "in_serving_softirq", so use
  	 * irq[save|restore] spin_lock variants to cover all possibilities
@@ -4224,10 +4224,10 @@ index d881cdd..a25ab1e 100644
  }
  
  static int liteuart_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/lpc32xx_hs.c b/rc6-cachy-rt/drivers/tty/serial/lpc32xx_hs.c
+diff --git a/drivers/tty/serial/lpc32xx_hs.c b/drivers/tty/serial/lpc32xx_hs.c
 index b38fe47..5149a94 100644
---- a/linux-6.6-rc6/drivers/tty/serial/lpc32xx_hs.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/lpc32xx_hs.c
+--- a/drivers/tty/serial/lpc32xx_hs.c
++++ b/drivers/tty/serial/lpc32xx_hs.c
 @@ -140,15 +140,15 @@ static void lpc32xx_hsuart_console_write(struct console *co, const char *s,
  	if (up->port.sysrq)
  		locked = 0;
@@ -4336,10 +4336,10 @@ index b38fe47..5149a94 100644
  
  	/* Don't rewrite B0 */
  	if (tty_termios_baud_rate(termios))
-diff --git a/linux-6.6-rc6/drivers/tty/serial/ma35d1_serial.c b/rc6-cachy-rt/drivers/tty/serial/ma35d1_serial.c
+diff --git a/drivers/tty/serial/ma35d1_serial.c b/drivers/tty/serial/ma35d1_serial.c
 index 465b1de..6fac924 100644
---- a/linux-6.6-rc6/drivers/tty/serial/ma35d1_serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/ma35d1_serial.c
+--- a/drivers/tty/serial/ma35d1_serial.c
++++ b/drivers/tty/serial/ma35d1_serial.c
 @@ -269,16 +269,16 @@ static void receive_chars(struct uart_ma35d1_port *up)
  		if (uart_handle_sysrq_char(&up->port, ch))
  			continue;
@@ -4417,10 +4417,10 @@ index 465b1de..6fac924 100644
  }
  
  static int __init ma35d1serial_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/mcf.c b/rc6-cachy-rt/drivers/tty/serial/mcf.c
+diff --git a/drivers/tty/serial/mcf.c b/drivers/tty/serial/mcf.c
 index 1666ce0..91b1524 100644
---- a/linux-6.6-rc6/drivers/tty/serial/mcf.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/mcf.c
+--- a/drivers/tty/serial/mcf.c
++++ b/drivers/tty/serial/mcf.c
 @@ -135,12 +135,12 @@ static void mcf_break_ctl(struct uart_port *port, int break_state)
  {
  	unsigned long flags;
@@ -4508,10 +4508,10 @@ index 1666ce0..91b1524 100644
  
  	return ret;
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/men_z135_uart.c b/rc6-cachy-rt/drivers/tty/serial/men_z135_uart.c
+diff --git a/drivers/tty/serial/men_z135_uart.c b/drivers/tty/serial/men_z135_uart.c
 index d2502aa..8048fa5 100644
---- a/linux-6.6-rc6/drivers/tty/serial/men_z135_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/men_z135_uart.c
+--- a/drivers/tty/serial/men_z135_uart.c
++++ b/drivers/tty/serial/men_z135_uart.c
 @@ -392,7 +392,7 @@ static irqreturn_t men_z135_intr(int irq, void *data)
  	if (!irq_id)
  		goto out;
@@ -4548,10 +4548,10 @@ index d2502aa..8048fa5 100644
  }
  
  static const char *men_z135_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/meson_uart.c b/rc6-cachy-rt/drivers/tty/serial/meson_uart.c
+diff --git a/drivers/tty/serial/meson_uart.c b/drivers/tty/serial/meson_uart.c
 index 790d910..45cc23e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/meson_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/meson_uart.c
+--- a/drivers/tty/serial/meson_uart.c
++++ b/drivers/tty/serial/meson_uart.c
 @@ -129,14 +129,14 @@ static void meson_uart_shutdown(struct uart_port *port)
  
  	free_irq(port->irq, port);
@@ -4679,10 +4679,10 @@ index 790d910..45cc23e 100644
  	local_irq_restore(flags);
  }
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/milbeaut_usio.c b/rc6-cachy-rt/drivers/tty/serial/milbeaut_usio.c
+diff --git a/drivers/tty/serial/milbeaut_usio.c b/drivers/tty/serial/milbeaut_usio.c
 index 70a9100..db3b81f 100644
---- a/linux-6.6-rc6/drivers/tty/serial/milbeaut_usio.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/milbeaut_usio.c
+--- a/drivers/tty/serial/milbeaut_usio.c
++++ b/drivers/tty/serial/milbeaut_usio.c
 @@ -207,9 +207,9 @@ static irqreturn_t mlb_usio_rx_irq(int irq, void *dev_id)
  {
  	struct uart_port *port = dev_id;
@@ -4744,10 +4744,10 @@ index 70a9100..db3b81f 100644
  }
  
  static const char *mlb_usio_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/mpc52xx_uart.c b/rc6-cachy-rt/drivers/tty/serial/mpc52xx_uart.c
+diff --git a/drivers/tty/serial/mpc52xx_uart.c b/drivers/tty/serial/mpc52xx_uart.c
 index 916507b..a252465 100644
---- a/linux-6.6-rc6/drivers/tty/serial/mpc52xx_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/mpc52xx_uart.c
+--- a/drivers/tty/serial/mpc52xx_uart.c
++++ b/drivers/tty/serial/mpc52xx_uart.c
 @@ -1096,14 +1096,14 @@ static void
  mpc52xx_uart_break_ctl(struct uart_port *port, int ctl)
  {
@@ -4797,10 +4797,10 @@ index 916507b..a252465 100644
  
  	return ret;
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/mps2-uart.c b/rc6-cachy-rt/drivers/tty/serial/mps2-uart.c
+diff --git a/drivers/tty/serial/mps2-uart.c b/drivers/tty/serial/mps2-uart.c
 index ea5a791..2a4c09f 100644
---- a/linux-6.6-rc6/drivers/tty/serial/mps2-uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/mps2-uart.c
+--- a/drivers/tty/serial/mps2-uart.c
++++ b/drivers/tty/serial/mps2-uart.c
 @@ -188,12 +188,12 @@ static irqreturn_t mps2_uart_rxirq(int irq, void *data)
  	if (unlikely(!(irqflag & UARTn_INT_RX)))
  		return IRQ_NONE;
@@ -4864,10 +4864,10 @@ index ea5a791..2a4c09f 100644
  
  	if (tty_termios_baud_rate(termios))
  		tty_termios_encode_baud_rate(termios, baud, baud);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/msm_serial.c b/rc6-cachy-rt/drivers/tty/serial/msm_serial.c
+diff --git a/drivers/tty/serial/msm_serial.c b/drivers/tty/serial/msm_serial.c
 index 90953e6..597264b 100644
---- a/linux-6.6-rc6/drivers/tty/serial/msm_serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/msm_serial.c
+--- a/drivers/tty/serial/msm_serial.c
++++ b/drivers/tty/serial/msm_serial.c
 @@ -444,7 +444,7 @@ static void msm_complete_tx_dma(void *args)
  	unsigned int count;
  	u32 val;
@@ -5012,10 +5012,10 @@ index 90953e6..597264b 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/mvebu-uart.c b/rc6-cachy-rt/drivers/tty/serial/mvebu-uart.c
+diff --git a/drivers/tty/serial/mvebu-uart.c b/drivers/tty/serial/mvebu-uart.c
 index ea924e9..0255646 100644
---- a/linux-6.6-rc6/drivers/tty/serial/mvebu-uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/mvebu-uart.c
+--- a/drivers/tty/serial/mvebu-uart.c
++++ b/drivers/tty/serial/mvebu-uart.c
 @@ -187,9 +187,9 @@ static unsigned int mvebu_uart_tx_empty(struct uart_port *port)
  	unsigned long flags;
  	unsigned int st;
@@ -5084,10 +5084,10 @@ index ea924e9..0255646 100644
  }
  
  static int mvebu_uart_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/omap-serial.c b/rc6-cachy-rt/drivers/tty/serial/omap-serial.c
+diff --git a/drivers/tty/serial/omap-serial.c b/drivers/tty/serial/omap-serial.c
 index 0ead88c..90369ad 100644
---- a/linux-6.6-rc6/drivers/tty/serial/omap-serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/omap-serial.c
+--- a/drivers/tty/serial/omap-serial.c
++++ b/drivers/tty/serial/omap-serial.c
 @@ -390,10 +390,10 @@ static void serial_omap_throttle(struct uart_port *port)
  	struct uart_omap_port *up = to_uart_omap_port(port);
  	unsigned long flags;
@@ -5234,10 +5234,10 @@ index 0ead88c..90369ad 100644
  }
  
  static int __init
-diff --git a/linux-6.6-rc6/drivers/tty/serial/owl-uart.c b/rc6-cachy-rt/drivers/tty/serial/owl-uart.c
+diff --git a/drivers/tty/serial/owl-uart.c b/drivers/tty/serial/owl-uart.c
 index e99970a..919f5e5 100644
---- a/linux-6.6-rc6/drivers/tty/serial/owl-uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/owl-uart.c
+--- a/drivers/tty/serial/owl-uart.c
++++ b/drivers/tty/serial/owl-uart.c
 @@ -125,12 +125,12 @@ static unsigned int owl_uart_tx_empty(struct uart_port *port)
  	u32 val;
  	unsigned int ret;
@@ -5345,10 +5345,10 @@ index e99970a..919f5e5 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/pch_uart.c b/rc6-cachy-rt/drivers/tty/serial/pch_uart.c
+diff --git a/drivers/tty/serial/pch_uart.c b/drivers/tty/serial/pch_uart.c
 index cc83b77..436cc6d 100644
---- a/linux-6.6-rc6/drivers/tty/serial/pch_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/pch_uart.c
+--- a/drivers/tty/serial/pch_uart.c
++++ b/drivers/tty/serial/pch_uart.c
 @@ -1347,7 +1347,7 @@ static void pch_uart_set_termios(struct uart_port *port,
  	baud = uart_get_baud_rate(port, termios, old, 0, port->uartclk / 16);
  
@@ -5389,10 +5389,10 @@ index cc83b77..436cc6d 100644
  	if (priv_locked)
  		spin_unlock(&priv->lock);
  	local_irq_restore(flags);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/pic32_uart.c b/rc6-cachy-rt/drivers/tty/serial/pic32_uart.c
+diff --git a/drivers/tty/serial/pic32_uart.c b/drivers/tty/serial/pic32_uart.c
 index e308d50..3a95bf5 100644
---- a/linux-6.6-rc6/drivers/tty/serial/pic32_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/pic32_uart.c
+--- a/drivers/tty/serial/pic32_uart.c
++++ b/drivers/tty/serial/pic32_uart.c
 @@ -243,7 +243,7 @@ static void pic32_uart_break_ctl(struct uart_port *port, int ctl)
  	struct pic32_sport *sport = to_pic32_sport(port);
  	unsigned long flags;
@@ -5471,10 +5471,10 @@ index e308d50..3a95bf5 100644
  }
  
  /* serial core request to claim uart iomem */
-diff --git a/linux-6.6-rc6/drivers/tty/serial/pmac_zilog.c b/rc6-cachy-rt/drivers/tty/serial/pmac_zilog.c
+diff --git a/drivers/tty/serial/pmac_zilog.c b/drivers/tty/serial/pmac_zilog.c
 index 13668ff..c8bf08c 100644
---- a/linux-6.6-rc6/drivers/tty/serial/pmac_zilog.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/pmac_zilog.c
+--- a/drivers/tty/serial/pmac_zilog.c
++++ b/drivers/tty/serial/pmac_zilog.c
 @@ -246,9 +246,9 @@ static bool pmz_receive_chars(struct uart_pmac_port *uap)
  #endif /* USE_CTRL_O_SYSRQ */
  		if (uap->port.sysrq) {
@@ -5667,10 +5667,10 @@ index 13668ff..c8bf08c 100644
  }
  
  /*
-diff --git a/linux-6.6-rc6/drivers/tty/serial/pxa.c b/rc6-cachy-rt/drivers/tty/serial/pxa.c
+diff --git a/drivers/tty/serial/pxa.c b/drivers/tty/serial/pxa.c
 index 73c60f5..46e70e1 100644
---- a/linux-6.6-rc6/drivers/tty/serial/pxa.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/pxa.c
+--- a/drivers/tty/serial/pxa.c
++++ b/drivers/tty/serial/pxa.c
 @@ -225,14 +225,14 @@ static inline irqreturn_t serial_pxa_irq(int irq, void *dev_id)
  	iir = serial_in(up, UART_IIR);
  	if (iir & UART_IIR_NO_INT)
@@ -5781,10 +5781,10 @@ index 73c60f5..46e70e1 100644
  	local_irq_restore(flags);
  	clk_disable(up->clk);
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/qcom_geni_serial.c b/rc6-cachy-rt/drivers/tty/serial/qcom_geni_serial.c
+diff --git a/drivers/tty/serial/qcom_geni_serial.c b/drivers/tty/serial/qcom_geni_serial.c
 index b8aa4c1..7e78f97 100644
---- a/linux-6.6-rc6/drivers/tty/serial/qcom_geni_serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/qcom_geni_serial.c
+--- a/drivers/tty/serial/qcom_geni_serial.c
++++ b/drivers/tty/serial/qcom_geni_serial.c
 @@ -482,9 +482,9 @@ static void qcom_geni_serial_console_write(struct console *co, const char *s,
  
  	uport = &port->uport;
@@ -5815,10 +5815,10 @@ index b8aa4c1..7e78f97 100644
  
  	m_irq_status = readl(uport->membase + SE_GENI_M_IRQ_STATUS);
  	s_irq_status = readl(uport->membase + SE_GENI_S_IRQ_STATUS);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/rda-uart.c b/rc6-cachy-rt/drivers/tty/serial/rda-uart.c
+diff --git a/drivers/tty/serial/rda-uart.c b/drivers/tty/serial/rda-uart.c
 index be5c842..d824c83 100644
---- a/linux-6.6-rc6/drivers/tty/serial/rda-uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/rda-uart.c
+--- a/drivers/tty/serial/rda-uart.c
++++ b/drivers/tty/serial/rda-uart.c
 @@ -139,12 +139,12 @@ static unsigned int rda_uart_tx_empty(struct uart_port *port)
  	unsigned int ret;
  	u32 val;
@@ -5956,10 +5956,10 @@ index be5c842..d824c83 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/rp2.c b/rc6-cachy-rt/drivers/tty/serial/rp2.c
+diff --git a/drivers/tty/serial/rp2.c b/drivers/tty/serial/rp2.c
 index de220ac..d46a81c 100644
---- a/linux-6.6-rc6/drivers/tty/serial/rp2.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/rp2.c
+--- a/drivers/tty/serial/rp2.c
++++ b/drivers/tty/serial/rp2.c
 @@ -276,9 +276,9 @@ static unsigned int rp2_uart_tx_empty(struct uart_port *port)
  	 * But the TXEMPTY bit doesn't seem to work unless the TX IRQ is
  	 * enabled.
@@ -6034,10 +6034,10 @@ index de220ac..d46a81c 100644
  }
  
  static const char *rp2_uart_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sa1100.c b/rc6-cachy-rt/drivers/tty/serial/sa1100.c
+diff --git a/drivers/tty/serial/sa1100.c b/drivers/tty/serial/sa1100.c
 index ad011f1..be7bcd7 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sa1100.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sa1100.c
+--- a/drivers/tty/serial/sa1100.c
++++ b/drivers/tty/serial/sa1100.c
 @@ -115,9 +115,9 @@ static void sa1100_timeout(struct timer_list *t)
  	unsigned long flags;
  
@@ -6115,10 +6115,10 @@ index ad011f1..be7bcd7 100644
  }
  
  static const char *sa1100_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/samsung_tty.c b/rc6-cachy-rt/drivers/tty/serial/samsung_tty.c
+diff --git a/drivers/tty/serial/samsung_tty.c b/drivers/tty/serial/samsung_tty.c
 index 07fb8a9..ee51a03 100644
---- a/linux-6.6-rc6/drivers/tty/serial/samsung_tty.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/samsung_tty.c
+--- a/drivers/tty/serial/samsung_tty.c
++++ b/drivers/tty/serial/samsung_tty.c
 @@ -248,7 +248,7 @@ static void s3c24xx_serial_rx_enable(struct uart_port *port)
  	unsigned int ucon, ufcon;
  	int count = 10000;
@@ -6324,10 +6324,10 @@ index 07fb8a9..ee51a03 100644
  }
  
  /* Shouldn't be __init, as it can be instantiated from other module */
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sb1250-duart.c b/rc6-cachy-rt/drivers/tty/serial/sb1250-duart.c
+diff --git a/drivers/tty/serial/sb1250-duart.c b/drivers/tty/serial/sb1250-duart.c
 index f3cd693..dbec29d 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sb1250-duart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sb1250-duart.c
+--- a/drivers/tty/serial/sb1250-duart.c
++++ b/drivers/tty/serial/sb1250-duart.c
 @@ -610,7 +610,7 @@ static void sbd_set_termios(struct uart_port *uport, struct ktermios *termios,
  	else
  		aux &= ~M_DUART_CTS_CHNG_ENA;
@@ -6373,10 +6373,10 @@ index f3cd693..dbec29d 100644
  }
  
  static int __init sbd_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sc16is7xx.c b/rc6-cachy-rt/drivers/tty/serial/sc16is7xx.c
+diff --git a/drivers/tty/serial/sc16is7xx.c b/drivers/tty/serial/sc16is7xx.c
 index f61d98e..9d8307f 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sc16is7xx.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sc16is7xx.c
+--- a/drivers/tty/serial/sc16is7xx.c
++++ b/drivers/tty/serial/sc16is7xx.c
 @@ -667,9 +667,9 @@ static void sc16is7xx_handle_tx(struct uart_port *port)
  	}
  
@@ -6518,10 +6518,10 @@ index f61d98e..9d8307f 100644
  
  	return 0;
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/serial-tegra.c b/rc6-cachy-rt/drivers/tty/serial/serial-tegra.c
+diff --git a/drivers/tty/serial/serial-tegra.c b/drivers/tty/serial/serial-tegra.c
 index d4ec943..6d4006b 100644
---- a/linux-6.6-rc6/drivers/tty/serial/serial-tegra.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/serial-tegra.c
+--- a/drivers/tty/serial/serial-tegra.c
++++ b/drivers/tty/serial/serial-tegra.c
 @@ -411,7 +411,7 @@ static int tegra_set_baudrate(struct tegra_uart_port *tup, unsigned int baud)
  		divisor = DIV_ROUND_CLOSEST(rate, baud * 16);
  	}
@@ -6658,10 +6658,10 @@ index d4ec943..6d4006b 100644
  }
  
  static const char *tegra_uart_type(struct uart_port *u)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_core.c b/rc6-cachy-rt/drivers/tty/serial/serial_core.c
+diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
 index d5ba6e9..557796e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/serial_core.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/serial_core.c
+--- a/drivers/tty/serial/serial_core.c
++++ b/drivers/tty/serial/serial_core.c
 @@ -79,7 +79,7 @@ static inline void uart_port_deref(struct uart_port *uport)
  	({								\
  		struct uart_port *__uport = uart_port_ref(state);	\
@@ -6971,10 +6971,10 @@ index d5ba6e9..557796e 100644
  
  		uart_rs485_config(port);
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_mctrl_gpio.c b/rc6-cachy-rt/drivers/tty/serial/serial_mctrl_gpio.c
+diff --git a/drivers/tty/serial/serial_mctrl_gpio.c b/drivers/tty/serial/serial_mctrl_gpio.c
 index 7d5aaa8..e51ca59 100644
---- a/linux-6.6-rc6/drivers/tty/serial/serial_mctrl_gpio.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/serial_mctrl_gpio.c
+--- a/drivers/tty/serial/serial_mctrl_gpio.c
++++ b/drivers/tty/serial/serial_mctrl_gpio.c
 @@ -184,7 +184,7 @@ static irqreturn_t mctrl_gpio_irq_handle(int irq, void *context)
  
  	mctrl_gpio_get(gpios, &mctrl);
@@ -6993,10 +6993,10 @@ index 7d5aaa8..e51ca59 100644
  
  	return IRQ_HANDLED;
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_port.c b/rc6-cachy-rt/drivers/tty/serial/serial_port.c
+diff --git a/drivers/tty/serial/serial_port.c b/drivers/tty/serial/serial_port.c
 index 8624232..88975a4 100644
---- a/linux-6.6-rc6/drivers/tty/serial/serial_port.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/serial_port.c
+--- a/drivers/tty/serial/serial_port.c
++++ b/drivers/tty/serial/serial_port.c
 @@ -35,10 +35,10 @@ static int serial_port_runtime_resume(struct device *dev)
  		goto out;
  
@@ -7010,10 +7010,10 @@ index 8624232..88975a4 100644
  
  out:
  	pm_runtime_mark_last_busy(dev);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/serial_txx9.c b/rc6-cachy-rt/drivers/tty/serial/serial_txx9.c
+diff --git a/drivers/tty/serial/serial_txx9.c b/drivers/tty/serial/serial_txx9.c
 index be08fb6..eaa9807 100644
---- a/linux-6.6-rc6/drivers/tty/serial/serial_txx9.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/serial_txx9.c
+--- a/drivers/tty/serial/serial_txx9.c
++++ b/drivers/tty/serial/serial_txx9.c
 @@ -335,13 +335,13 @@ static irqreturn_t serial_txx9_interrupt(int irq, void *dev_id)
  	unsigned int status;
  
@@ -7108,10 +7108,10 @@ index be08fb6..eaa9807 100644
  }
  
  static void
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sh-sci.c b/rc6-cachy-rt/drivers/tty/serial/sh-sci.c
+diff --git a/drivers/tty/serial/sh-sci.c b/drivers/tty/serial/sh-sci.c
 index a560b72..84ab434 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sh-sci.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sh-sci.c
+--- a/drivers/tty/serial/sh-sci.c
++++ b/drivers/tty/serial/sh-sci.c
 @@ -1205,7 +1205,7 @@ static void sci_dma_tx_complete(void *arg)
  
  	dev_dbg(port->dev, "%s(%d)\n", __func__, port->line);
@@ -7374,10 +7374,10 @@ index a560b72..84ab434 100644
  }
  
  static int serial_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sifive.c b/rc6-cachy-rt/drivers/tty/serial/sifive.c
+diff --git a/drivers/tty/serial/sifive.c b/drivers/tty/serial/sifive.c
 index d195c5d..b296e57 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sifive.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sifive.c
+--- a/drivers/tty/serial/sifive.c
++++ b/drivers/tty/serial/sifive.c
 @@ -521,11 +521,11 @@ static irqreturn_t sifive_serial_irq(int irq, void *dev_id)
  	struct sifive_serial_port *ssp = dev_id;
  	u32 ip;
@@ -7440,10 +7440,10 @@ index d195c5d..b296e57 100644
  	local_irq_restore(flags);
  }
  
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sprd_serial.c b/rc6-cachy-rt/drivers/tty/serial/sprd_serial.c
+diff --git a/drivers/tty/serial/sprd_serial.c b/drivers/tty/serial/sprd_serial.c
 index f328fa5..f257525 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sprd_serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sprd_serial.c
+--- a/drivers/tty/serial/sprd_serial.c
++++ b/drivers/tty/serial/sprd_serial.c
 @@ -247,7 +247,7 @@ static void sprd_complete_tx_dma(void *data)
  	struct circ_buf *xmit = &port->state->xmit;
  	unsigned long flags;
@@ -7566,10 +7566,10 @@ index f328fa5..f257525 100644
  }
  
  static int sprd_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/st-asc.c b/rc6-cachy-rt/drivers/tty/serial/st-asc.c
+diff --git a/drivers/tty/serial/st-asc.c b/drivers/tty/serial/st-asc.c
 index 92b9f68..a821f5d 100644
---- a/linux-6.6-rc6/drivers/tty/serial/st-asc.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/st-asc.c
+--- a/drivers/tty/serial/st-asc.c
++++ b/drivers/tty/serial/st-asc.c
 @@ -319,7 +319,7 @@ static irqreturn_t asc_interrupt(int irq, void *ptr)
  	struct uart_port *port = ptr;
  	u32 status;
@@ -7640,10 +7640,10 @@ index 92b9f68..a821f5d 100644
  }
  
  static int asc_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/stm32-usart.c b/rc6-cachy-rt/drivers/tty/serial/stm32-usart.c
+diff --git a/drivers/tty/serial/stm32-usart.c b/drivers/tty/serial/stm32-usart.c
 index 5e9cf0c..8c51ec9 100644
---- a/linux-6.6-rc6/drivers/tty/serial/stm32-usart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/stm32-usart.c
+--- a/drivers/tty/serial/stm32-usart.c
++++ b/drivers/tty/serial/stm32-usart.c
 @@ -537,7 +537,7 @@ static void stm32_usart_rx_dma_complete(void *arg)
  	unsigned int size;
  	unsigned long flags;
@@ -7788,10 +7788,10 @@ index 5e9cf0c..8c51ec9 100644
  			/* Poll data from DMA RX buffer if any */
  			if (!stm32_usart_rx_dma_pause(stm32_port))
  				size += stm32_usart_receive_chars(port, true);
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sunhv.c b/rc6-cachy-rt/drivers/tty/serial/sunhv.c
+diff --git a/drivers/tty/serial/sunhv.c b/drivers/tty/serial/sunhv.c
 index c671d67..5bfc004 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sunhv.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sunhv.c
+--- a/drivers/tty/serial/sunhv.c
++++ b/drivers/tty/serial/sunhv.c
 @@ -217,10 +217,10 @@ static irqreturn_t sunhv_interrupt(int irq, void *dev_id)
  	struct tty_port *tport;
  	unsigned long flags;
@@ -7901,10 +7901,10 @@ index c671d67..5bfc004 100644
  }
  
  static struct console sunhv_console = {
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sunplus-uart.c b/rc6-cachy-rt/drivers/tty/serial/sunplus-uart.c
+diff --git a/drivers/tty/serial/sunplus-uart.c b/drivers/tty/serial/sunplus-uart.c
 index 3aacd5e..4251f4e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sunplus-uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sunplus-uart.c
+--- a/drivers/tty/serial/sunplus-uart.c
++++ b/drivers/tty/serial/sunplus-uart.c
 @@ -184,7 +184,7 @@ static void sunplus_break_ctl(struct uart_port *port, int ctl)
  	unsigned long flags;
  	unsigned int lcr;
@@ -8011,10 +8011,10 @@ index 3aacd5e..4251f4e 100644
  
  	local_irq_restore(flags);
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sunsab.c b/rc6-cachy-rt/drivers/tty/serial/sunsab.c
+diff --git a/drivers/tty/serial/sunsab.c b/drivers/tty/serial/sunsab.c
 index 40eeaf8..6aa51a6 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sunsab.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sunsab.c
+--- a/drivers/tty/serial/sunsab.c
++++ b/drivers/tty/serial/sunsab.c
 @@ -310,7 +310,7 @@ static irqreturn_t sunsab_interrupt(int irq, void *dev_id)
  	unsigned long flags;
  	unsigned char gis;
@@ -8151,10 +8151,10 @@ index 40eeaf8..6aa51a6 100644
  	
  	return 0;
  }
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sunsu.c b/rc6-cachy-rt/drivers/tty/serial/sunsu.c
+diff --git a/drivers/tty/serial/sunsu.c b/drivers/tty/serial/sunsu.c
 index 58a4342..1e051cc 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sunsu.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sunsu.c
+--- a/drivers/tty/serial/sunsu.c
++++ b/drivers/tty/serial/sunsu.c
 @@ -212,9 +212,9 @@ static void enable_rsa(struct uart_sunsu_port *up)
  {
  	if (up->port.type == PORT_RSA) {
@@ -8334,10 +8334,10 @@ index 58a4342..1e051cc 100644
  }
  
  /*
-diff --git a/linux-6.6-rc6/drivers/tty/serial/sunzilog.c b/rc6-cachy-rt/drivers/tty/serial/sunzilog.c
+diff --git a/drivers/tty/serial/sunzilog.c b/drivers/tty/serial/sunzilog.c
 index c8c71c5..d3b5e86 100644
---- a/linux-6.6-rc6/drivers/tty/serial/sunzilog.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/sunzilog.c
+--- a/drivers/tty/serial/sunzilog.c
++++ b/drivers/tty/serial/sunzilog.c
 @@ -531,7 +531,7 @@ static irqreturn_t sunzilog_interrupt(int irq, void *dev_id)
  		struct tty_port *port;
  		unsigned char r3;
@@ -8509,10 +8509,10 @@ index c8c71c5..d3b5e86 100644
  
  #ifdef CONFIG_SERIO
  	if (up->flags & (SUNZILOG_FLAG_CONS_KEYB |
-diff --git a/linux-6.6-rc6/drivers/tty/serial/timbuart.c b/rc6-cachy-rt/drivers/tty/serial/timbuart.c
+diff --git a/drivers/tty/serial/timbuart.c b/drivers/tty/serial/timbuart.c
 index 0859394..0cc6524 100644
---- a/linux-6.6-rc6/drivers/tty/serial/timbuart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/timbuart.c
+--- a/drivers/tty/serial/timbuart.c
++++ b/drivers/tty/serial/timbuart.c
 @@ -174,7 +174,7 @@ static void timbuart_tasklet(struct tasklet_struct *t)
  	struct timbuart_port *uart = from_tasklet(uart, t, tasklet);
  	u32 isr, ier = 0;
@@ -8544,10 +8544,10 @@ index 0859394..0cc6524 100644
  }
  
  static const char *timbuart_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/uartlite.c b/rc6-cachy-rt/drivers/tty/serial/uartlite.c
+diff --git a/drivers/tty/serial/uartlite.c b/drivers/tty/serial/uartlite.c
 index b225a78..404c14a 100644
---- a/linux-6.6-rc6/drivers/tty/serial/uartlite.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/uartlite.c
+--- a/drivers/tty/serial/uartlite.c
++++ b/drivers/tty/serial/uartlite.c
 @@ -216,11 +216,11 @@ static irqreturn_t ulite_isr(int irq, void *dev_id)
  	unsigned long flags;
  
@@ -8613,10 +8613,10 @@ index b225a78..404c14a 100644
  }
  
  static int ulite_console_setup(struct console *co, char *options)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/ucc_uart.c b/rc6-cachy-rt/drivers/tty/serial/ucc_uart.c
+diff --git a/drivers/tty/serial/ucc_uart.c b/drivers/tty/serial/ucc_uart.c
 index b06661b..ed7a6bb 100644
---- a/linux-6.6-rc6/drivers/tty/serial/ucc_uart.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/ucc_uart.c
+--- a/drivers/tty/serial/ucc_uart.c
++++ b/drivers/tty/serial/ucc_uart.c
 @@ -931,7 +931,7 @@ static void qe_uart_set_termios(struct uart_port *port,
  	baud = uart_get_baud_rate(port, termios, old, 0, port->uartclk / 16);
  
@@ -8635,10 +8635,10 @@ index b06661b..ed7a6bb 100644
  }
  
  /*
-diff --git a/linux-6.6-rc6/drivers/tty/serial/vt8500_serial.c b/rc6-cachy-rt/drivers/tty/serial/vt8500_serial.c
+diff --git a/drivers/tty/serial/vt8500_serial.c b/drivers/tty/serial/vt8500_serial.c
 index c5d5c27..78a1c1e 100644
---- a/linux-6.6-rc6/drivers/tty/serial/vt8500_serial.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/vt8500_serial.c
+--- a/drivers/tty/serial/vt8500_serial.c
++++ b/drivers/tty/serial/vt8500_serial.c
 @@ -227,7 +227,7 @@ static irqreturn_t vt8500_irq(int irq, void *dev_id)
  	struct uart_port *port = dev_id;
  	unsigned long isr;
@@ -8675,10 +8675,10 @@ index c5d5c27..78a1c1e 100644
  }
  
  static const char *vt8500_type(struct uart_port *port)
-diff --git a/linux-6.6-rc6/drivers/tty/serial/xilinx_uartps.c b/rc6-cachy-rt/drivers/tty/serial/xilinx_uartps.c
+diff --git a/drivers/tty/serial/xilinx_uartps.c b/drivers/tty/serial/xilinx_uartps.c
 index 2e5e86a..9c13dac 100644
---- a/linux-6.6-rc6/drivers/tty/serial/xilinx_uartps.c
-+++ b/rc6-cachy-rt/drivers/tty/serial/xilinx_uartps.c
+--- a/drivers/tty/serial/xilinx_uartps.c
++++ b/drivers/tty/serial/xilinx_uartps.c
 @@ -346,7 +346,7 @@ static irqreturn_t cdns_uart_isr(int irq, void *dev_id)
  	struct uart_port *port = (struct uart_port *)dev_id;
  	unsigned int isrstatus;
@@ -8915,10 +8915,10 @@ index 2e5e86a..9c13dac 100644
  	}
  
  	return uart_resume_port(cdns_uart->cdns_uart_driver, port);
-diff --git a/linux-6.6-rc6/drivers/tty/tty_io.c b/rc6-cachy-rt/drivers/tty/tty_io.c
+diff --git a/drivers/tty/tty_io.c b/drivers/tty/tty_io.c
 index 8a94e5a..3831596 100644
---- a/linux-6.6-rc6/drivers/tty/tty_io.c
-+++ b/rc6-cachy-rt/drivers/tty/tty_io.c
+--- a/drivers/tty/tty_io.c
++++ b/drivers/tty/tty_io.c
 @@ -3540,8 +3540,15 @@ static ssize_t show_cons_active(struct device *dev,
  	for_each_console(c) {
  		if (!c->device)
@@ -8937,10 +8937,10 @@ index 8a94e5a..3831596 100644
  		if ((c->flags & CON_ENABLED) == 0)
  			continue;
  		cs[i++] = c;
-diff --git a/linux-6.6-rc6/fs/proc/consoles.c b/rc6-cachy-rt/fs/proc/consoles.c
+diff --git a/fs/proc/consoles.c b/fs/proc/consoles.c
 index e0758fe..2703676 100644
---- a/linux-6.6-rc6/fs/proc/consoles.c
-+++ b/rc6-cachy-rt/fs/proc/consoles.c
+--- a/fs/proc/consoles.c
++++ b/fs/proc/consoles.c
 @@ -21,12 +21,14 @@ static int show_console_dev(struct seq_file *m, void *v)
  		{ CON_ENABLED,		'E' },
  		{ CON_CONSDEV,		'C' },
@@ -8975,10 +8975,10 @@ index e0758fe..2703676 100644
  	if (dev)
  		seq_printf(m, " %4d:%d", MAJOR(dev), MINOR(dev));
  
-diff --git a/linux-6.6-rc6/include/linux/bottom_half.h b/rc6-cachy-rt/include/linux/bottom_half.h
+diff --git a/include/linux/bottom_half.h b/include/linux/bottom_half.h
 index fc53e0a..448bbef 100644
---- a/linux-6.6-rc6/include/linux/bottom_half.h
-+++ b/rc6-cachy-rt/include/linux/bottom_half.h
+--- a/include/linux/bottom_half.h
++++ b/include/linux/bottom_half.h
 @@ -35,8 +35,10 @@ static inline void local_bh_enable(void)
  
  #ifdef CONFIG_PREEMPT_RT
@@ -8990,10 +8990,10 @@ index fc53e0a..448bbef 100644
  #endif
  
  #endif /* _LINUX_BH_H */
-diff --git a/linux-6.6-rc6/include/linux/console.h b/rc6-cachy-rt/include/linux/console.h
+diff --git a/include/linux/console.h b/include/linux/console.h
 index 7de11c7..6bbb898 100644
---- a/linux-6.6-rc6/include/linux/console.h
-+++ b/rc6-cachy-rt/include/linux/console.h
+--- a/include/linux/console.h
++++ b/include/linux/console.h
 @@ -16,7 +16,9 @@
  
  #include <linux/atomic.h>
@@ -9185,10 +9185,10 @@ index 7de11c7..6bbb898 100644
  extern int console_set_on_cmdline;
  extern struct console *early_console;
  
-diff --git a/linux-6.6-rc6/include/linux/entry-common.h b/rc6-cachy-rt/include/linux/entry-common.h
+diff --git a/include/linux/entry-common.h b/include/linux/entry-common.h
 index d95ab85..3dc3704 100644
---- a/linux-6.6-rc6/include/linux/entry-common.h
-+++ b/rc6-cachy-rt/include/linux/entry-common.h
+--- a/include/linux/entry-common.h
++++ b/include/linux/entry-common.h
 @@ -57,9 +57,15 @@
  # define ARCH_EXIT_TO_USER_MODE_WORK		(0)
  #endif
@@ -9206,10 +9206,10 @@ index d95ab85..3dc3704 100644
  	 ARCH_EXIT_TO_USER_MODE_WORK)
  
  /**
-diff --git a/linux-6.6-rc6/include/linux/interrupt.h b/rc6-cachy-rt/include/linux/interrupt.h
+diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
 index 4a1dc88..a5091ac 100644
---- a/linux-6.6-rc6/include/linux/interrupt.h
-+++ b/rc6-cachy-rt/include/linux/interrupt.h
+--- a/include/linux/interrupt.h
++++ b/include/linux/interrupt.h
 @@ -609,6 +609,35 @@ extern void __raise_softirq_irqoff(unsigned int nr);
  extern void raise_softirq_irqoff(unsigned int nr);
  extern void raise_softirq(unsigned int nr);
@@ -9246,10 +9246,10 @@ index 4a1dc88..a5091ac 100644
  DECLARE_PER_CPU(struct task_struct *, ksoftirqd);
  
  static inline struct task_struct *this_cpu_ksoftirqd(void)
-diff --git a/linux-6.6-rc6/include/linux/netdevice.h b/rc6-cachy-rt/include/linux/netdevice.h
+diff --git a/include/linux/netdevice.h b/include/linux/netdevice.h
 index 0896aaa..a7a3ba1 100644
---- a/linux-6.6-rc6/include/linux/netdevice.h
-+++ b/rc6-cachy-rt/include/linux/netdevice.h
+--- a/include/linux/netdevice.h
++++ b/include/linux/netdevice.h
 @@ -3236,7 +3236,11 @@ struct softnet_data {
  	int			defer_count;
  	int			defer_ipi_scheduled;
@@ -9262,10 +9262,10 @@ index 0896aaa..a7a3ba1 100644
  };
  
  static inline void input_queue_head_incr(struct softnet_data *sd)
-diff --git a/linux-6.6-rc6/include/linux/preempt.h b/rc6-cachy-rt/include/linux/preempt.h
+diff --git a/include/linux/preempt.h b/include/linux/preempt.h
 index 1424670..3c56b6f 100644
---- a/linux-6.6-rc6/include/linux/preempt.h
-+++ b/rc6-cachy-rt/include/linux/preempt.h
+--- a/include/linux/preempt.h
++++ b/include/linux/preempt.h
 @@ -197,6 +197,20 @@ extern void preempt_count_sub(int val);
  #define preempt_count_inc() preempt_count_add(1)
  #define preempt_count_dec() preempt_count_sub(1)
@@ -9393,10 +9393,10 @@ index 1424670..3c56b6f 100644
  
  #endif /* CONFIG_SMP */
  
-diff --git a/linux-6.6-rc6/include/linux/printk.h b/rc6-cachy-rt/include/linux/printk.h
+diff --git a/include/linux/printk.h b/include/linux/printk.h
 index 8ef499a..d77e13f 100644
---- a/linux-6.6-rc6/include/linux/printk.h
-+++ b/rc6-cachy-rt/include/linux/printk.h
+--- a/include/linux/printk.h
++++ b/include/linux/printk.h
 @@ -9,6 +9,8 @@
  #include <linux/ratelimit_types.h>
  #include <linux/once_lite.h>
@@ -9455,10 +9455,10 @@ index 8ef499a..d77e13f 100644
  #endif
  
  #ifdef CONFIG_SMP
-diff --git a/linux-6.6-rc6/include/linux/rcupdate.h b/rc6-cachy-rt/include/linux/rcupdate.h
+diff --git a/include/linux/rcupdate.h b/include/linux/rcupdate.h
 index 5e5f920..44aab5c 100644
---- a/linux-6.6-rc6/include/linux/rcupdate.h
-+++ b/rc6-cachy-rt/include/linux/rcupdate.h
+--- a/include/linux/rcupdate.h
++++ b/include/linux/rcupdate.h
 @@ -303,6 +303,11 @@ static inline void rcu_lock_acquire(struct lockdep_map *map)
  	lock_acquire(map, 0, 0, 2, 0, NULL, _THIS_IP_);
  }
@@ -9479,10 +9479,10 @@ index 5e5f920..44aab5c 100644
  # define rcu_lock_release(a)		do { } while (0)
  
  static inline int rcu_read_lock_held(void)
-diff --git a/linux-6.6-rc6/include/linux/sched/rt.h b/rc6-cachy-rt/include/linux/sched/rt.h
+diff --git a/include/linux/sched/rt.h b/include/linux/sched/rt.h
 index 994c256..b2b9e6e 100644
---- a/linux-6.6-rc6/include/linux/sched/rt.h
-+++ b/rc6-cachy-rt/include/linux/sched/rt.h
+--- a/include/linux/sched/rt.h
++++ b/include/linux/sched/rt.h
 @@ -30,6 +30,10 @@ static inline bool task_is_realtime(struct task_struct *tsk)
  }
  
@@ -9494,10 +9494,10 @@ index 994c256..b2b9e6e 100644
  /*
   * Must hold either p->pi_lock or task_rq(p)->lock.
   */
-diff --git a/linux-6.6-rc6/include/linux/sched.h b/rc6-cachy-rt/include/linux/sched.h
+diff --git a/include/linux/sched.h b/include/linux/sched.h
 index 77f01ac..4d49243 100644
---- a/linux-6.6-rc6/include/linux/sched.h
-+++ b/rc6-cachy-rt/include/linux/sched.h
+--- a/include/linux/sched.h
++++ b/include/linux/sched.h
 @@ -911,6 +911,9 @@ struct task_struct {
  	 * ->sched_remote_wakeup gets used, so it can be in this word.
  	 */
@@ -9560,10 +9560,10 @@ index 77f01ac..4d49243 100644
  /*
   * cond_resched() and cond_resched_lock(): latency reduction via
   * explicit rescheduling in places that are safe. The return
-diff --git a/linux-6.6-rc6/include/linux/serial_8250.h b/rc6-cachy-rt/include/linux/serial_8250.h
+diff --git a/include/linux/serial_8250.h b/include/linux/serial_8250.h
 index be65de6..dab5e82 100644
---- a/linux-6.6-rc6/include/linux/serial_8250.h
-+++ b/rc6-cachy-rt/include/linux/serial_8250.h
+--- a/include/linux/serial_8250.h
++++ b/include/linux/serial_8250.h
 @@ -204,6 +204,8 @@ void serial8250_init_port(struct uart_8250_port *up);
  void serial8250_set_defaults(struct uart_8250_port *up);
  void serial8250_console_write(struct uart_8250_port *up, const char *s,
@@ -9573,10 +9573,10 @@ index be65de6..dab5e82 100644
  int serial8250_console_setup(struct uart_port *port, char *options, bool probe);
  int serial8250_console_exit(struct uart_port *port);
  
-diff --git a/linux-6.6-rc6/include/linux/serial_core.h b/rc6-cachy-rt/include/linux/serial_core.h
+diff --git a/include/linux/serial_core.h b/include/linux/serial_core.h
 index bb6f073..18ce60b 100644
---- a/linux-6.6-rc6/include/linux/serial_core.h
-+++ b/rc6-cachy-rt/include/linux/serial_core.h
+--- a/include/linux/serial_core.h
++++ b/include/linux/serial_core.h
 @@ -588,6 +588,99 @@ struct uart_port {
  	void			*private_data;		/* generic platform data pointer */
  };
@@ -9726,10 +9726,10 @@ index bb6f073..18ce60b 100644
  }
  #endif	/* CONFIG_MAGIC_SYSRQ_SERIAL */
  
-diff --git a/linux-6.6-rc6/include/linux/srcu.h b/rc6-cachy-rt/include/linux/srcu.h
+diff --git a/include/linux/srcu.h b/include/linux/srcu.h
 index 127ef3b..236610e 100644
---- a/linux-6.6-rc6/include/linux/srcu.h
-+++ b/rc6-cachy-rt/include/linux/srcu.h
+--- a/include/linux/srcu.h
++++ b/include/linux/srcu.h
 @@ -229,7 +229,7 @@ static inline int srcu_read_lock_nmisafe(struct srcu_struct *ssp) __acquires(ssp
  
  	srcu_check_nmi_safety(ssp, true);
@@ -9739,10 +9739,10 @@ index 127ef3b..236610e 100644
  	return retval;
  }
  
-diff --git a/linux-6.6-rc6/include/linux/thread_info.h b/rc6-cachy-rt/include/linux/thread_info.h
+diff --git a/include/linux/thread_info.h b/include/linux/thread_info.h
 index 9ea0b28..00a01d5 100644
---- a/linux-6.6-rc6/include/linux/thread_info.h
-+++ b/rc6-cachy-rt/include/linux/thread_info.h
+--- a/include/linux/thread_info.h
++++ b/include/linux/thread_info.h
 @@ -178,14 +178,65 @@ static __always_inline unsigned long read_ti_thread_flags(struct thread_info *ti
  #endif /* !CONFIG_GENERIC_ENTRY */
  
@@ -9828,10 +9828,10 @@ index 9ea0b28..00a01d5 100644
  #endif /* _ASM_GENERIC_BITOPS_INSTRUMENTED_NON_ATOMIC_H */
  
  #ifndef CONFIG_HAVE_ARCH_WITHIN_STACK_FRAMES
-diff --git a/linux-6.6-rc6/include/linux/trace_events.h b/rc6-cachy-rt/include/linux/trace_events.h
+diff --git a/include/linux/trace_events.h b/include/linux/trace_events.h
 index 21ae37e..206625a 100644
---- a/linux-6.6-rc6/include/linux/trace_events.h
-+++ b/rc6-cachy-rt/include/linux/trace_events.h
+--- a/include/linux/trace_events.h
++++ b/include/linux/trace_events.h
 @@ -81,6 +81,7 @@ struct trace_entry {
  	unsigned char		flags;
  	unsigned char		preempt_count;
@@ -9866,10 +9866,10 @@ index 21ae37e..206625a 100644
  	TRACE_FLAG_NMI			= 0x40,
  	TRACE_FLAG_BH_OFF		= 0x80,
  };
-diff --git a/linux-6.6-rc6/kernel/Kconfig.preempt b/rc6-cachy-rt/kernel/Kconfig.preempt
+diff --git a/kernel/Kconfig.preempt b/kernel/Kconfig.preempt
 index c2f1fd9..b787bb9 100644
---- a/linux-6.6-rc6/kernel/Kconfig.preempt
-+++ b/rc6-cachy-rt/kernel/Kconfig.preempt
+--- a/kernel/Kconfig.preempt
++++ b/kernel/Kconfig.preempt
 @@ -1,5 +1,11 @@
  # SPDX-License-Identifier: GPL-2.0-only
  
@@ -9891,10 +9891,10 @@ index c2f1fd9..b787bb9 100644
  	select PREEMPTION
  	help
  	  This option turns the kernel into a real-time kernel by replacing
-diff --git a/linux-6.6-rc6/kernel/entry/common.c b/rc6-cachy-rt/kernel/entry/common.c
+diff --git a/kernel/entry/common.c b/kernel/entry/common.c
 index d7ee4bc..b9f08f6 100644
---- a/linux-6.6-rc6/kernel/entry/common.c
-+++ b/rc6-cachy-rt/kernel/entry/common.c
+--- a/kernel/entry/common.c
++++ b/kernel/entry/common.c
 @@ -155,7 +155,7 @@ static unsigned long exit_to_user_mode_loop(struct pt_regs *regs,
  
  		local_irq_enable_exit_to_user(ti_work);
@@ -9913,10 +9913,10 @@ index d7ee4bc..b9f08f6 100644
  			preempt_schedule_irq();
  	}
  }
-diff --git a/linux-6.6-rc6/kernel/futex/pi.c b/rc6-cachy-rt/kernel/futex/pi.c
+diff --git a/kernel/futex/pi.c b/kernel/futex/pi.c
 index ce2889f..d636a1b 100644
---- a/linux-6.6-rc6/kernel/futex/pi.c
-+++ b/rc6-cachy-rt/kernel/futex/pi.c
+--- a/kernel/futex/pi.c
++++ b/kernel/futex/pi.c
 @@ -1,6 +1,7 @@
  // SPDX-License-Identifier: GPL-2.0-or-later
  
@@ -10077,10 +10077,10 @@ index ce2889f..d636a1b 100644
  	/*
  	 * We have no kernel internal state, i.e. no waiters in the
  	 * kernel. Waiters which are about to queue themselves are stuck
-diff --git a/linux-6.6-rc6/kernel/futex/requeue.c b/rc6-cachy-rt/kernel/futex/requeue.c
+diff --git a/kernel/futex/requeue.c b/kernel/futex/requeue.c
 index cba8b1a..4c73e0b 100644
---- a/linux-6.6-rc6/kernel/futex/requeue.c
-+++ b/rc6-cachy-rt/kernel/futex/requeue.c
+--- a/kernel/futex/requeue.c
++++ b/kernel/futex/requeue.c
 @@ -850,11 +850,13 @@ int futex_wait_requeue_pi(u32 __user *uaddr, unsigned int flags,
  		pi_mutex = &q.pi_state->pi_mutex;
  		ret = rt_mutex_wait_proxy_lock(pi_mutex, to, &rt_waiter);
@@ -10097,10 +10097,10 @@ index cba8b1a..4c73e0b 100644
  		debug_rt_mutex_free_waiter(&rt_waiter);
  		/*
  		 * Fixup the pi_state owner and possibly acquire the lock if we
-diff --git a/linux-6.6-rc6/kernel/ksysfs.c b/rc6-cachy-rt/kernel/ksysfs.c
+diff --git a/kernel/ksysfs.c b/kernel/ksysfs.c
 index 1d4bc49..486c68c 100644
---- a/linux-6.6-rc6/kernel/ksysfs.c
-+++ b/rc6-cachy-rt/kernel/ksysfs.c
+--- a/kernel/ksysfs.c
++++ b/kernel/ksysfs.c
 @@ -179,6 +179,15 @@ KERNEL_ATTR_RO(crash_elfcorehdr_size);
  
  #endif /* CONFIG_CRASH_CORE */
@@ -10127,10 +10127,10 @@ index 1d4bc49..486c68c 100644
  #endif
  	NULL
  };
-diff --git a/linux-6.6-rc6/kernel/locking/lockdep.c b/rc6-cachy-rt/kernel/locking/lockdep.c
+diff --git a/kernel/locking/lockdep.c b/kernel/locking/lockdep.c
 index e85b5ad..5310a94 100644
---- a/linux-6.6-rc6/kernel/locking/lockdep.c
-+++ b/rc6-cachy-rt/kernel/locking/lockdep.c
+--- a/kernel/locking/lockdep.c
++++ b/kernel/locking/lockdep.c
 @@ -56,6 +56,7 @@
  #include <linux/kprobes.h>
  #include <linux/lockdep.h>
@@ -10162,10 +10162,10 @@ index e85b5ad..5310a94 100644
  }
  
  /*
-diff --git a/linux-6.6-rc6/kernel/locking/rtmutex.c b/rc6-cachy-rt/kernel/locking/rtmutex.c
+diff --git a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
 index 21db0df..4a10e8c 100644
---- a/linux-6.6-rc6/kernel/locking/rtmutex.c
-+++ b/rc6-cachy-rt/kernel/locking/rtmutex.c
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
 @@ -218,6 +218,11 @@ static __always_inline bool rt_mutex_cmpxchg_acquire(struct rt_mutex_base *lock,
  	return try_cmpxchg_acquire(&lock->owner, &old, new);
  }
@@ -10252,10 +10252,10 @@ index 21db0df..4a10e8c 100644
  		return 0;
  
  	return rt_mutex_slowlock(lock, NULL, state);
-diff --git a/linux-6.6-rc6/kernel/locking/rwbase_rt.c b/rc6-cachy-rt/kernel/locking/rwbase_rt.c
+diff --git a/kernel/locking/rwbase_rt.c b/kernel/locking/rwbase_rt.c
 index 25ec023..34a5956 100644
---- a/linux-6.6-rc6/kernel/locking/rwbase_rt.c
-+++ b/rc6-cachy-rt/kernel/locking/rwbase_rt.c
+--- a/kernel/locking/rwbase_rt.c
++++ b/kernel/locking/rwbase_rt.c
 @@ -71,6 +71,7 @@ static int __sched __rwbase_read_lock(struct rwbase_rt *rwb,
  	struct rt_mutex_base *rtm = &rwb->rtmutex;
  	int ret;
@@ -10305,10 +10305,10 @@ index 25ec023..34a5956 100644
  	return 0;
  }
  
-diff --git a/linux-6.6-rc6/kernel/locking/rwsem.c b/rc6-cachy-rt/kernel/locking/rwsem.c
+diff --git a/kernel/locking/rwsem.c b/kernel/locking/rwsem.c
 index 9eabd58..2340b6d 100644
---- a/linux-6.6-rc6/kernel/locking/rwsem.c
-+++ b/rc6-cachy-rt/kernel/locking/rwsem.c
+--- a/kernel/locking/rwsem.c
++++ b/kernel/locking/rwsem.c
 @@ -1427,8 +1427,14 @@ static inline void __downgrade_write(struct rw_semaphore *sem)
  #define rwbase_signal_pending_state(state, current)	\
  	signal_pending_state(state, current)
@@ -10325,10 +10325,10 @@ index 9eabd58..2340b6d 100644
  
  #include "rwbase_rt.c"
  
-diff --git a/linux-6.6-rc6/kernel/locking/spinlock_rt.c b/rc6-cachy-rt/kernel/locking/spinlock_rt.c
+diff --git a/kernel/locking/spinlock_rt.c b/kernel/locking/spinlock_rt.c
 index 48a19ed..38e2924 100644
---- a/linux-6.6-rc6/kernel/locking/spinlock_rt.c
-+++ b/rc6-cachy-rt/kernel/locking/spinlock_rt.c
+--- a/kernel/locking/spinlock_rt.c
++++ b/kernel/locking/spinlock_rt.c
 @@ -37,6 +37,8 @@
  
  static __always_inline void rtlock_lock(struct rt_mutex_base *rtm)
@@ -10352,10 +10352,10 @@ index 48a19ed..38e2924 100644
  #include "rwbase_rt.c"
  /*
   * The common functions which get wrapped into the rwlock API.
-diff --git a/linux-6.6-rc6/kernel/locking/ww_rt_mutex.c b/rc6-cachy-rt/kernel/locking/ww_rt_mutex.c
+diff --git a/kernel/locking/ww_rt_mutex.c b/kernel/locking/ww_rt_mutex.c
 index d1473c6..c7196de 100644
---- a/linux-6.6-rc6/kernel/locking/ww_rt_mutex.c
-+++ b/rc6-cachy-rt/kernel/locking/ww_rt_mutex.c
+--- a/kernel/locking/ww_rt_mutex.c
++++ b/kernel/locking/ww_rt_mutex.c
 @@ -62,7 +62,7 @@ __ww_rt_mutex_lock(struct ww_mutex *lock, struct ww_acquire_ctx *ww_ctx,
  	}
  	mutex_acquire_nest(&rtm->dep_map, 0, 0, nest_lock, ip);
@@ -10365,10 +10365,10 @@ index d1473c6..c7196de 100644
  		if (ww_ctx)
  			ww_mutex_set_context_fastpath(lock, ww_ctx);
  		return 0;
-diff --git a/linux-6.6-rc6/kernel/panic.c b/rc6-cachy-rt/kernel/panic.c
+diff --git a/kernel/panic.c b/kernel/panic.c
 index ffa037f..b4c3640 100644
---- a/linux-6.6-rc6/kernel/panic.c
-+++ b/rc6-cachy-rt/kernel/panic.c
+--- a/kernel/panic.c
++++ b/kernel/panic.c
 @@ -275,6 +275,7 @@ static void panic_other_cpus_shutdown(bool crash_kexec)
   */
  void panic(const char *fmt, ...)
@@ -10532,10 +10532,10 @@ index ffa037f..b4c3640 100644
  }
  
  #ifdef CONFIG_BUG
-diff --git a/linux-6.6-rc6/kernel/printk/Makefile b/rc6-cachy-rt/kernel/printk/Makefile
+diff --git a/kernel/printk/Makefile b/kernel/printk/Makefile
 index f5b388e..39a2b61 100644
---- a/linux-6.6-rc6/kernel/printk/Makefile
-+++ b/rc6-cachy-rt/kernel/printk/Makefile
+--- a/kernel/printk/Makefile
++++ b/kernel/printk/Makefile
 @@ -1,6 +1,6 @@
  # SPDX-License-Identifier: GPL-2.0-only
  obj-y	= printk.o
@@ -10544,10 +10544,10 @@ index f5b388e..39a2b61 100644
  obj-$(CONFIG_A11Y_BRAILLE_CONSOLE)	+= braille.o
  obj-$(CONFIG_PRINTK_INDEX)	+= index.o
  
-diff --git a/linux-6.6-rc6/kernel/printk/internal.h b/rc6-cachy-rt/kernel/printk/internal.h
+diff --git a/kernel/printk/internal.h b/kernel/printk/internal.h
 index 7d4979d..654a9bf 100644
---- a/linux-6.6-rc6/kernel/printk/internal.h
-+++ b/rc6-cachy-rt/kernel/printk/internal.h
+--- a/kernel/printk/internal.h
++++ b/kernel/printk/internal.h
 @@ -3,6 +3,8 @@
   * internal.h - printk internal definitions
   */
@@ -10707,11 +10707,11 @@ index 7d4979d..654a9bf 100644
 +#ifdef CONFIG_PRINTK
 +void console_prepend_dropped(struct printk_message *pmsg, unsigned long dropped);
 +#endif
-diff --git a/rc6-cachy-rt/kernel/printk/nbcon.c b/rc6-cachy-rt/kernel/printk/nbcon.c
+diff --git a/kernel/printk/nbcon.c b/kernel/printk/nbcon.c
 new file mode 100644
 index 0000000..4cd2365
 --- /dev/null
-+++ b/rc6-cachy-rt/kernel/printk/nbcon.c
++++ b/kernel/printk/nbcon.c
 @@ -0,0 +1,1677 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +// Copyright (C) 2022 Linutronix GmbH, John Ogness
@@ -12390,10 +12390,10 @@ index 0000000..4cd2365
 +	return 0;
 +}
 +device_initcall(printk_init_ops);
-diff --git a/linux-6.6-rc6/kernel/printk/printk.c b/rc6-cachy-rt/kernel/printk/printk.c
+diff --git a/kernel/printk/printk.c b/kernel/printk/printk.c
 index 0b3af15..81ecec9 100644
---- a/linux-6.6-rc6/kernel/printk/printk.c
-+++ b/rc6-cachy-rt/kernel/printk/printk.c
+--- a/kernel/printk/printk.c
++++ b/kernel/printk/printk.c
 @@ -102,12 +102,6 @@ DEFINE_STATIC_SRCU(console_srcu);
   */
  int __read_mostly suppress_printk;
@@ -13287,10 +13287,10 @@ index 0b3af15..81ecec9 100644
  	defer_console_output();
  }
  
-diff --git a/linux-6.6-rc6/kernel/printk/printk_safe.c b/rc6-cachy-rt/kernel/printk/printk_safe.c
+diff --git a/kernel/printk/printk_safe.c b/kernel/printk/printk_safe.c
 index 6d10927..8d9408d 100644
---- a/linux-6.6-rc6/kernel/printk/printk_safe.c
-+++ b/rc6-cachy-rt/kernel/printk/printk_safe.c
+--- a/kernel/printk/printk_safe.c
++++ b/kernel/printk/printk_safe.c
 @@ -26,6 +26,18 @@ void __printk_safe_exit(void)
  	this_cpu_dec(printk_context);
  }
@@ -13310,10 +13310,10 @@ index 6d10927..8d9408d 100644
  asmlinkage int vprintk(const char *fmt, va_list args)
  {
  #ifdef CONFIG_KGDB_KDB
-diff --git a/linux-6.6-rc6/kernel/rcu/rcutorture.c b/rc6-cachy-rt/kernel/rcu/rcutorture.c
+diff --git a/kernel/rcu/rcutorture.c b/kernel/rcu/rcutorture.c
 index ade42d6..eebb9b4 100644
---- a/linux-6.6-rc6/kernel/rcu/rcutorture.c
-+++ b/rc6-cachy-rt/kernel/rcu/rcutorture.c
+--- a/kernel/rcu/rcutorture.c
++++ b/kernel/rcu/rcutorture.c
 @@ -2408,6 +2408,12 @@ static int rcutorture_booster_init(unsigned int cpu)
  		WARN_ON_ONCE(!t);
  		sp.sched_priority = 2;
@@ -13327,10 +13327,10 @@ index ade42d6..eebb9b4 100644
  	}
  
  	/* Don't allow time recalculation while creating a new task. */
-diff --git a/linux-6.6-rc6/kernel/rcu/tree_stall.h b/rc6-cachy-rt/kernel/rcu/tree_stall.h
+diff --git a/kernel/rcu/tree_stall.h b/kernel/rcu/tree_stall.h
 index 6f06dc1..0a58f8b 100644
---- a/linux-6.6-rc6/kernel/rcu/tree_stall.h
-+++ b/rc6-cachy-rt/kernel/rcu/tree_stall.h
+--- a/kernel/rcu/tree_stall.h
++++ b/kernel/rcu/tree_stall.h
 @@ -8,6 +8,7 @@
   */
  
@@ -13365,10 +13365,10 @@ index 6f06dc1..0a58f8b 100644
  }
  
  static void print_cpu_stall(unsigned long gps)
-diff --git a/linux-6.6-rc6/kernel/sched/core.c b/rc6-cachy-rt/kernel/sched/core.c
+diff --git a/kernel/sched/core.c b/kernel/sched/core.c
 index 802551e..a9c755e 100644
---- a/linux-6.6-rc6/kernel/sched/core.c
-+++ b/rc6-cachy-rt/kernel/sched/core.c
+--- a/kernel/sched/core.c
++++ b/kernel/sched/core.c
 @@ -1062,6 +1062,46 @@ void resched_curr(struct rq *rq)
  		trace_sched_wake_idle_without_ipi(cpu);
  }
@@ -13637,10 +13637,10 @@ index 802551e..a9c755e 100644
  	/*
  	 * The idle tasks have their own, simple scheduling class:
  	 */
-diff --git a/linux-6.6-rc6/kernel/sched/fair.c b/rc6-cachy-rt/kernel/sched/fair.c
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
 index 061a30a..205346f 100644
---- a/linux-6.6-rc6/kernel/sched/fair.c
-+++ b/rc6-cachy-rt/kernel/sched/fair.c
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
 @@ -1037,7 +1037,7 @@ static void update_deadline(struct cfs_rq *cfs_rq, struct sched_entity *se)
  	 * The task has consumed its request, reschedule.
  	 */
@@ -13695,10 +13695,10 @@ index 061a30a..205346f 100644
  	} else
  		check_preempt_curr(rq, p, 0);
  }
-diff --git a/linux-6.6-rc6/kernel/sched/features.h b/rc6-cachy-rt/kernel/sched/features.h
+diff --git a/kernel/sched/features.h b/kernel/sched/features.h
 index f770168..2c0ffe1 100644
---- a/linux-6.6-rc6/kernel/sched/features.h
-+++ b/rc6-cachy-rt/kernel/sched/features.h
+--- a/kernel/sched/features.h
++++ b/kernel/sched/features.h
 @@ -37,6 +37,9 @@ SCHED_FEAT(NONTASK_CAPACITY, true)
  
  #ifdef CONFIG_PREEMPT_RT
@@ -13709,10 +13709,10 @@ index f770168..2c0ffe1 100644
  #else
  
  /*
-diff --git a/linux-6.6-rc6/kernel/sched/rt.c b/rc6-cachy-rt/kernel/sched/rt.c
+diff --git a/kernel/sched/rt.c b/kernel/sched/rt.c
 index 0597ba0..716b9f0 100644
---- a/linux-6.6-rc6/kernel/sched/rt.c
-+++ b/rc6-cachy-rt/kernel/sched/rt.c
+--- a/kernel/sched/rt.c
++++ b/kernel/sched/rt.c
 @@ -2247,8 +2247,11 @@ static int rto_next_cpu(struct root_domain *rd)
  
  		rd->rto_cpu = cpu;
@@ -13726,10 +13726,10 @@ index 0597ba0..716b9f0 100644
  
  		rd->rto_cpu = -1;
  
-diff --git a/linux-6.6-rc6/kernel/sched/sched.h b/rc6-cachy-rt/kernel/sched/sched.h
+diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
 index 0484627..e9cf4da 100644
---- a/linux-6.6-rc6/kernel/sched/sched.h
-+++ b/rc6-cachy-rt/kernel/sched/sched.h
+--- a/kernel/sched/sched.h
++++ b/kernel/sched/sched.h
 @@ -2437,6 +2437,15 @@ extern void reweight_task(struct task_struct *p, int prio);
  extern void resched_curr(struct rq *rq);
  extern void resched_cpu(int cpu);
@@ -13746,10 +13746,10 @@ index 0484627..e9cf4da 100644
  extern struct rt_bandwidth def_rt_bandwidth;
  extern void init_rt_bandwidth(struct rt_bandwidth *rt_b, u64 period, u64 runtime);
  extern bool sched_rt_bandwidth_account(struct rt_rq *rt_rq);
-diff --git a/linux-6.6-rc6/kernel/signal.c b/rc6-cachy-rt/kernel/signal.c
+diff --git a/kernel/signal.c b/kernel/signal.c
 index 0901901..b710263 100644
---- a/linux-6.6-rc6/kernel/signal.c
-+++ b/rc6-cachy-rt/kernel/signal.c
+--- a/kernel/signal.c
++++ b/kernel/signal.c
 @@ -2329,15 +2329,35 @@ static int ptrace_stop(int exit_code, int why, unsigned long message,
  		do_notify_parent_cldstop(current, false, why);
  
@@ -13791,10 +13791,10 @@ index 0901901..b710263 100644
  	schedule();
  	cgroup_leave_frozen(true);
  
-diff --git a/linux-6.6-rc6/kernel/softirq.c b/rc6-cachy-rt/kernel/softirq.c
+diff --git a/kernel/softirq.c b/kernel/softirq.c
 index 210cf5f..cae0ae2 100644
---- a/linux-6.6-rc6/kernel/softirq.c
-+++ b/rc6-cachy-rt/kernel/softirq.c
+--- a/kernel/softirq.c
++++ b/kernel/softirq.c
 @@ -247,6 +247,19 @@ out:
  }
  EXPORT_SYMBOL(__local_bh_enable_ip);
@@ -13923,10 +13923,10 @@ index 210cf5f..cae0ae2 100644
  	return 0;
  }
  early_initcall(spawn_ksoftirqd);
-diff --git a/linux-6.6-rc6/kernel/time/hrtimer.c b/rc6-cachy-rt/kernel/time/hrtimer.c
+diff --git a/kernel/time/hrtimer.c b/kernel/time/hrtimer.c
 index 238262e..be97b23 100644
---- a/linux-6.6-rc6/kernel/time/hrtimer.c
-+++ b/rc6-cachy-rt/kernel/time/hrtimer.c
+--- a/kernel/time/hrtimer.c
++++ b/kernel/time/hrtimer.c
 @@ -1808,7 +1808,7 @@ retry:
  	if (!ktime_before(now, cpu_base->softirq_expires_next)) {
  		cpu_base->softirq_expires_next = KTIME_MAX;
@@ -13945,10 +13945,10 @@ index 238262e..be97b23 100644
  	}
  
  	__hrtimer_run_queues(cpu_base, now, flags, HRTIMER_ACTIVE_HARD);
-diff --git a/linux-6.6-rc6/kernel/time/tick-sched.c b/rc6-cachy-rt/kernel/time/tick-sched.c
+diff --git a/kernel/time/tick-sched.c b/kernel/time/tick-sched.c
 index 87015e9..3bea1d0 100644
---- a/linux-6.6-rc6/kernel/time/tick-sched.c
-+++ b/rc6-cachy-rt/kernel/time/tick-sched.c
+--- a/kernel/time/tick-sched.c
++++ b/kernel/time/tick-sched.c
 @@ -795,7 +795,7 @@ static void tick_nohz_restart(struct tick_sched *ts, ktime_t now)
  
  static inline bool local_timer_softirq_pending(void)
@@ -13958,10 +13958,10 @@ index 87015e9..3bea1d0 100644
  }
  
  static ktime_t tick_nohz_next_event(struct tick_sched *ts, int cpu)
-diff --git a/linux-6.6-rc6/kernel/time/timer.c b/rc6-cachy-rt/kernel/time/timer.c
+diff --git a/kernel/time/timer.c b/kernel/time/timer.c
 index 63a8ce7..b3fbe97 100644
---- a/linux-6.6-rc6/kernel/time/timer.c
-+++ b/rc6-cachy-rt/kernel/time/timer.c
+--- a/kernel/time/timer.c
++++ b/kernel/time/timer.c
 @@ -1470,9 +1470,16 @@ static inline void timer_base_unlock_expiry(struct timer_base *base)
   */
  static void timer_sync_wait_running(struct timer_base *base)
@@ -13989,10 +13989,10 @@ index 63a8ce7..b3fbe97 100644
  }
  
  /*
-diff --git a/linux-6.6-rc6/kernel/trace/trace.c b/rc6-cachy-rt/kernel/trace/trace.c
+diff --git a/kernel/trace/trace.c b/kernel/trace/trace.c
 index abaaf51..f00ad98 100644
---- a/linux-6.6-rc6/kernel/trace/trace.c
-+++ b/rc6-cachy-rt/kernel/trace/trace.c
+--- a/kernel/trace/trace.c
++++ b/kernel/trace/trace.c
 @@ -2720,11 +2720,19 @@ unsigned int tracing_gen_ctx_irq_test(unsigned int irqs_status)
  	if (softirq_count() >> (SOFTIRQ_SHIFT + 1))
  		trace_flags |= TRACE_FLAG_BH_OFF;
@@ -14067,10 +14067,10 @@ index abaaf51..f00ad98 100644
  }
  
  void
-diff --git a/linux-6.6-rc6/kernel/trace/trace_events.c b/rc6-cachy-rt/kernel/trace/trace_events.c
+diff --git a/kernel/trace/trace_events.c b/kernel/trace/trace_events.c
 index f49d6dd..4999ddf 100644
---- a/linux-6.6-rc6/kernel/trace/trace_events.c
-+++ b/rc6-cachy-rt/kernel/trace/trace_events.c
+--- a/kernel/trace/trace_events.c
++++ b/kernel/trace/trace_events.c
 @@ -210,6 +210,7 @@ static int trace_define_common_fields(void)
  	/* Holds both preempt_count and migrate_disable */
  	__common_field(unsigned char, preempt_count);
@@ -14079,10 +14079,10 @@ index f49d6dd..4999ddf 100644
  
  	return ret;
  }
-diff --git a/linux-6.6-rc6/kernel/trace/trace_output.c b/rc6-cachy-rt/kernel/trace/trace_output.c
+diff --git a/kernel/trace/trace_output.c b/kernel/trace/trace_output.c
 index db57509..6e1b552 100644
---- a/linux-6.6-rc6/kernel/trace/trace_output.c
-+++ b/rc6-cachy-rt/kernel/trace/trace_output.c
+--- a/kernel/trace/trace_output.c
++++ b/kernel/trace/trace_output.c
 @@ -445,6 +445,7 @@ int trace_print_lat_fmt(struct trace_seq *s, struct trace_entry *entry)
  {
  	char hardsoft_irq;
@@ -14142,10 +14142,10 @@ index db57509..6e1b552 100644
  	if (entry->preempt_count & 0xf0)
  		trace_seq_printf(s, "%x", entry->preempt_count >> 4);
  	else
-diff --git a/linux-6.6-rc6/net/core/dev.c b/rc6-cachy-rt/net/core/dev.c
+diff --git a/net/core/dev.c b/net/core/dev.c
 index 5aaf575..26917a6 100644
---- a/linux-6.6-rc6/net/core/dev.c
-+++ b/rc6-cachy-rt/net/core/dev.c
+--- a/net/core/dev.c
++++ b/net/core/dev.c
 @@ -4677,15 +4677,6 @@ static void rps_trigger_softirq(void *data)
  
  #endif /* CONFIG_RPS */
@@ -14207,10 +14207,10 @@ index 5aaf575..26917a6 100644
  		spin_lock_init(&sd->defer_lock);
  
  		init_gro_hash(&sd->backlog);
-diff --git a/linux-6.6-rc6/net/core/skbuff.c b/rc6-cachy-rt/net/core/skbuff.c
+diff --git a/net/core/skbuff.c b/net/core/skbuff.c
 index 4eaf7ed..93fdd94 100644
---- a/linux-6.6-rc6/net/core/skbuff.c
-+++ b/rc6-cachy-rt/net/core/skbuff.c
+--- a/net/core/skbuff.c
++++ b/net/core/skbuff.c
 @@ -6840,8 +6840,13 @@ nodefer:	__kfree_skb(skb);
  	/* Make sure to trigger NET_RX_SOFTIRQ on the remote CPU
  	 * if we are unlucky enough (this seems very unlikely).


### PR DESCRIPTION
Using v6.6-rc6-rt9 as a base
removed EXPERT requirement for PREEMPT_RT
removed local version
removed ARM changes