### PR TITLE
Add temporary patches for NVIDIA module

### DIFF
--- a/6.6/misc/nvidia/nvidia-drm-hotplug-workqueue.patch
+++ b/6.6/misc/nvidia/nvidia-drm-hotplug-workqueue.patch
@@ -1,0 +1,104 @@
+From d82eb6c87ee2e05b6bbd35f703a41e68b3adc3a7 Mon Sep 17 00:00:00 2001
+From: Aaron Plattner <aplattner@nvidia.com>
+Date: Tue, 26 Dec 2023 11:58:46 -0800
+Subject: [PATCH] nvidia-drm: Use a workqueue to defer calling
+ drm_kms_helper_hotplug_event
+
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c     | 24 ++++++++++++++++++++++++
+ kernel/nvidia-drm/nvidia-drm-encoder.c |  4 ++--
+ kernel/nvidia-drm/nvidia-drm-priv.h    |  1 +
+ 3 files changed, 27 insertions(+), 2 deletions(-)
+
+diff --git kernel/nvidia-drm/nvidia-drm-drv.c kernel/nvidia-drm/nvidia-drm-drv.c
+index e0ddb6c..9f7424d 100644
+--- kernel/nvidia-drm/nvidia-drm-drv.c
++++ kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -74,6 +74,7 @@
+ #endif
+ 
+ #include <linux/pci.h>
++#include <linux/workqueue.h>
+ 
+ /*
+  * Commit fcd70cd36b9b ("drm: Split out drm_probe_helper.h")
+@@ -405,6 +406,27 @@ static int nv_drm_create_properties(struct nv_drm_device *nv_dev)
+     return 0;
+ }
+ 
++#if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
++/*
++ * We can't just call drm_kms_helper_hotplug_event directly because
++ * fbdev_generic may attempt to set a mode from inside the hotplug event
++ * handler. Because kapi event handling runs on nvkms_kthread_q, this blocks
++ * other event processing including the flip completion notifier expected by
++ * nv_drm_atomic_commit.
++ *
++ * Defer hotplug event handling to a work item so that nvkms_kthread_q can
++ * continue processing events while a DRM modeset is in progress.
++ */
++static void nv_drm_handle_hotplug_event(struct work_struct *work)
++{
++    struct delayed_work *dwork = to_delayed_work(work);
++    struct nv_drm_device *nv_dev =
++        container_of(dwork, struct nv_drm_device, hotplug_event_work);
++
++    drm_kms_helper_hotplug_event(nv_dev->dev);
++}
++#endif
++
+ static int nv_drm_load(struct drm_device *dev, unsigned long flags)
+ {
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+@@ -540,6 +562,7 @@ static int nv_drm_load(struct drm_device *dev, unsigned long flags)
+ 
+     /* Enable event handling */
+ 
++    INIT_DELAYED_WORK(&nv_dev->hotplug_event_work, nv_drm_handle_hotplug_event);
+     atomic_set(&nv_dev->enable_event_handling, true);
+ 
+     init_waitqueue_head(&nv_dev->flip_event_wq);
+@@ -567,6 +590,7 @@ static void __nv_drm_unload(struct drm_device *dev)
+         return;
+     }
+ 
++    cancel_delayed_work_sync(&nv_dev->hotplug_event_work);
+     mutex_lock(&nv_dev->lock);
+ 
+     WARN_ON(nv_dev->subOwnershipGranted);
+diff --git kernel/nvidia-drm/nvidia-drm-encoder.c kernel/nvidia-drm/nvidia-drm-encoder.c
+index b5ef5a2..7c0c119 100644
+--- kernel/nvidia-drm/nvidia-drm-encoder.c
++++ kernel/nvidia-drm/nvidia-drm-encoder.c
+@@ -300,7 +300,7 @@ void nv_drm_handle_display_change(struct nv_drm_device *nv_dev,
+ 
+     nv_drm_connector_mark_connection_status_dirty(nv_encoder->nv_connector);
+ 
+-    drm_kms_helper_hotplug_event(dev);
++    schedule_delayed_work(&nv_dev->hotplug_event_work, 0);
+ }
+ 
+ void nv_drm_handle_dynamic_display_connected(struct nv_drm_device *nv_dev,
+@@ -347,6 +347,6 @@ void nv_drm_handle_dynamic_display_connected(struct nv_drm_device *nv_dev,
+     drm_reinit_primary_mode_group(dev);
+ #endif
+ 
+-    drm_kms_helper_hotplug_event(dev);
++    schedule_delayed_work(&nv_dev->hotplug_event_work, 0);
+ }
+ #endif
+diff --git kernel/nvidia-drm/nvidia-drm-priv.h kernel/nvidia-drm/nvidia-drm-priv.h
+index 253155f..c9ce727 100644
+--- kernel/nvidia-drm/nvidia-drm-priv.h
++++ kernel/nvidia-drm/nvidia-drm-priv.h
+@@ -126,6 +126,7 @@ struct nv_drm_device {
+     NvU64 modifiers[6 /* block linear */ + 1 /* linear */ + 1 /* terminator */];
+ #endif
+ 
++    struct delayed_work hotplug_event_work;
+     atomic_t enable_event_handling;
+ 
+     /**
+-- 
+2.43.0
+

--- a/6.7/misc/nvidia/nvidia-drm-hotplug-workqueue.patch
+++ b/6.7/misc/nvidia/nvidia-drm-hotplug-workqueue.patch
@@ -1,0 +1,104 @@
+From d82eb6c87ee2e05b6bbd35f703a41e68b3adc3a7 Mon Sep 17 00:00:00 2001
+From: Aaron Plattner <aplattner@nvidia.com>
+Date: Tue, 26 Dec 2023 11:58:46 -0800
+Subject: [PATCH] nvidia-drm: Use a workqueue to defer calling
+ drm_kms_helper_hotplug_event
+
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c     | 24 ++++++++++++++++++++++++
+ kernel/nvidia-drm/nvidia-drm-encoder.c |  4 ++--
+ kernel/nvidia-drm/nvidia-drm-priv.h    |  1 +
+ 3 files changed, 27 insertions(+), 2 deletions(-)
+
+diff --git kernel/nvidia-drm/nvidia-drm-drv.c kernel/nvidia-drm/nvidia-drm-drv.c
+index e0ddb6c..9f7424d 100644
+--- kernel/nvidia-drm/nvidia-drm-drv.c
++++ kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -74,6 +74,7 @@
+ #endif
+ 
+ #include <linux/pci.h>
++#include <linux/workqueue.h>
+ 
+ /*
+  * Commit fcd70cd36b9b ("drm: Split out drm_probe_helper.h")
+@@ -405,6 +406,27 @@ static int nv_drm_create_properties(struct nv_drm_device *nv_dev)
+     return 0;
+ }
+ 
++#if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
++/*
++ * We can't just call drm_kms_helper_hotplug_event directly because
++ * fbdev_generic may attempt to set a mode from inside the hotplug event
++ * handler. Because kapi event handling runs on nvkms_kthread_q, this blocks
++ * other event processing including the flip completion notifier expected by
++ * nv_drm_atomic_commit.
++ *
++ * Defer hotplug event handling to a work item so that nvkms_kthread_q can
++ * continue processing events while a DRM modeset is in progress.
++ */
++static void nv_drm_handle_hotplug_event(struct work_struct *work)
++{
++    struct delayed_work *dwork = to_delayed_work(work);
++    struct nv_drm_device *nv_dev =
++        container_of(dwork, struct nv_drm_device, hotplug_event_work);
++
++    drm_kms_helper_hotplug_event(nv_dev->dev);
++}
++#endif
++
+ static int nv_drm_load(struct drm_device *dev, unsigned long flags)
+ {
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+@@ -540,6 +562,7 @@ static int nv_drm_load(struct drm_device *dev, unsigned long flags)
+ 
+     /* Enable event handling */
+ 
++    INIT_DELAYED_WORK(&nv_dev->hotplug_event_work, nv_drm_handle_hotplug_event);
+     atomic_set(&nv_dev->enable_event_handling, true);
+ 
+     init_waitqueue_head(&nv_dev->flip_event_wq);
+@@ -567,6 +590,7 @@ static void __nv_drm_unload(struct drm_device *dev)
+         return;
+     }
+ 
++    cancel_delayed_work_sync(&nv_dev->hotplug_event_work);
+     mutex_lock(&nv_dev->lock);
+ 
+     WARN_ON(nv_dev->subOwnershipGranted);
+diff --git kernel/nvidia-drm/nvidia-drm-encoder.c kernel/nvidia-drm/nvidia-drm-encoder.c
+index b5ef5a2..7c0c119 100644
+--- kernel/nvidia-drm/nvidia-drm-encoder.c
++++ kernel/nvidia-drm/nvidia-drm-encoder.c
+@@ -300,7 +300,7 @@ void nv_drm_handle_display_change(struct nv_drm_device *nv_dev,
+ 
+     nv_drm_connector_mark_connection_status_dirty(nv_encoder->nv_connector);
+ 
+-    drm_kms_helper_hotplug_event(dev);
++    schedule_delayed_work(&nv_dev->hotplug_event_work, 0);
+ }
+ 
+ void nv_drm_handle_dynamic_display_connected(struct nv_drm_device *nv_dev,
+@@ -347,6 +347,6 @@ void nv_drm_handle_dynamic_display_connected(struct nv_drm_device *nv_dev,
+     drm_reinit_primary_mode_group(dev);
+ #endif
+ 
+-    drm_kms_helper_hotplug_event(dev);
++    schedule_delayed_work(&nv_dev->hotplug_event_work, 0);
+ }
+ #endif
+diff --git kernel/nvidia-drm/nvidia-drm-priv.h kernel/nvidia-drm/nvidia-drm-priv.h
+index 253155f..c9ce727 100644
+--- kernel/nvidia-drm/nvidia-drm-priv.h
++++ kernel/nvidia-drm/nvidia-drm-priv.h
+@@ -126,6 +126,7 @@ struct nv_drm_device {
+     NvU64 modifiers[6 /* block linear */ + 1 /* linear */ + 1 /* terminator */];
+ #endif
+ 
++    struct delayed_work hotplug_event_work;
+     atomic_t enable_event_handling;
+ 
+     /**
+-- 
+2.43.0
+


### PR DESCRIPTION
I wouldn't really want to download them from a temporary link provided by NVIDIA.