### PR TITLE
Rebase + fix for 0001-intel-thread-director.patch

### DIFF
--- a/6.7/misc/0001-intel-thread-director.patch
+++ b/6.7/misc/0001-intel-thread-director.patch
@@ -1,7 +1,7 @@
-From	Ricardo Neri <>
+ From	Ricardo Neri <>
 Subject	[PATCH v4 00/24] sched: Introduce classes of tasks for load balance
 Date	Mon, 12 Jun 2023 21:23:58 -0700
- 
+
  arch/x86/include/asm/cpufeatures.h       |   2 +
  arch/x86/include/asm/disabled-features.h |   8 +-
  arch/x86/include/asm/hreset.h            |  30 +++
@@ -19,11 +19,11 @@ Date	Mon, 12 Jun 2023 21:23:58 -0700
  include/linux/sched/topology.h           |   6 +
  init/Kconfig                             |  12 ++
  kernel/sched/core.c                      |  10 +-
- kernel/sched/fair.c                      | 316 ++++++++++++++++++++++++++++++-
+ kernel/sched/fair.c                      | 318 ++++++++++++++++++++++++++++++-
  kernel/sched/sched.h                     |  66 +++++++
  kernel/sched/topology.c                  |   9 +
  kernel/time/timer.c                      |   2 +-
- 21 files changed, 840 insertions(+), 17 deletions(-)
+ 21 files changed, 841 insertions(+), 18 deletions(-)
 
 diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
 index 4af140cf5..aedc1740b 100644
@@ -851,7 +851,7 @@ index a708d225c..6d8c1fec7 100644
  
  	rq_lock(rq, &rf);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index d7a3c63a2..2c6740d9b 100644
+index d7a3c63a2..ae490da9e 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -1303,7 +1303,14 @@ update_stats_curr_start(struct cfs_rq *cfs_rq, struct sched_entity *se)
@@ -1255,6 +1255,15 @@ index d7a3c63a2..2c6740d9b 100644
  			}
  			break;
  
+@@ -11170,7 +11474,7 @@ static int should_we_balance(struct lb_env *env)
+ 		 * balancing cores, but remember the first idle SMT CPU for
+ 		 * later consideration.  Find CPU on an idle core first.
+ 		 */
+-		if (!(env->sd->flags & SD_SHARE_CPUCAPACITY) && !is_core_idle(cpu)) {
++		if (!(env->sd->flags & SD_SHARE_CPUCAPACITY) && !sched_smt_siblings_idle(cpu)) {
+ 			if (idle_smt == -1)
+ 				idle_smt = cpu;
+ 			/*
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
 index 2e5a95486..1f02bc899 100644
 --- a/kernel/sched/sched.h

--- a/6.7/misc/0001-intel-thread-director.patch
+++ b/6.7/misc/0001-intel-thread-director.patch
@@ -1,10 +1,7 @@
-From 35ea9d63343409bdb312b28c7aaa39a36446aa64 Mon Sep 17 00:00:00 2001
-From: Peter Jung <admin@ptr1337.dev>
-Date: Mon, 13 Nov 2023 13:44:54 +0100
-Subject: [PATCH] intel-thread-director
+From	Ricardo Neri <>
+Subject	[PATCH v4 00/24] sched: Introduce classes of tasks for load balance
+Date	Mon, 12 Jun 2023 21:23:58 -0700
 
-Signed-off-by: Peter Jung <admin@ptr1337.dev>
----
  arch/x86/include/asm/cpufeatures.h       |   2 +
  arch/x86/include/asm/disabled-features.h |   8 +-
  arch/x86/include/asm/hreset.h            |  30 +++
@@ -13,25 +10,25 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  arch/x86/kernel/Makefile                 |   2 +
  arch/x86/kernel/cpu/common.c             |  30 ++-
  arch/x86/kernel/cpu/cpuid-deps.c         |   1 +
+ arch/x86/kernel/cpu/cpuid-deps.c.rej     |  10 +
  arch/x86/kernel/process_32.c             |   3 +
  arch/x86/kernel/process_64.c             |   3 +
- arch/x86/kernel/sched_ipcc.c             |  93 +++++++
+ arch/x86/kernel/sched_ipcc.c             |  93 +++++++++
  drivers/thermal/intel/Kconfig            |   1 +
- drivers/thermal/intel/intel_hfi.c        | 219 +++++++++++++++-
- include/linux/sched.h                    |  24 +-
+ drivers/thermal/intel/intel_hfi.c        | 219 ++++++++++++++++++++-
+ include/linux/sched.h                    |  24 ++-
  include/linux/sched/topology.h           |   6 +
- init/Kconfig                             |  12 +
+ init/Kconfig                             |  12 ++
  kernel/sched/core.c                      |  10 +-
- kernel/sched/fair.c                      | 316 ++++++++++++++++++++++-
- kernel/sched/sched.h                     |  66 +++++
+ kernel/sched/core.c.rej                  |  23 +++
+ kernel/sched/fair.c                      | 316 ++++++++++++++++++++++++++++++-
+ kernel/sched/sched.h                     |  66 +++++++
  kernel/sched/topology.c                  |   9 +
  kernel/time/timer.c                      |   2 +-
- 21 files changed, 840 insertions(+), 17 deletions(-)
- create mode 100644 arch/x86/include/asm/hreset.h
- create mode 100644 arch/x86/kernel/sched_ipcc.c
+ 23 files changed, 873 insertions(+), 17 deletions(-)
 
 diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
-index 4af140cf5719..aedc1740b6ab 100644
+index 4af140cf5..aedc1740b 100644
 --- a/arch/x86/include/asm/cpufeatures.h
 +++ b/arch/x86/include/asm/cpufeatures.h
 @@ -323,6 +323,7 @@
@@ -51,7 +48,7 @@ index 4af140cf5719..aedc1740b6ab 100644
  /* AMD SVM Feature Identification, CPUID level 0x8000000a (EDX), word 15 */
  #define X86_FEATURE_NPT			(15*32+ 0) /* Nested Page Table support */
 diff --git a/arch/x86/include/asm/disabled-features.h b/arch/x86/include/asm/disabled-features.h
-index 702d93fdd10e..f4aa34cfd20d 100644
+index 702d93fdd..f4aa34cfd 100644
 --- a/arch/x86/include/asm/disabled-features.h
 +++ b/arch/x86/include/asm/disabled-features.h
 @@ -117,6 +117,12 @@
@@ -78,7 +75,7 @@ index 702d93fdd10e..f4aa34cfd20d 100644
  			 DISABLE_ENQCMD)
 diff --git a/arch/x86/include/asm/hreset.h b/arch/x86/include/asm/hreset.h
 new file mode 100644
-index 000000000000..d68ca2fb8642
+index 000000000..d68ca2fb8
 --- /dev/null
 +++ b/arch/x86/include/asm/hreset.h
 @@ -0,0 +1,30 @@
@@ -113,7 +110,7 @@ index 000000000000..d68ca2fb8642
 +
 +#endif /* _ASM_X86_HRESET_H */
 diff --git a/arch/x86/include/asm/msr-index.h b/arch/x86/include/asm/msr-index.h
-index 1d51e1850ed0..1f928e10b674 100644
+index 1d51e1850..1f928e10b 100644
 --- a/arch/x86/include/asm/msr-index.h
 +++ b/arch/x86/include/asm/msr-index.h
 @@ -1136,6 +1136,11 @@
@@ -129,7 +126,7 @@ index 1d51e1850ed0..1f928e10b674 100644
  /* x2APIC locked status */
  #define MSR_IA32_XAPIC_DISABLE_STATUS	0xBD
 diff --git a/arch/x86/include/asm/topology.h b/arch/x86/include/asm/topology.h
-index 5f87f6b9b09e..29fc06efcb6b 100644
+index 5f87f6b9b..29fc06efc 100644
 --- a/arch/x86/include/asm/topology.h
 +++ b/arch/x86/include/asm/topology.h
 @@ -235,4 +235,19 @@ void init_freq_invariance_cppc(void);
@@ -153,7 +150,7 @@ index 5f87f6b9b09e..29fc06efcb6b 100644
 +
  #endif /* _ASM_X86_TOPOLOGY_H */
 diff --git a/arch/x86/kernel/Makefile b/arch/x86/kernel/Makefile
-index 0000325ab98f..9bc7319175df 100644
+index 0000325ab..9bc731917 100644
 --- a/arch/x86/kernel/Makefile
 +++ b/arch/x86/kernel/Makefile
 @@ -150,6 +150,8 @@ obj-$(CONFIG_X86_CET)			+= cet.o
@@ -166,7 +163,7 @@ index 0000325ab98f..9bc7319175df 100644
  # 64 bit specific files
  ifeq ($(CONFIG_X86_64),y)
 diff --git a/arch/x86/kernel/cpu/common.c b/arch/x86/kernel/cpu/common.c
-index b14fc8c1c953..19eafa63e146 100644
+index b14fc8c1c..19eafa63e 100644
 --- a/arch/x86/kernel/cpu/common.c
 +++ b/arch/x86/kernel/cpu/common.c
 @@ -57,6 +57,7 @@
@@ -224,19 +221,35 @@ index b14fc8c1c953..19eafa63e146 100644
  	/* Enable FSGSBASE instructions if available. */
  	if (cpu_has(c, X86_FEATURE_FSGSBASE)) {
 diff --git a/arch/x86/kernel/cpu/cpuid-deps.c b/arch/x86/kernel/cpu/cpuid-deps.c
-index e462c1d3800a..2ab036125a56 100644
+index e462c1d38..db62700cd 100644
 --- a/arch/x86/kernel/cpu/cpuid-deps.c
 +++ b/arch/x86/kernel/cpu/cpuid-deps.c
-@@ -82,6 +82,7 @@ static const struct cpuid_dep cpuid_deps[] = {
+@@ -81,6 +81,7 @@ static const struct cpuid_dep cpuid_deps[] = {
+ 	{ X86_FEATURE_XFD,			X86_FEATURE_XSAVES    },
  	{ X86_FEATURE_XFD,			X86_FEATURE_XGETBV1   },
  	{ X86_FEATURE_AMX_TILE,			X86_FEATURE_XFD       },
- 	{ X86_FEATURE_SHSTK,			X86_FEATURE_XSAVES    },
 +	{ X86_FEATURE_ITD,			X86_FEATURE_HFI       },
+ 	{ X86_FEATURE_SHSTK,			X86_FEATURE_XSAVES    },
  	{}
  };
- 
+diff --git a/arch/x86/kernel/cpu/cpuid-deps.c.rej b/arch/x86/kernel/cpu/cpuid-deps.c.rej
+new file mode 100644
+index 000000000..6acbe6680
+--- /dev/null
++++ b/arch/x86/kernel/cpu/cpuid-deps.c.rej
+@@ -0,0 +1,10 @@
++--- arch/x86/kernel/cpu/cpuid-deps.c
+++++ arch/x86/kernel/cpu/cpuid-deps.c
++@@ -81,6 +81,7 @@ static const struct cpuid_dep cpuid_deps[] = {
++ 	{ X86_FEATURE_XFD,			X86_FEATURE_XSAVES    },
++ 	{ X86_FEATURE_XFD,			X86_FEATURE_XGETBV1   },
++ 	{ X86_FEATURE_AMX_TILE,			X86_FEATURE_XFD       },
+++	{ X86_FEATURE_ITD,			X86_FEATURE_HFI       },
++ 	{}
++ };
++ 
 diff --git a/arch/x86/kernel/process_32.c b/arch/x86/kernel/process_32.c
-index 708c87b88cc1..7353bb119e79 100644
+index 708c87b88..7353bb119 100644
 --- a/arch/x86/kernel/process_32.c
 +++ b/arch/x86/kernel/process_32.c
 @@ -52,6 +52,7 @@
@@ -257,7 +270,7 @@ index 708c87b88cc1..7353bb119e79 100644
  }
  
 diff --git a/arch/x86/kernel/process_64.c b/arch/x86/kernel/process_64.c
-index 33b268747bb7..202a6735c092 100644
+index 33b268747..202a6735c 100644
 --- a/arch/x86/kernel/process_64.c
 +++ b/arch/x86/kernel/process_64.c
 @@ -54,6 +54,7 @@
@@ -279,7 +292,7 @@ index 33b268747bb7..202a6735c092 100644
  
 diff --git a/arch/x86/kernel/sched_ipcc.c b/arch/x86/kernel/sched_ipcc.c
 new file mode 100644
-index 000000000000..dd73fc8be49b
+index 000000000..dd73fc8be
 --- /dev/null
 +++ b/arch/x86/kernel/sched_ipcc.c
 @@ -0,0 +1,93 @@
@@ -377,7 +390,7 @@ index 000000000000..dd73fc8be49b
 +		debounce_and_update_class(curr, hfi_class + 1);
 +}
 diff --git a/drivers/thermal/intel/Kconfig b/drivers/thermal/intel/Kconfig
-index ecd7e07eece0..418db04dc876 100644
+index ecd7e07ee..418db04dc 100644
 --- a/drivers/thermal/intel/Kconfig
 +++ b/drivers/thermal/intel/Kconfig
 @@ -109,6 +109,7 @@ config INTEL_HFI_THERMAL
@@ -389,7 +402,7 @@ index ecd7e07eece0..418db04dc876 100644
  	  Select this option to enable the Hardware Feedback Interface. If
  	  selected, hardware provides guidance to the operating system on
 diff --git a/drivers/thermal/intel/intel_hfi.c b/drivers/thermal/intel/intel_hfi.c
-index c69db6c90869..75bf18dc7f51 100644
+index c69db6c90..75bf18dc7 100644
 --- a/drivers/thermal/intel/intel_hfi.c
 +++ b/drivers/thermal/intel/intel_hfi.c
 @@ -29,9 +29,12 @@
@@ -729,7 +742,7 @@ index c69db6c90869..75bf18dc7f51 100644
  	for (j = 0; j < i; ++j) {
  		hfi_instance = &hfi_instances[j];
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 292c31697248..2aeaea87bdc1 100644
+index 292c31697..2aeaea87b 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -127,6 +127,8 @@ struct user_event_mm;
@@ -783,7 +796,7 @@ index 292c31697248..2aeaea87bdc1 100644
 +
  #endif
 diff --git a/include/linux/sched/topology.h b/include/linux/sched/topology.h
-index de545ba85218..3a44e18480bc 100644
+index de545ba85..3a44e1848 100644
 --- a/include/linux/sched/topology.h
 +++ b/include/linux/sched/topology.h
 @@ -284,4 +284,10 @@ static inline int task_node(const struct task_struct *p)
@@ -798,10 +811,10 @@ index de545ba85218..3a44e18480bc 100644
 +
  #endif /* _LINUX_SCHED_TOPOLOGY_H */
 diff --git a/init/Kconfig b/init/Kconfig
-index 27d87b3569dd..e14da0c5b6da 100644
+index 9ffb103fc..0a7fc7b1c 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -844,6 +844,18 @@ config UCLAMP_BUCKETS_COUNT
+@@ -840,6 +840,18 @@ config UCLAMP_BUCKETS_COUNT
  
  	  If in doubt, use the default value.
  
@@ -821,21 +834,21 @@ index 27d87b3569dd..e14da0c5b6da 100644
  
  #
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index a708d225c28e..9e2b352fd6c8 100644
+index a708d225c..6d8c1fec7 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
-@@ -4498,6 +4498,11 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
+@@ -4496,6 +4496,11 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
+ 	p->se.prev_sum_exec_runtime	= 0;
+ 	p->se.nr_migrations		= 0;
  	p->se.vruntime			= 0;
- 	p->se.vlag			= 0;
- 	p->se.slice			= sysctl_sched_base_slice;
 +#ifdef CONFIG_IPC_CLASSES
 +	p->ipcc				= IPC_CLASS_UNCLASSIFIED;
 +	p->ipcc_tmp			= IPC_CLASS_UNCLASSIFIED;
 +	p->ipcc_cntr			= 0;
 +#endif
+ 	p->se.vlag			= 0;
+ 	p->se.slice			= sysctl_sched_base_slice;
  	INIT_LIST_HEAD(&p->se.group_node);
- 
- #ifdef CONFIG_FAIR_GROUP_SCHED
 @@ -5629,7 +5634,7 @@ static inline u64 cpu_resched_latency(struct rq *rq) { return 0; }
   * This function gets called by the timer code, with HZ frequency.
   * We call it with interrupts disabled.
@@ -855,11 +868,40 @@ index a708d225c28e..9e2b352fd6c8 100644
  	sched_clock_tick();
  
  	rq_lock(rq, &rf);
+diff --git a/kernel/sched/core.c.rej b/kernel/sched/core.c.rej
+new file mode 100644
+index 000000000..7b09a25eb
+--- /dev/null
++++ b/kernel/sched/core.c.rej
+@@ -0,0 +1,23 @@
++--- kernel/sched/core.c
+++++ kernel/sched/core.c
++@@ -4500,6 +4500,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
++ 	p->se.prev_sum_exec_runtime	= 0;
++ 	p->se.nr_migrations		= 0;
++ 	p->se.vruntime			= 0;
+++#ifdef CONFIG_IPC_CLASSES
+++	p->ipcc				= IPC_CLASS_UNCLASSIFIED;
+++#endif
++ 	INIT_LIST_HEAD(&p->se.group_node);
++ 
++ #ifdef CONFIG_FAIR_GROUP_SCHED
++--- kernel/sched/core.c
+++++ kernel/sched/core.c
++@@ -4502,6 +4502,8 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
++ 	p->se.vruntime			= 0;
++ #ifdef CONFIG_IPC_CLASSES
++ 	p->ipcc				= IPC_CLASS_UNCLASSIFIED;
+++	p->ipcc_tmp			= IPC_CLASS_UNCLASSIFIED;
+++	p->ipcc_cntr			= 0;
++ #endif
++ 	INIT_LIST_HEAD(&p->se.group_node);
++ 
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index bb0faea2e04b..a8053954057f 100644
+index d7a3c63a2..2c6740d9b 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
-@@ -1316,7 +1316,14 @@ update_stats_curr_start(struct cfs_rq *cfs_rq, struct sched_entity *se)
+@@ -1303,7 +1303,14 @@ update_stats_curr_start(struct cfs_rq *cfs_rq, struct sched_entity *se)
   * Scheduling class queueing methods:
   */
  
@@ -875,7 +917,7 @@ index bb0faea2e04b..a8053954057f 100644
  {
  #ifdef CONFIG_SCHED_SMT
  	int sibling;
-@@ -2019,7 +2026,7 @@ static inline int numa_idle_core(int idle_core, int cpu)
+@@ -2006,7 +2013,7 @@ static inline int numa_idle_core(int idle_core, int cpu)
  	 * Prefer cores instead of packing HT siblings
  	 * and triggering future load balancing.
  	 */
@@ -884,7 +926,7 @@ index bb0faea2e04b..a8053954057f 100644
  		idle_core = cpu;
  
  	return idle_core;
-@@ -9299,6 +9306,13 @@ struct sg_lb_stats {
+@@ -9391,6 +9398,13 @@ struct sg_lb_stats {
  	unsigned int nr_numa_running;
  	unsigned int nr_preferred_running;
  #endif
@@ -898,7 +940,7 @@ index bb0faea2e04b..a8053954057f 100644
  };
  
  /*
-@@ -9577,6 +9591,248 @@ group_type group_classify(unsigned int imbalance_pct,
+@@ -9669,6 +9683,248 @@ group_type group_classify(unsigned int imbalance_pct,
  	return group_has_spare;
  }
  
@@ -1147,7 +1189,7 @@ index bb0faea2e04b..a8053954057f 100644
  /**
   * sched_use_asym_prio - Check whether asym_packing priority must be used
   * @sd:		The scheduling domain of the load balancing
-@@ -9593,7 +9849,7 @@ static bool sched_use_asym_prio(struct sched_domain *sd, int cpu)
+@@ -9685,7 +9941,7 @@ static bool sched_use_asym_prio(struct sched_domain *sd, int cpu)
  	if (!sched_smt_active())
  		return true;
  
@@ -1156,7 +1198,7 @@ index bb0faea2e04b..a8053954057f 100644
  }
  
  /**
-@@ -9732,6 +9988,7 @@ static inline void update_sg_lb_stats(struct lb_env *env,
+@@ -9824,6 +10080,7 @@ static inline void update_sg_lb_stats(struct lb_env *env,
  	int i, nr_running, local_group;
  
  	memset(sgs, 0, sizeof(*sgs));
@@ -1164,7 +1206,7 @@ index bb0faea2e04b..a8053954057f 100644
  
  	local_group = group == sds->local;
  
-@@ -9781,6 +10038,8 @@ static inline void update_sg_lb_stats(struct lb_env *env,
+@@ -9873,6 +10130,8 @@ static inline void update_sg_lb_stats(struct lb_env *env,
  			if (sgs->group_misfit_task_load < load)
  				sgs->group_misfit_task_load = load;
  		}
@@ -1173,7 +1215,7 @@ index bb0faea2e04b..a8053954057f 100644
  	}
  
  	sgs->group_capacity = group->sgc->capacity;
-@@ -9800,6 +10059,9 @@ static inline void update_sg_lb_stats(struct lb_env *env,
+@@ -9892,6 +10151,9 @@ static inline void update_sg_lb_stats(struct lb_env *env,
  
  	sgs->group_type = group_classify(env->sd->imbalance_pct, group, sgs);
  
@@ -1183,7 +1225,7 @@ index bb0faea2e04b..a8053954057f 100644
  	/* Computing avg_load makes sense only when group is overloaded */
  	if (sgs->group_type == group_overloaded)
  		sgs->avg_load = (sgs->group_load * SCHED_CAPACITY_SCALE) /
-@@ -9871,6 +10133,16 @@ static bool update_sd_pick_busiest(struct lb_env *env,
+@@ -9963,6 +10225,16 @@ static bool update_sd_pick_busiest(struct lb_env *env,
  		/* Prefer to move from lowest priority CPU's work */
  		if (sched_asym_prefer(sg->asym_prefer_cpu, sds->busiest->asym_prefer_cpu))
  			return false;
@@ -1200,7 +1242,7 @@ index bb0faea2e04b..a8053954057f 100644
  		break;
  
  	case group_misfit_task:
-@@ -9911,10 +10183,21 @@ static bool update_sd_pick_busiest(struct lb_env *env,
+@@ -10003,10 +10275,21 @@ static bool update_sd_pick_busiest(struct lb_env *env,
  		if (sgs->avg_load == busiest->avg_load) {
  			/*
  			 * SMT sched groups need more help than non-SMT groups.
@@ -1225,7 +1267,7 @@ index bb0faea2e04b..a8053954057f 100644
  		}
  
  		break;
-@@ -10831,6 +11114,7 @@ static struct rq *find_busiest_queue(struct lb_env *env,
+@@ -10923,6 +11206,7 @@ static struct rq *find_busiest_queue(struct lb_env *env,
  {
  	struct rq *busiest = NULL, *rq;
  	unsigned long busiest_util = 0, busiest_load = 0, busiest_capacity = 1;
@@ -1233,7 +1275,7 @@ index bb0faea2e04b..a8053954057f 100644
  	unsigned int busiest_nr = 0;
  	int i;
  
-@@ -10947,6 +11231,26 @@ static struct rq *find_busiest_queue(struct lb_env *env,
+@@ -11039,6 +11323,26 @@ static struct rq *find_busiest_queue(struct lb_env *env,
  			if (busiest_nr < nr_running) {
  				busiest_nr = nr_running;
  				busiest = rq;
@@ -1261,7 +1303,7 @@ index bb0faea2e04b..a8053954057f 100644
  			break;
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index c55d6c97ca9c..6f80bb187d59 100644
+index 2e5a95486..1f02bc899 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2579,6 +2579,72 @@ void arch_scale_freq_tick(void)
@@ -1338,7 +1380,7 @@ index c55d6c97ca9c..6f80bb187d59 100644
  /**
   * arch_scale_freq_capacity - get the frequency scale factor of a given CPU.
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
-index 10d1391e7416..da49c3c51623 100644
+index 10d1391e7..da49c3c51 100644
 --- a/kernel/sched/topology.c
 +++ b/kernel/sched/topology.c
 @@ -677,6 +677,15 @@ DEFINE_PER_CPU(struct sched_domain __rcu *, sd_asym_cpucapacity);
@@ -1358,7 +1400,7 @@ index 10d1391e7416..da49c3c51623 100644
  {
  	struct sched_domain_shared *sds = NULL;
 diff --git a/kernel/time/timer.c b/kernel/time/timer.c
-index 63a8ce7177dd..e15e24105891 100644
+index 63a8ce717..e15e24105 100644
 --- a/kernel/time/timer.c
 +++ b/kernel/time/timer.c
 @@ -2073,7 +2073,7 @@ void update_process_times(int user_tick)
@@ -1370,6 +1412,3 @@ index 63a8ce7177dd..e15e24105891 100644
  	if (IS_ENABLED(CONFIG_POSIX_TIMERS))
  		run_posix_cpu_timers();
  }
--- 
-2.42.1
-

--- a/6.7/misc/0001-intel-thread-director.patch
+++ b/6.7/misc/0001-intel-thread-director.patch
@@ -1,7 +1,3 @@
-From	Ricardo Neri <>
-Subject	[PATCH v4 00/24] sched: Introduce classes of tasks for load balance
-Date	Mon, 12 Jun 2023 21:23:58 -0700
-
  arch/x86/include/asm/cpufeatures.h       |   2 +
  arch/x86/include/asm/disabled-features.h |   8 +-
  arch/x86/include/asm/hreset.h            |  30 +++
@@ -10,7 +6,6 @@ Date	Mon, 12 Jun 2023 21:23:58 -0700
  arch/x86/kernel/Makefile                 |   2 +
  arch/x86/kernel/cpu/common.c             |  30 ++-
  arch/x86/kernel/cpu/cpuid-deps.c         |   1 +
- arch/x86/kernel/cpu/cpuid-deps.c.rej     |  10 +
  arch/x86/kernel/process_32.c             |   3 +
  arch/x86/kernel/process_64.c             |   3 +
  arch/x86/kernel/sched_ipcc.c             |  93 +++++++++
@@ -20,12 +15,11 @@ Date	Mon, 12 Jun 2023 21:23:58 -0700
  include/linux/sched/topology.h           |   6 +
  init/Kconfig                             |  12 ++
  kernel/sched/core.c                      |  10 +-
- kernel/sched/core.c.rej                  |  23 +++
  kernel/sched/fair.c                      | 316 ++++++++++++++++++++++++++++++-
  kernel/sched/sched.h                     |  66 +++++++
  kernel/sched/topology.c                  |   9 +
  kernel/time/timer.c                      |   2 +-
- 23 files changed, 873 insertions(+), 17 deletions(-)
+ 21 files changed, 840 insertions(+), 17 deletions(-)
 
 diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
 index 4af140cf5..aedc1740b 100644
@@ -232,22 +226,6 @@ index e462c1d38..db62700cd 100644
  	{ X86_FEATURE_SHSTK,			X86_FEATURE_XSAVES    },
  	{}
  };
-diff --git a/arch/x86/kernel/cpu/cpuid-deps.c.rej b/arch/x86/kernel/cpu/cpuid-deps.c.rej
-new file mode 100644
-index 000000000..6acbe6680
---- /dev/null
-+++ b/arch/x86/kernel/cpu/cpuid-deps.c.rej
-@@ -0,0 +1,10 @@
-+--- arch/x86/kernel/cpu/cpuid-deps.c
-++++ arch/x86/kernel/cpu/cpuid-deps.c
-+@@ -81,6 +81,7 @@ static const struct cpuid_dep cpuid_deps[] = {
-+ 	{ X86_FEATURE_XFD,			X86_FEATURE_XSAVES    },
-+ 	{ X86_FEATURE_XFD,			X86_FEATURE_XGETBV1   },
-+ 	{ X86_FEATURE_AMX_TILE,			X86_FEATURE_XFD       },
-++	{ X86_FEATURE_ITD,			X86_FEATURE_HFI       },
-+ 	{}
-+ };
-+ 
 diff --git a/arch/x86/kernel/process_32.c b/arch/x86/kernel/process_32.c
 index 708c87b88..7353bb119 100644
 --- a/arch/x86/kernel/process_32.c
@@ -868,35 +846,6 @@ index a708d225c..6d8c1fec7 100644
  	sched_clock_tick();
  
  	rq_lock(rq, &rf);
-diff --git a/kernel/sched/core.c.rej b/kernel/sched/core.c.rej
-new file mode 100644
-index 000000000..7b09a25eb
---- /dev/null
-+++ b/kernel/sched/core.c.rej
-@@ -0,0 +1,23 @@
-+--- kernel/sched/core.c
-++++ kernel/sched/core.c
-+@@ -4500,6 +4500,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
-+ 	p->se.prev_sum_exec_runtime	= 0;
-+ 	p->se.nr_migrations		= 0;
-+ 	p->se.vruntime			= 0;
-++#ifdef CONFIG_IPC_CLASSES
-++	p->ipcc				= IPC_CLASS_UNCLASSIFIED;
-++#endif
-+ 	INIT_LIST_HEAD(&p->se.group_node);
-+ 
-+ #ifdef CONFIG_FAIR_GROUP_SCHED
-+--- kernel/sched/core.c
-++++ kernel/sched/core.c
-+@@ -4502,6 +4502,8 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
-+ 	p->se.vruntime			= 0;
-+ #ifdef CONFIG_IPC_CLASSES
-+ 	p->ipcc				= IPC_CLASS_UNCLASSIFIED;
-++	p->ipcc_tmp			= IPC_CLASS_UNCLASSIFIED;
-++	p->ipcc_cntr			= 0;
-+ #endif
-+ 	INIT_LIST_HEAD(&p->se.group_node);
-+ 
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
 index d7a3c63a2..2c6740d9b 100644
 --- a/kernel/sched/fair.c

--- a/6.7/misc/0001-intel-thread-director.patch
+++ b/6.7/misc/0001-intel-thread-director.patch
@@ -1,3 +1,7 @@
+From	Ricardo Neri <>
+Subject	[PATCH v4 00/24] sched: Introduce classes of tasks for load balance
+Date	Mon, 12 Jun 2023 21:23:58 -0700
+ 
  arch/x86/include/asm/cpufeatures.h       |   2 +
  arch/x86/include/asm/disabled-features.h |   8 +-
  arch/x86/include/asm/hreset.h            |  30 +++


### PR DESCRIPTION
Intel thread director rebase for rc8 to prepare for 6.7 release. The patch was taken from the original kernel mail list again.