### PR TITLE
Adding patch for p-cores first on intel hybrid

### DIFF
--- a/6.7/misc/0001-intel-pcores-fair.patch
+++ b/6.7/misc/0001-intel-pcores-fair.patch
@@ -1,0 +1,75 @@
+From 68a15ef01803c252261ebb47d86dfc1f2c68ae1e Mon Sep 17 00:00:00 2001
+From: Tim Chen <tim.c.chen@linux.intel.com>
+Date: Fri, 6 Oct 2023 15:58:56 -0700
+Subject: [PATCH] sched/fair: Don't force smt balancing when CPU has spare
+ capacity
+
+Currently group_smt_balance is picked whenever there are more
+than two tasks on a core with two SMT.  However, the utilization
+of those tasks may be low and do not warrant a task
+migration to a CPU of lower priority.
+
+Adjust sched group clssification and sibling_imbalance()
+to reflect this consideration.  Use sibling_imbalance() to
+compute imbalance in calculate_imbalance() for the group_smt_balance
+case.
+
+Signed-off-by: Tim Chen <tim.c.chen@linux.intel.com>
+
+---
+ kernel/sched/fair.c | 23 +++++++++++------------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
+index ef7490c4b8b4..7dd7c2d2367a 100644
+--- a/kernel/sched/fair.c
++++ b/kernel/sched/fair.c
+@@ -9460,14 +9460,15 @@ group_type group_classify(unsigned int imbalance_pct,
+ 	if (sgs->group_asym_packing)
+ 		return group_asym_packing;
+ 
+-	if (sgs->group_smt_balance)
+-		return group_smt_balance;
+-
+ 	if (sgs->group_misfit_task_load)
+ 		return group_misfit_task;
+ 
+-	if (!group_has_capacity(imbalance_pct, sgs))
+-		return group_fully_busy;
++	if (!group_has_capacity(imbalance_pct, sgs)) {
++		if (sgs->group_smt_balance)
++			return group_smt_balance;
++		else
++			return group_fully_busy;
++	}
+ 
+ 	return group_has_spare;
+ }
+@@ -9573,6 +9574,11 @@ static inline long sibling_imbalance(struct lb_env *env,
+ 	if (env->idle == CPU_NOT_IDLE || !busiest->sum_nr_running)
+ 		return 0;
+ 
++	/* Do not pull tasks off preferred group with spare capacity */
++	if (busiest->group_type == group_has_spare &&
++	    sched_asym_prefer(sds->busiest->asym_prefer_cpu, env->dst_cpu))
++		return 0;
++
+ 	ncores_busiest = sds->busiest->cores;
+ 	ncores_local = sds->local->cores;
+ 
+@@ -10411,13 +10417,6 @@ static inline void calculate_imbalance(struct lb_env *env, struct sd_lb_stats *s
+ 		return;
+ 	}
+ 
+-	if (busiest->group_type == group_smt_balance) {
+-		/* Reduce number of tasks sharing CPU capacity */
+-		env->migration_type = migrate_task;
+-		env->imbalance = 1;
+-		return;
+-	}
+-
+ 	if (busiest->group_type == group_imbalanced) {
+ 		/*
+ 		 * In the group_imb case we cannot rely on group-wide averages
+-- 
+2.32.0


### PR DESCRIPTION
Adding patch from https://lore.kernel.org/lkml/b2b9121c6d2003b45f7fde6a97bb479a1ed634c7.camel@linux.intel.com/ which makes p-cores as a preference.