### PR TITLE
6.9: Updated RT to v6.9-rc6-rt3, based on Cachy patchset

### DIFF
--- a/6.9/misc/0001-rt.patch
+++ b/6.9/misc/0001-rt.patch
@@ -1,79 +1,28 @@
-From 8e89a5fb8df3f8833d307552aca9552ab77eb63f Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Mon, 15 Apr 2024 11:22:14 +0200
-Subject: [PATCH] rt
-
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
----
- arch/x86/Kconfig                              |   3 +
- arch/x86/include/asm/thread_info.h            |   6 +-
- drivers/acpi/processor_idle.c                 |   2 +-
- drivers/block/zram/zram_drv.c                 |  37 +
- drivers/block/zram/zram_drv.h                 |   3 +
- drivers/gpu/drm/i915/Kconfig                  |   1 -
- drivers/gpu/drm/i915/display/intel_crtc.c     |   9 +-
- drivers/gpu/drm/i915/display/intel_vblank.c   |  44 +-
- drivers/gpu/drm/i915/gt/intel_breadcrumbs.c   |   5 +-
- .../drm/i915/gt/intel_execlists_submission.c  |  17 +-
- drivers/gpu/drm/i915/gt/uc/intel_guc.h        |   2 +-
- drivers/gpu/drm/i915/i915_request.c           |   2 -
- drivers/gpu/drm/i915/i915_trace.h             |   6 +-
- drivers/gpu/drm/i915/i915_utils.h             |   2 +-
- drivers/gpu/drm/ttm/tests/ttm_bo_test.c       |   8 +-
- drivers/tty/serial/8250/8250_core.c           |  51 +-
- drivers/tty/serial/8250/8250_port.c           | 157 +++-
- drivers/tty/serial/amba-pl011.c               |   2 +-
- drivers/tty/serial/serial_core.c              |  16 +-
- drivers/tty/tty_io.c                          |   9 +-
- fs/proc/consoles.c                            |  14 +-
- include/linux/bottom_half.h                   |   2 +
- include/linux/console.h                       | 172 +++-
- include/linux/entry-common.h                  |   2 +-
- include/linux/entry-kvm.h                     |   2 +-
- include/linux/interrupt.h                     |  29 +
- include/linux/netdevice.h                     |   1 +
- include/linux/perf_event.h                    |   4 +-
- include/linux/printk.h                        |  32 +-
- include/linux/sched.h                         |  13 +-
- include/linux/sched/idle.h                    |   8 +-
- include/linux/serial_8250.h                   |   6 +
- include/linux/serial_core.h                   | 116 ++-
- include/linux/thread_info.h                   |  24 +
- include/linux/trace_events.h                  |   8 +-
- kernel/Kconfig.preempt                        |  19 +-
- kernel/entry/common.c                         |   4 +-
- kernel/entry/kvm.c                            |   2 +-
- kernel/events/core.c                          |  98 +--
- kernel/ksysfs.c                               |  12 +
- kernel/locking/lockdep.c                      |  91 ++-
- kernel/panic.c                                |   9 +
- kernel/printk/internal.h                      | 110 ++-
- kernel/printk/nbcon.c                         | 743 +++++++++++++++++-
- kernel/printk/printk.c                        | 669 +++++++++++++---
- kernel/printk/printk_ringbuffer.h             |   2 +
- kernel/printk/printk_safe.c                   |  12 +
- kernel/rcu/rcutorture.c                       |   6 +
- kernel/rcu/tree_exp.h                         |   7 +
- kernel/rcu/tree_stall.h                       |   9 +
- kernel/sched/core.c                           |  65 +-
- kernel/sched/debug.c                          |  19 +
- kernel/sched/fair.c                           |  46 +-
- kernel/sched/features.h                       |   2 +
- kernel/sched/idle.c                           |   3 +-
- kernel/sched/rt.c                             |   5 +-
- kernel/sched/sched.h                          |   1 +
- kernel/softirq.c                              |  95 ++-
- kernel/time/hrtimer.c                         |   4 +-
- kernel/time/tick-sched.c                      |   2 +-
- kernel/time/timer.c                           |  11 +-
- kernel/trace/trace.c                          |   2 +
- kernel/trace/trace_output.c                   |  16 +-
- net/core/dev.c                                | 217 +++--
- net/core/skbuff.c                             |   4 +-
- 65 files changed, 2709 insertions(+), 391 deletions(-)
-
+diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
+index cae81c5c8..fe35ab745 100644
+--- a/Documentation/admin-guide/kernel-parameters.txt
++++ b/Documentation/admin-guide/kernel-parameters.txt
+@@ -6560,6 +6560,18 @@
+ 			Force threading of all interrupt handlers except those
+ 			marked explicitly IRQF_NO_THREAD.
+ 
++	threadprintk	[KNL]
++			Force threaded printing of all legacy consoles. Be
++			aware that with this option, the shutdown, reboot, and
++			panic messages may not be printed on the legacy
++			consoles. Also, earlycon/earlyprintk printing will be
++			delayed until a regular console or the kthread is
++			available.
++
++			Users can view /proc/consoles to see if their console
++			driver is legacy or not. Non-legacy (NBCON) console
++			drivers are already threaded and are shown with 'N'.
++
+ 	topology=	[S390,EARLY]
+ 			Format: {off | on}
+ 			Specify if the kernel should make use of the cpu
 diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index 4474bf32d..0afbf8b93 100644
+index 928820e61..a10b985b8 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
 @@ -28,6 +28,7 @@ config X86_64
@@ -84,7 +33,7 @@ index 4474bf32d..0afbf8b93 100644
  	select HAVE_ARCH_SOFT_DIRTY
  	select MODULES_USE_ELF_RELA
  	select NEED_DMA_MAP_STATE
-@@ -119,6 +120,7 @@ config X86
+@@ -120,6 +121,7 @@ config X86
  	select ARCH_USES_CFI_TRAPS		if X86_64 && CFI_CLANG
  	select ARCH_SUPPORTS_LTO_CLANG
  	select ARCH_SUPPORTS_LTO_CLANG_THIN
@@ -92,7 +41,7 @@ index 4474bf32d..0afbf8b93 100644
  	select ARCH_USE_BUILTIN_BSWAP
  	select ARCH_USE_CMPXCHG_LOCKREF		if X86_CMPXCHG64
  	select ARCH_USE_MEMTEST
-@@ -276,6 +278,7 @@ config X86
+@@ -277,6 +279,7 @@ config X86
  	select HAVE_STATIC_CALL
  	select HAVE_STATIC_CALL_INLINE		if HAVE_OBJTOOL
  	select HAVE_PREEMPT_DYNAMIC_CALL
@@ -259,6 +208,21 @@ index 25593f6aa..22b800045 100644
  
  	if (intel_vgpu_active(dev_priv))
  		goto out;
+diff --git a/drivers/gpu/drm/i915/display/intel_display_trace.h b/drivers/gpu/drm/i915/display/intel_display_trace.h
+index 7862e7cef..9b8327410 100644
+--- a/drivers/gpu/drm/i915/display/intel_display_trace.h
++++ b/drivers/gpu/drm/i915/display/intel_display_trace.h
+@@ -9,6 +9,10 @@
+ #if !defined(__INTEL_DISPLAY_TRACE_H__) || defined(TRACE_HEADER_MULTI_READ)
+ #define __INTEL_DISPLAY_TRACE_H__
+ 
++#if defined(CONFIG_PREEMPT_RT) && !defined(NOTRACE)
++#define NOTRACE
++#endif
++
+ #include <linux/string_helpers.h>
+ #include <linux/types.h>
+ #include <linux/tracepoint.h>
 diff --git a/drivers/gpu/drm/i915/display/intel_vblank.c b/drivers/gpu/drm/i915/display/intel_vblank.c
 index baf7354cb..d639b51a4 100644
 --- a/drivers/gpu/drm/i915/display/intel_vblank.c
@@ -464,29 +428,20 @@ index 519e096c6..466b5ee8e 100644
  
  	/*
 diff --git a/drivers/gpu/drm/i915/i915_trace.h b/drivers/gpu/drm/i915/i915_trace.h
-index ce1cbee1b..3c51620d0 100644
+index ce1cbee1b..247e7d944 100644
 --- a/drivers/gpu/drm/i915/i915_trace.h
 +++ b/drivers/gpu/drm/i915/i915_trace.h
 @@ -6,6 +6,10 @@
  #if !defined(_I915_TRACE_H_) || defined(TRACE_HEADER_MULTI_READ)
  #define _I915_TRACE_H_
  
-+#ifdef CONFIG_PREEMPT_RT
++#if defined(CONFIG_PREEMPT_RT) && !defined(NOTRACE)
 +#define NOTRACE
 +#endif
 +
  #include <linux/stringify.h>
  #include <linux/types.h>
  #include <linux/tracepoint.h>
-@@ -322,7 +326,7 @@ DEFINE_EVENT(i915_request, i915_request_add,
- 	     TP_ARGS(rq)
- );
- 
--#if defined(CONFIG_DRM_I915_LOW_LEVEL_TRACEPOINTS)
-+#if defined(CONFIG_DRM_I915_LOW_LEVEL_TRACEPOINTS) && !defined(NOTRACE)
- DEFINE_EVENT(i915_request, i915_request_guc_submit,
- 	     TP_PROTO(struct i915_request *rq),
- 	     TP_ARGS(rq)
 diff --git a/drivers/gpu/drm/i915/i915_utils.h b/drivers/gpu/drm/i915/i915_utils.h
 index b45ef0560..7c6077d2d 100644
 --- a/drivers/gpu/drm/i915/i915_utils.h
@@ -526,6 +481,34 @@ index 1f8a4f8ad..9cc367a79 100644
  
  	/* The deadlock will be caught by WW mutex, don't warn about it */
  	lock_release(&bo2->base.resv->lock.base.dep_map, 1);
+diff --git a/drivers/net/ethernet/chelsio/cxgb4/sge.c b/drivers/net/ethernet/chelsio/cxgb4/sge.c
+index 49d5808b7..de52bcb88 100644
+--- a/drivers/net/ethernet/chelsio/cxgb4/sge.c
++++ b/drivers/net/ethernet/chelsio/cxgb4/sge.c
+@@ -2670,12 +2670,12 @@ int cxgb4_selftest_lb_pkt(struct net_device *netdev)
+ 	lb->loopback = 1;
+ 
+ 	q = &adap->sge.ethtxq[pi->first_qset];
+-	__netif_tx_lock(q->txq, smp_processor_id());
++	__netif_tx_lock_bh(q->txq);
+ 
+ 	reclaim_completed_tx(adap, &q->q, -1, true);
+ 	credits = txq_avail(&q->q) - ndesc;
+ 	if (unlikely(credits < 0)) {
+-		__netif_tx_unlock(q->txq);
++		__netif_tx_unlock_bh(q->txq);
+ 		return -ENOMEM;
+ 	}
+ 
+@@ -2710,7 +2710,7 @@ int cxgb4_selftest_lb_pkt(struct net_device *netdev)
+ 	init_completion(&lb->completion);
+ 	txq_advance(&q->q, ndesc);
+ 	cxgb4_ring_tx_db(adap, &q->q, ndesc);
+-	__netif_tx_unlock(q->txq);
++	__netif_tx_unlock_bh(q->txq);
+ 
+ 	/* wait for the pkt to return */
+ 	ret = wait_for_completion_timeout(&lb->completion, 10 * HZ);
 diff --git a/drivers/tty/serial/8250/8250_core.c b/drivers/tty/serial/8250/8250_core.c
 index b62ad9006..4e4f5501d 100644
 --- a/drivers/tty/serial/8250/8250_core.c
@@ -862,10 +845,10 @@ index 2fa3fb30d..7618a5783 100644
  	}
  
 diff --git a/drivers/tty/serial/serial_core.c b/drivers/tty/serial/serial_core.c
-index ff85ebd3a..dd88f3034 100644
+index c476d8843..bb6d82ae8 100644
 --- a/drivers/tty/serial/serial_core.c
 +++ b/drivers/tty/serial/serial_core.c
-@@ -3157,8 +3157,15 @@ static int serial_core_add_one_port(struct uart_driver *drv, struct uart_port *u
+@@ -3172,8 +3172,15 @@ static int serial_core_add_one_port(struct uart_driver *drv, struct uart_port *u
  	state->uart_port = uport;
  	uport->state = state;
  
@@ -882,7 +865,7 @@ index ff85ebd3a..dd88f3034 100644
  	uport->minor = drv->tty_driver->minor_start + uport->line;
  	uport->name = kasprintf(GFP_KERNEL, "%s%d", drv->dev_name,
  				drv->tty_driver->name_base + uport->line);
-@@ -3167,13 +3174,6 @@ static int serial_core_add_one_port(struct uart_driver *drv, struct uart_port *u
+@@ -3182,13 +3189,6 @@ static int serial_core_add_one_port(struct uart_driver *drv, struct uart_port *u
  		goto out;
  	}
  
@@ -4991,10 +4974,10 @@ index 8d5d98a58..b462333db 100644
  }
  late_initcall(sched_init_debug);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 03be0d133..4f62fd779 100644
+index 95bade948..851c22040 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
-@@ -975,8 +975,10 @@ static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
+@@ -994,8 +994,10 @@ static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
   * XXX: strictly: vd_i += N*r_i/w_i such that: vd_i > ve_i
   * this is probably good enough.
   */
@@ -5006,7 +4989,7 @@ index 03be0d133..4f62fd779 100644
  	if ((s64)(se->vruntime - se->deadline) < 0)
  		return;
  
-@@ -995,10 +997,19 @@ static void update_deadline(struct cfs_rq *cfs_rq, struct sched_entity *se)
+@@ -1014,10 +1016,19 @@ static void update_deadline(struct cfs_rq *cfs_rq, struct sched_entity *se)
  	/*
  	 * The task has consumed its request, reschedule.
  	 */
@@ -5029,7 +5012,7 @@ index 03be0d133..4f62fd779 100644
  }
  
  #include "pelt.h"
-@@ -1153,7 +1164,7 @@ s64 update_curr_common(struct rq *rq)
+@@ -1172,7 +1183,7 @@ s64 update_curr_common(struct rq *rq)
  /*
   * Update the current task's runtime statistics.
   */
@@ -5038,7 +5021,7 @@ index 03be0d133..4f62fd779 100644
  {
  	struct sched_entity *curr = cfs_rq->curr;
  	s64 delta_exec;
-@@ -1166,7 +1177,7 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1185,7 +1196,7 @@ static void update_curr(struct cfs_rq *cfs_rq)
  		return;
  
  	curr->vruntime += calc_delta_fair(delta_exec, curr);
@@ -5047,7 +5030,7 @@ index 03be0d133..4f62fd779 100644
  	update_min_vruntime(cfs_rq);
  
  	if (entity_is_task(curr))
-@@ -1175,6 +1186,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1194,6 +1205,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	account_cfs_rq_runtime(cfs_rq, delta_exec);
  }
  
@@ -5059,7 +5042,7 @@ index 03be0d133..4f62fd779 100644
  static void update_curr_fair(struct rq *rq)
  {
  	update_curr(cfs_rq_of(&rq->curr->se));
-@@ -5499,7 +5515,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
+@@ -5518,7 +5534,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
  	/*
  	 * Update run-time statistics of the 'current'.
  	 */
@@ -5068,7 +5051,7 @@ index 03be0d133..4f62fd779 100644
  
  	/*
  	 * Ensure that runnable average is periodically updated.
-@@ -5513,7 +5529,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
+@@ -5532,7 +5548,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
  	 * validating it and just reschedule.
  	 */
  	if (queued) {
@@ -5077,7 +5060,7 @@ index 03be0d133..4f62fd779 100644
  		return;
  	}
  	/*
-@@ -5659,7 +5675,7 @@ static void __account_cfs_rq_runtime(struct cfs_rq *cfs_rq, u64 delta_exec)
+@@ -5678,7 +5694,7 @@ static void __account_cfs_rq_runtime(struct cfs_rq *cfs_rq, u64 delta_exec)
  	 * hierarchy can be throttled
  	 */
  	if (!assign_cfs_rq_runtime(cfs_rq) && likely(cfs_rq->curr))
@@ -5086,7 +5069,7 @@ index 03be0d133..4f62fd779 100644
  }
  
  static __always_inline
-@@ -5919,7 +5935,7 @@ void unthrottle_cfs_rq(struct cfs_rq *cfs_rq)
+@@ -5938,7 +5954,7 @@ void unthrottle_cfs_rq(struct cfs_rq *cfs_rq)
  
  	/* Determine whether we need to wake up potentially idle CPU: */
  	if (rq->curr == rq->idle && rq->cfs.nr_running)
@@ -5095,7 +5078,7 @@ index 03be0d133..4f62fd779 100644
  }
  
  #ifdef CONFIG_SMP
-@@ -6634,7 +6650,7 @@ static void hrtick_start_fair(struct rq *rq, struct task_struct *p)
+@@ -6653,7 +6669,7 @@ static void hrtick_start_fair(struct rq *rq, struct task_struct *p)
  
  		if (delta < 0) {
  			if (task_current(rq, p))
@@ -5104,7 +5087,7 @@ index 03be0d133..4f62fd779 100644
  			return;
  		}
  		hrtick_start(rq, delta);
-@@ -8310,7 +8326,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8329,7 +8345,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	 * prevents us from potentially nominating it as a false LAST_BUDDY
  	 * below.
  	 */
@@ -5113,7 +5096,7 @@ index 03be0d133..4f62fd779 100644
  		return;
  
  	/* Idle tasks are by definition preempted by non-idle tasks. */
-@@ -8352,7 +8368,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8371,7 +8387,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	return;
  
  preempt:
@@ -5122,7 +5105,7 @@ index 03be0d133..4f62fd779 100644
  }
  
  #ifdef CONFIG_SMP
-@@ -12498,7 +12514,7 @@ static inline void task_tick_core(struct rq *rq, struct task_struct *curr)
+@@ -12517,7 +12533,7 @@ static inline void task_tick_core(struct rq *rq, struct task_struct *curr)
  	 */
  	if (rq->core->core_forceidle_count && rq->cfs.nr_running == 1 &&
  	    __entity_slice_used(&curr->se, MIN_NR_TASKS_DURING_FORCEIDLE))
@@ -5131,7 +5114,7 @@ index 03be0d133..4f62fd779 100644
  }
  
  /*
-@@ -12663,7 +12679,7 @@ prio_changed_fair(struct rq *rq, struct task_struct *p, int oldprio)
+@@ -12682,7 +12698,7 @@ prio_changed_fair(struct rq *rq, struct task_struct *p, int oldprio)
  	 */
  	if (task_current(rq, p)) {
  		if (p->prio > oldprio)
@@ -5182,10 +5165,10 @@ index 3261b067b..8771140e0 100644
  		rd->rto_cpu = -1;
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index d22426792..044f08f3e 100644
+index f7d2fb6cc..e29c28a34 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -2463,6 +2463,7 @@ extern void init_sched_fair_class(void);
+@@ -2465,6 +2465,7 @@ extern void init_sched_fair_class(void);
  extern void reweight_task(struct task_struct *p, int prio);
  
  extern void resched_curr(struct rq *rq);
@@ -5441,7 +5424,7 @@ index d8b302d01..4f58a196e 100644
  		need_resched = 'p';
  		break;
 diff --git a/net/core/dev.c b/net/core/dev.c
-index 984ff8b9d..b2d5dd70f 100644
+index 331848eca..1180675fd 100644
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
 @@ -78,6 +78,7 @@
@@ -5523,7 +5506,7 @@ index 984ff8b9d..b2d5dd70f 100644
  		spin_unlock_irq(&sd->input_pkt_queue.lock);
  	else if (!IS_ENABLED(CONFIG_PREEMPT_RT))
  		local_irq_enable();
-@@ -4404,6 +4430,7 @@ EXPORT_SYMBOL(__dev_direct_xmit);
+@@ -4410,6 +4436,7 @@ EXPORT_SYMBOL(__dev_direct_xmit);
  /*************************************************************************
   *			Receiver routines
   *************************************************************************/
@@ -5531,7 +5514,7 @@ index 984ff8b9d..b2d5dd70f 100644
  
  unsigned int sysctl_skb_defer_max __read_mostly = 64;
  int weight_p __read_mostly = 64;           /* old backlog weight */
-@@ -4427,18 +4454,16 @@ static inline void ____napi_schedule(struct softnet_data *sd,
+@@ -4433,18 +4460,16 @@ static inline void ____napi_schedule(struct softnet_data *sd,
  		 */
  		thread = READ_ONCE(napi->thread);
  		if (thread) {
@@ -5555,7 +5538,7 @@ index 984ff8b9d..b2d5dd70f 100644
  	list_add_tail(&napi->poll_list, &sd->poll_list);
  	WRITE_ONCE(napi->list_owner, smp_processor_id());
  	/* If not called from net_rx_action()
-@@ -4678,6 +4703,11 @@ static void napi_schedule_rps(struct softnet_data *sd)
+@@ -4684,6 +4709,11 @@ static void napi_schedule_rps(struct softnet_data *sd)
  
  #ifdef CONFIG_RPS
  	if (sd != mysd) {
@@ -5567,7 +5550,7 @@ index 984ff8b9d..b2d5dd70f 100644
  		sd->rps_ipi_next = mysd->rps_ipi_list;
  		mysd->rps_ipi_list = sd;
  
-@@ -4692,6 +4722,23 @@ static void napi_schedule_rps(struct softnet_data *sd)
+@@ -4698,6 +4728,23 @@ static void napi_schedule_rps(struct softnet_data *sd)
  	__napi_schedule_irqoff(&mysd->backlog);
  }
  
@@ -5591,7 +5574,7 @@ index 984ff8b9d..b2d5dd70f 100644
  #ifdef CONFIG_NET_FLOW_LIMIT
  int netdev_flow_limit_table_len __read_mostly = (1 << 12);
  #endif
-@@ -4747,7 +4794,7 @@ static int enqueue_to_backlog(struct sk_buff *skb, int cpu,
+@@ -4753,7 +4800,7 @@ static int enqueue_to_backlog(struct sk_buff *skb, int cpu,
  	reason = SKB_DROP_REASON_NOT_SPECIFIED;
  	sd = &per_cpu(softnet_data, cpu);
  
@@ -5600,7 +5583,7 @@ index 984ff8b9d..b2d5dd70f 100644
  	if (!netif_running(skb->dev))
  		goto drop;
  	qlen = skb_queue_len(&sd->input_pkt_queue);
-@@ -4757,7 +4804,7 @@ static int enqueue_to_backlog(struct sk_buff *skb, int cpu,
+@@ -4763,7 +4810,7 @@ static int enqueue_to_backlog(struct sk_buff *skb, int cpu,
  enqueue:
  			__skb_queue_tail(&sd->input_pkt_queue, skb);
  			input_queue_tail_incr_save(sd, qtail);
@@ -5609,7 +5592,7 @@ index 984ff8b9d..b2d5dd70f 100644
  			return NET_RX_SUCCESS;
  		}
  
-@@ -4772,7 +4819,7 @@ static int enqueue_to_backlog(struct sk_buff *skb, int cpu,
+@@ -4778,7 +4825,7 @@ static int enqueue_to_backlog(struct sk_buff *skb, int cpu,
  
  drop:
  	sd->dropped++;
@@ -5618,7 +5601,7 @@ index 984ff8b9d..b2d5dd70f 100644
  
  	dev_core_stats_rx_dropped_inc(skb->dev);
  	kfree_skb_reason(skb, reason);
-@@ -5838,7 +5885,7 @@ static void flush_backlog(struct work_struct *work)
+@@ -5844,7 +5891,7 @@ static void flush_backlog(struct work_struct *work)
  	local_bh_disable();
  	sd = this_cpu_ptr(&softnet_data);
  
@@ -5627,7 +5610,7 @@ index 984ff8b9d..b2d5dd70f 100644
  	skb_queue_walk_safe(&sd->input_pkt_queue, skb, tmp) {
  		if (skb->dev->reg_state == NETREG_UNREGISTERING) {
  			__skb_unlink(skb, &sd->input_pkt_queue);
-@@ -5846,7 +5893,7 @@ static void flush_backlog(struct work_struct *work)
+@@ -5852,7 +5899,7 @@ static void flush_backlog(struct work_struct *work)
  			input_queue_head_incr(sd);
  		}
  	}
@@ -5636,7 +5619,7 @@ index 984ff8b9d..b2d5dd70f 100644
  
  	skb_queue_walk_safe(&sd->process_queue, skb, tmp) {
  		if (skb->dev->reg_state == NETREG_UNREGISTERING) {
-@@ -5864,14 +5911,14 @@ static bool flush_required(int cpu)
+@@ -5870,14 +5917,14 @@ static bool flush_required(int cpu)
  	struct softnet_data *sd = &per_cpu(softnet_data, cpu);
  	bool do_flush;
  
@@ -5653,7 +5636,7 @@ index 984ff8b9d..b2d5dd70f 100644
  
  	return do_flush;
  #endif
-@@ -5937,7 +5984,7 @@ static void net_rps_action_and_irq_enable(struct softnet_data *sd)
+@@ -5943,7 +5990,7 @@ static void net_rps_action_and_irq_enable(struct softnet_data *sd)
  #ifdef CONFIG_RPS
  	struct softnet_data *remsd = sd->rps_ipi_list;
  
@@ -5662,7 +5645,7 @@ index 984ff8b9d..b2d5dd70f 100644
  		sd->rps_ipi_list = NULL;
  
  		local_irq_enable();
-@@ -5952,7 +5999,7 @@ static void net_rps_action_and_irq_enable(struct softnet_data *sd)
+@@ -5958,7 +6005,7 @@ static void net_rps_action_and_irq_enable(struct softnet_data *sd)
  static bool sd_has_rps_ipi_waiting(struct softnet_data *sd)
  {
  #ifdef CONFIG_RPS
@@ -5671,7 +5654,7 @@ index 984ff8b9d..b2d5dd70f 100644
  #else
  	return false;
  #endif
-@@ -5986,7 +6033,7 @@ static int process_backlog(struct napi_struct *napi, int quota)
+@@ -5992,7 +6039,7 @@ static int process_backlog(struct napi_struct *napi, int quota)
  
  		}
  
@@ -5680,7 +5663,7 @@ index 984ff8b9d..b2d5dd70f 100644
  		if (skb_queue_empty(&sd->input_pkt_queue)) {
  			/*
  			 * Inline a custom version of __napi_complete().
-@@ -5996,13 +6043,13 @@ static int process_backlog(struct napi_struct *napi, int quota)
+@@ -6002,13 +6049,13 @@ static int process_backlog(struct napi_struct *napi, int quota)
  			 * We can use a plain write instead of clear_bit(),
  			 * and we dont need an smp_mb() memory barrier.
  			 */
@@ -5696,7 +5679,7 @@ index 984ff8b9d..b2d5dd70f 100644
  	}
  
  	return work;
-@@ -6710,8 +6757,6 @@ static int napi_poll(struct napi_struct *n, struct list_head *repoll)
+@@ -6716,8 +6763,6 @@ static int napi_poll(struct napi_struct *n, struct list_head *repoll)
  
  static int napi_thread_wait(struct napi_struct *napi)
  {
@@ -5705,7 +5688,7 @@ index 984ff8b9d..b2d5dd70f 100644
  	set_current_state(TASK_INTERRUPTIBLE);
  
  	while (!kthread_should_stop()) {
-@@ -6720,15 +6765,13 @@ static int napi_thread_wait(struct napi_struct *napi)
+@@ -6726,15 +6771,13 @@ static int napi_thread_wait(struct napi_struct *napi)
  		 * Testing SCHED bit is not enough because SCHED bit might be
  		 * set by some other busy poll thread or by napi_disable().
  		 */
@@ -5722,7 +5705,7 @@ index 984ff8b9d..b2d5dd70f 100644
  		set_current_state(TASK_INTERRUPTIBLE);
  	}
  	__set_current_state(TASK_RUNNING);
-@@ -6736,43 +6779,48 @@ static int napi_thread_wait(struct napi_struct *napi)
+@@ -6742,43 +6785,48 @@ static int napi_thread_wait(struct napi_struct *napi)
  	return -1;
  }
  
@@ -5798,7 +5781,7 @@ index 984ff8b9d..b2d5dd70f 100644
  	return 0;
  }
  
-@@ -11373,7 +11421,7 @@ static int dev_cpu_dead(unsigned int oldcpu)
+@@ -11379,7 +11427,7 @@ static int dev_cpu_dead(unsigned int oldcpu)
  
  		list_del_init(&napi->poll_list);
  		if (napi->poll == process_backlog)
@@ -5807,7 +5790,7 @@ index 984ff8b9d..b2d5dd70f 100644
  		else
  			____napi_schedule(sd, napi);
  	}
-@@ -11381,12 +11429,14 @@ static int dev_cpu_dead(unsigned int oldcpu)
+@@ -11387,12 +11435,14 @@ static int dev_cpu_dead(unsigned int oldcpu)
  	raise_softirq_irqoff(NET_TX_SOFTIRQ);
  	local_irq_enable();
  
@@ -5826,7 +5809,7 @@ index 984ff8b9d..b2d5dd70f 100644
  
  	/* Process offline CPU's input_pkt_queue */
  	while ((skb = __skb_dequeue(&oldsd->process_queue))) {
-@@ -11725,6 +11775,38 @@ static int net_page_pool_create(int cpuid)
+@@ -11731,6 +11781,38 @@ static int net_page_pool_create(int cpuid)
  	return 0;
  }
  
@@ -5865,7 +5848,7 @@ index 984ff8b9d..b2d5dd70f 100644
  /*
   *       This is called single threaded during boot, so no need
   *       to take the rtnl semaphore.
-@@ -11776,10 +11858,13 @@ static int __init net_dev_init(void)
+@@ -11782,10 +11864,13 @@ static int __init net_dev_init(void)
  		init_gro_hash(&sd->backlog);
  		sd->backlog.poll = process_backlog;
  		sd->backlog.weight = weight_p;
@@ -5894,6 +5877,3 @@ index b99127712..17617c29b 100644
  }
  
  static void skb_splice_csum_page(struct sk_buff *skb, struct page *page,
--- 
-2.44.0.325.g11c821f2f2
-


### PR DESCRIPTION
Using v6.9-rc6-rt3 as a base
removed EXPERT requirement for PREEMPT_RT
removed local version
removed ARM changes
rebased on CachyOS patchset