### PR TITLE
6.8: Updated NTsync5 to v4 version

### DIFF
--- a/6.8/0008-ntsync.patch
+++ b/6.8/0008-ntsync.patch
@@ -1,32 +1,34 @@
-From 194a4fc590161a73bb2b3f39653074d006c790d0 Mon Sep 17 00:00:00 2001
-From: Peter Jung <admin@ptr1337.dev>
-Date: Sat, 27 Apr 2024 20:14:52 +0200
-Subject: [PATCH 8/9] ntsync
+From 7c3ed5efabc7ef6a13044f64f2b640a56246383b Mon Sep 17 00:00:00 2001
+From: artewar67 <artewar67@yandex.ru>
+Date: Mon, 6 May 2024 21:35:12 +0500
+Subject: [PATCH] misc: Update ntsync5 to v4
 
-Signed-off-by: Peter Jung <admin@ptr1337.dev>
+Signed-off-by: artewar67 <artewar67@yandex.ru>
 ---
  Documentation/userspace-api/index.rst         |    1 +
  .../userspace-api/ioctl/ioctl-number.rst      |    2 +
  Documentation/userspace-api/ntsync.rst        |  399 +++++
  MAINTAINERS                                   |    9 +
- drivers/misc/Kconfig                          |    9 +
+ drivers/misc/Kconfig                          |   11 +
  drivers/misc/Makefile                         |    1 +
- drivers/misc/ntsync.c                         | 1146 ++++++++++++++
+ drivers/misc/ntsync.c                         | 1166 ++++++++++++++
  include/uapi/linux/ntsync.h                   |   62 +
  tools/testing/selftests/Makefile              |    1 +
- .../testing/selftests/drivers/ntsync/Makefile |    8 +
+ .../selftests/drivers/ntsync/.gitignore       |    1 +
+ .../testing/selftests/drivers/ntsync/Makefile |    7 +
  tools/testing/selftests/drivers/ntsync/config |    1 +
  .../testing/selftests/drivers/ntsync/ntsync.c | 1407 +++++++++++++++++
- 12 files changed, 3046 insertions(+)
+ 13 files changed, 3068 insertions(+)
  create mode 100644 Documentation/userspace-api/ntsync.rst
  create mode 100644 drivers/misc/ntsync.c
  create mode 100644 include/uapi/linux/ntsync.h
+ create mode 100644 tools/testing/selftests/drivers/ntsync/.gitignore
  create mode 100644 tools/testing/selftests/drivers/ntsync/Makefile
  create mode 100644 tools/testing/selftests/drivers/ntsync/config
  create mode 100644 tools/testing/selftests/drivers/ntsync/ntsync.c
 
 diff --git a/Documentation/userspace-api/index.rst b/Documentation/userspace-api/index.rst
-index 09f61bd2ac2e..f5a72ed27def 100644
+index 09f61bd2a..f5a72ed27 100644
 --- a/Documentation/userspace-api/index.rst
 +++ b/Documentation/userspace-api/index.rst
 @@ -34,6 +34,7 @@ place where this information is gathered.
@@ -34,11 +36,11 @@ index 09f61bd2ac2e..f5a72ed27def 100644
     isapnp
     dcdbas
 +   ntsync
- 
+
  .. only::  subproject and html
- 
+
 diff --git a/Documentation/userspace-api/ioctl/ioctl-number.rst b/Documentation/userspace-api/ioctl/ioctl-number.rst
-index 457e16f06e04..2f5c6994f042 100644
+index 457e16f06..2f5c6994f 100644
 --- a/Documentation/userspace-api/ioctl/ioctl-number.rst
 +++ b/Documentation/userspace-api/ioctl/ioctl-number.rst
 @@ -173,6 +173,8 @@ Code  Seq#    Include File                                           Comments
@@ -52,7 +54,7 @@ index 457e16f06e04..2f5c6994f042 100644
  'P'   60-6F  sound/sscape_ioctl.h                                    conflict!
 diff --git a/Documentation/userspace-api/ntsync.rst b/Documentation/userspace-api/ntsync.rst
 new file mode 100644
-index 000000000000..202c2350d3af
+index 000000000..202c2350d
 --- /dev/null
 +++ b/Documentation/userspace-api/ntsync.rst
 @@ -0,0 +1,399 @@
@@ -456,13 +458,13 @@ index 000000000000..202c2350d3af
 +  ``objs`` and in ``alert``. If this is attempted, the function fails
 +  with ``EINVAL``.
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 1aabf1c15bb3..91af49091a3c 100644
+index 1aabf1c15..91af49091 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -15609,6 +15609,15 @@ T:	git https://github.com/Paragon-Software-Group/linux-ntfs3.git
  F:	Documentation/filesystems/ntfs3.rst
  F:	fs/ntfs3/
- 
+
 +NTSYNC SYNCHRONIZATION PRIMITIVE DRIVER
 +M:	Elizabeth Figura <zfigura@codeweavers.com>
 +L:	wine-devel@winehq.org
@@ -476,13 +478,13 @@ index 1aabf1c15bb3..91af49091a3c 100644
  M:	Finn Thain <fthain@linux-m68k.org>
  L:	linux-m68k@lists.linux-m68k.org
 diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
-index 4fb291f0bf7c..bdd8a71bd853 100644
+index 4fb291f0b..801ed229e 100644
 --- a/drivers/misc/Kconfig
 +++ b/drivers/misc/Kconfig
-@@ -504,6 +504,15 @@ config OPEN_DICE
- 	  measured boot flow. Userspace can use CDIs for remote attestation
- 	  and sealing.
- 
+@@ -506,6 +506,17 @@ config OPEN_DICE
+
+ 	  If unsure, say N.
+
 +config NTSYNC
 +	tristate "NT synchronization primitive emulation"
 +	help
@@ -492,11 +494,13 @@ index 4fb291f0bf7c..bdd8a71bd853 100644
 +	  To compile this driver as a module, choose M here: the
 +	  module will be called ntsync.
 +
- 	  If unsure, say N.
- 
++	  If unsure, say N.
++
  config VCPU_STALL_DETECTOR
+ 	tristate "Guest vCPU stall detector"
+ 	depends on OF && HAS_IOMEM
 diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
-index ea6ea5bbbc9c..153a3f4837e8 100644
+index ea6ea5bbb..153a3f483 100644
 --- a/drivers/misc/Makefile
 +++ b/drivers/misc/Makefile
 @@ -59,6 +59,7 @@ obj-$(CONFIG_PVPANIC)   	+= pvpanic/
@@ -509,15 +513,15 @@ index ea6ea5bbbc9c..153a3f4837e8 100644
  obj-$(CONFIG_GP_PCI1XXXX)	+= mchp_pci1xxxx/
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
 new file mode 100644
-index 000000000000..496704268603
+index 000000000..19fd70ac3
 --- /dev/null
 +++ b/drivers/misc/ntsync.c
-@@ -0,0 +1,1146 @@
+@@ -0,0 +1,1166 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * ntsync.c - Kernel driver for NT synchronization primitives
 + *
-+ * Copyright (C) 2024 Elizabeth Figura
++ * Copyright (C) 2024 Elizabeth Figura <zfigura@codeweavers.com>
 + */
 +
 +#include <linux/anon_inodes.h>
@@ -542,6 +546,19 @@ index 000000000000..496704268603
 +	NTSYNC_TYPE_MUTEX,
 +	NTSYNC_TYPE_EVENT,
 +};
++
++/*
++ * Individual synchronization primitives are represented by
++ * struct ntsync_obj, and each primitive is backed by a file.
++ *
++ * The whole namespace is represented by a struct ntsync_device also
++ * backed by a file.
++ *
++ * Both rely on struct file for reference counting. Individual
++ * ntsync_obj objects take a reference to the device when created.
++ * Wait operations take a reference to each object being waited on for
++ * the duration of the wait.
++ */
 +
 +struct ntsync_obj {
 +	spinlock_t lock;
@@ -610,7 +627,7 @@ index 000000000000..496704268603
 +	__u32 owner;
 +
 +	/*
-+	 * Protected via atomic_cmpxchg(). Only the thread that wins the
++	 * Protected via atomic_try_cmpxchg(). Only the thread that wins the
 +	 * compare-and-swap may actually change object states and wake this
 +	 * task.
 +	 */
@@ -668,6 +685,7 @@ index 000000000000..496704268603
 +{
 +	__u32 count = q->count;
 +	bool can_wake = true;
++	int signaled = -1;
 +	__u32 i;
 +
 +	lockdep_assert_held(&dev->wait_all_lock);
@@ -686,7 +704,7 @@ index 000000000000..496704268603
 +		}
 +	}
 +
-+	if (can_wake && atomic_cmpxchg(&q->signaled, -1, 0) == -1) {
++	if (can_wake && atomic_try_cmpxchg(&q->signaled, &signaled, 0)) {
 +		for (i = 0; i < count; i++) {
 +			struct ntsync_obj *obj = q->entries[i].obj;
 +
@@ -735,11 +753,12 @@ index 000000000000..496704268603
 +
 +	list_for_each_entry(entry, &sem->any_waiters, node) {
 +		struct ntsync_q *q = entry->q;
++		int signaled = -1;
 +
 +		if (!sem->u.sem.count)
 +			break;
 +
-+		if (atomic_cmpxchg(&q->signaled, -1, entry->index) == -1) {
++		if (atomic_try_cmpxchg(&q->signaled, &signaled, entry->index)) {
 +			sem->u.sem.count--;
 +			wake_up_process(q->task);
 +		}
@@ -754,13 +773,14 @@ index 000000000000..496704268603
 +
 +	list_for_each_entry(entry, &mutex->any_waiters, node) {
 +		struct ntsync_q *q = entry->q;
++		int signaled = -1;
 +
 +		if (mutex->u.mutex.count == UINT_MAX)
 +			break;
 +		if (mutex->u.mutex.owner && mutex->u.mutex.owner != q->owner)
 +			continue;
 +
-+		if (atomic_cmpxchg(&q->signaled, -1, entry->index) == -1) {
++		if (atomic_try_cmpxchg(&q->signaled, &signaled, entry->index)) {
 +			if (mutex->u.mutex.ownerdead)
 +				q->ownerdead = true;
 +			mutex->u.mutex.ownerdead = false;
@@ -779,11 +799,12 @@ index 000000000000..496704268603
 +
 +	list_for_each_entry(entry, &event->any_waiters, node) {
 +		struct ntsync_q *q = entry->q;
++		int signaled = -1;
 +
 +		if (!event->u.event.signaled)
 +			break;
 +
-+		if (atomic_cmpxchg(&q->signaled, -1, entry->index) == -1) {
++		if (atomic_try_cmpxchg(&q->signaled, &signaled, entry->index)) {
 +			if (!event->u.event.manual)
 +				event->u.event.signaled = false;
 +			wake_up_process(q->task);
@@ -1258,6 +1279,9 @@ index 000000000000..496704268603
 +	struct file *file = fget(fd);
 +	struct ntsync_obj *obj;
 +
++	if (!file)
++		return NULL;
++
 +	if (file->f_op != &ntsync_obj_fops) {
 +		fput(file);
 +		return NULL;
@@ -1656,12 +1680,12 @@ index 000000000000..496704268603
 +
 +module_misc_device(ntsync_misc);
 +
-+MODULE_AUTHOR("Elizabeth Figura");
++MODULE_AUTHOR("Elizabeth Figura <zfigura@codeweavers.com>");
 +MODULE_DESCRIPTION("Kernel driver for NT synchronization primitives");
 +MODULE_LICENSE("GPL");
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
 new file mode 100644
-index 000000000000..074f26423426
+index 000000000..f21dbac42
 --- /dev/null
 +++ b/include/uapi/linux/ntsync.h
 @@ -0,0 +1,62 @@
@@ -1669,7 +1693,7 @@ index 000000000000..074f26423426
 +/*
 + * Kernel support for NT synchronization primitive emulation
 + *
-+ * Copyright (C) 2021-2022 Elizabeth Figura
++ * Copyright (C) 2021-2022 Elizabeth Figura <zfigura@codeweavers.com>
 + */
 +
 +#ifndef __LINUX_NTSYNC_H
@@ -1703,8 +1727,8 @@ index 000000000000..074f26423426
 +	__u32 count;
 +	__u32 owner;
 +	__u32 index;
-+	__u32 alert;
 +	__u32 flags;
++	__u32 alert;
 +	__u32 pad;
 +};
 +
@@ -1728,7 +1752,7 @@ index 000000000000..074f26423426
 +
 +#endif
 diff --git a/tools/testing/selftests/Makefile b/tools/testing/selftests/Makefile
-index 15b6a111c3be..6c714a4e6478 100644
+index 15b6a111c..6c714a4e6 100644
 --- a/tools/testing/selftests/Makefile
 +++ b/tools/testing/selftests/Makefile
 @@ -15,6 +15,7 @@ TARGETS += cpu-hotplug
@@ -1739,30 +1763,36 @@ index 15b6a111c3be..6c714a4e6478 100644
  TARGETS += drivers/s390x/uvdevice
  TARGETS += drivers/net/bonding
  TARGETS += drivers/net/team
+diff --git a/tools/testing/selftests/drivers/ntsync/.gitignore b/tools/testing/selftests/drivers/ntsync/.gitignore
+new file mode 100644
+index 000000000..848573a3d
+--- /dev/null
++++ b/tools/testing/selftests/drivers/ntsync/.gitignore
+@@ -0,0 +1 @@
++ntsync
 diff --git a/tools/testing/selftests/drivers/ntsync/Makefile b/tools/testing/selftests/drivers/ntsync/Makefile
 new file mode 100644
-index 000000000000..a34da5ccacf0
+index 000000000..dbf2b055c
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/Makefile
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,7 @@
 +# SPDX-LICENSE-IDENTIFIER: GPL-2.0-only
 +TEST_GEN_PROGS := ntsync
 +
-+top_srcdir =../../../../..
-+CFLAGS += -I$(top_srcdir)/usr/include
++CFLAGS += $(KHDR_INCLUDES)
 +LDLIBS += -lpthread
 +
 +include ../../lib.mk
 diff --git a/tools/testing/selftests/drivers/ntsync/config b/tools/testing/selftests/drivers/ntsync/config
 new file mode 100644
-index 000000000000..60539c826d06
+index 000000000..60539c826
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/config
 @@ -0,0 +1 @@
 +CONFIG_WINESYNC=y
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
 new file mode 100644
-index 000000000000..aba513c9af01
+index 000000000..5fa2c9a07
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -0,0 +1,1407 @@
@@ -1770,7 +1800,7 @@ index 000000000000..aba513c9af01
 +/*
 + * Various unit tests for the "ntsync" synchronization primitive driver.
 + *
-+ * Copyright (C) 2021-2022 Elizabeth Figura
++ * Copyright (C) 2021-2022 Elizabeth Figura <zfigura@codeweavers.com>
 + */
 +
 +#define _GNU_SOURCE
@@ -3173,6 +3203,6 @@ index 000000000000..aba513c9af01
 +}
 +
 +TEST_HARNESS_MAIN
--- 
+--
 2.45.0
 

--- a/6.8/all/0001-cachyos-base-all.patch
+++ b/6.8/all/0001-cachyos-base-all.patch
@@ -25571,35 +25571,37 @@ index faad00cce269..c7c9eb656468 100644
 -- 
 2.45.0
 
-From 194a4fc590161a73bb2b3f39653074d006c790d0 Mon Sep 17 00:00:00 2001
-From: Peter Jung <admin@ptr1337.dev>
-Date: Sat, 27 Apr 2024 20:14:52 +0200
-Subject: [PATCH 8/9] ntsync
+From 7c3ed5efabc7ef6a13044f64f2b640a56246383b Mon Sep 17 00:00:00 2001
+From: artewar67 <artewar67@yandex.ru>
+Date: Mon, 6 May 2024 21:35:12 +0500
+Subject: [PATCH] misc: Update ntsync5 to v4
 
-Signed-off-by: Peter Jung <admin@ptr1337.dev>
+Signed-off-by: artewar67 <artewar67@yandex.ru>
 ---
  Documentation/userspace-api/index.rst         |    1 +
  .../userspace-api/ioctl/ioctl-number.rst      |    2 +
  Documentation/userspace-api/ntsync.rst        |  399 +++++
  MAINTAINERS                                   |    9 +
- drivers/misc/Kconfig                          |    9 +
+ drivers/misc/Kconfig                          |   11 +
  drivers/misc/Makefile                         |    1 +
- drivers/misc/ntsync.c                         | 1146 ++++++++++++++
+ drivers/misc/ntsync.c                         | 1166 ++++++++++++++
  include/uapi/linux/ntsync.h                   |   62 +
  tools/testing/selftests/Makefile              |    1 +
- .../testing/selftests/drivers/ntsync/Makefile |    8 +
+ .../selftests/drivers/ntsync/.gitignore       |    1 +
+ .../testing/selftests/drivers/ntsync/Makefile |    7 +
  tools/testing/selftests/drivers/ntsync/config |    1 +
  .../testing/selftests/drivers/ntsync/ntsync.c | 1407 +++++++++++++++++
- 12 files changed, 3046 insertions(+)
+ 13 files changed, 3068 insertions(+)
  create mode 100644 Documentation/userspace-api/ntsync.rst
  create mode 100644 drivers/misc/ntsync.c
  create mode 100644 include/uapi/linux/ntsync.h
+ create mode 100644 tools/testing/selftests/drivers/ntsync/.gitignore
  create mode 100644 tools/testing/selftests/drivers/ntsync/Makefile
  create mode 100644 tools/testing/selftests/drivers/ntsync/config
  create mode 100644 tools/testing/selftests/drivers/ntsync/ntsync.c
 
 diff --git a/Documentation/userspace-api/index.rst b/Documentation/userspace-api/index.rst
-index 09f61bd2ac2e..f5a72ed27def 100644
+index 09f61bd2a..f5a72ed27 100644
 --- a/Documentation/userspace-api/index.rst
 +++ b/Documentation/userspace-api/index.rst
 @@ -34,6 +34,7 @@ place where this information is gathered.
@@ -25607,11 +25609,11 @@ index 09f61bd2ac2e..f5a72ed27def 100644
     isapnp
     dcdbas
 +   ntsync
- 
+
  .. only::  subproject and html
- 
+
 diff --git a/Documentation/userspace-api/ioctl/ioctl-number.rst b/Documentation/userspace-api/ioctl/ioctl-number.rst
-index 457e16f06e04..2f5c6994f042 100644
+index 457e16f06..2f5c6994f 100644
 --- a/Documentation/userspace-api/ioctl/ioctl-number.rst
 +++ b/Documentation/userspace-api/ioctl/ioctl-number.rst
 @@ -173,6 +173,8 @@ Code  Seq#    Include File                                           Comments
@@ -25625,7 +25627,7 @@ index 457e16f06e04..2f5c6994f042 100644
  'P'   60-6F  sound/sscape_ioctl.h                                    conflict!
 diff --git a/Documentation/userspace-api/ntsync.rst b/Documentation/userspace-api/ntsync.rst
 new file mode 100644
-index 000000000000..202c2350d3af
+index 000000000..202c2350d
 --- /dev/null
 +++ b/Documentation/userspace-api/ntsync.rst
 @@ -0,0 +1,399 @@
@@ -26029,13 +26031,13 @@ index 000000000000..202c2350d3af
 +  ``objs`` and in ``alert``. If this is attempted, the function fails
 +  with ``EINVAL``.
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 1aabf1c15bb3..91af49091a3c 100644
+index 1aabf1c15..91af49091 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -15609,6 +15609,15 @@ T:	git https://github.com/Paragon-Software-Group/linux-ntfs3.git
  F:	Documentation/filesystems/ntfs3.rst
  F:	fs/ntfs3/
- 
+
 +NTSYNC SYNCHRONIZATION PRIMITIVE DRIVER
 +M:	Elizabeth Figura <zfigura@codeweavers.com>
 +L:	wine-devel@winehq.org
@@ -26049,13 +26051,13 @@ index 1aabf1c15bb3..91af49091a3c 100644
  M:	Finn Thain <fthain@linux-m68k.org>
  L:	linux-m68k@lists.linux-m68k.org
 diff --git a/drivers/misc/Kconfig b/drivers/misc/Kconfig
-index 4fb291f0bf7c..bdd8a71bd853 100644
+index 4fb291f0b..801ed229e 100644
 --- a/drivers/misc/Kconfig
 +++ b/drivers/misc/Kconfig
-@@ -504,6 +504,15 @@ config OPEN_DICE
- 	  measured boot flow. Userspace can use CDIs for remote attestation
- 	  and sealing.
- 
+@@ -506,6 +506,17 @@ config OPEN_DICE
+
+ 	  If unsure, say N.
+
 +config NTSYNC
 +	tristate "NT synchronization primitive emulation"
 +	help
@@ -26065,11 +26067,13 @@ index 4fb291f0bf7c..bdd8a71bd853 100644
 +	  To compile this driver as a module, choose M here: the
 +	  module will be called ntsync.
 +
- 	  If unsure, say N.
- 
++	  If unsure, say N.
++
  config VCPU_STALL_DETECTOR
+ 	tristate "Guest vCPU stall detector"
+ 	depends on OF && HAS_IOMEM
 diff --git a/drivers/misc/Makefile b/drivers/misc/Makefile
-index ea6ea5bbbc9c..153a3f4837e8 100644
+index ea6ea5bbb..153a3f483 100644
 --- a/drivers/misc/Makefile
 +++ b/drivers/misc/Makefile
 @@ -59,6 +59,7 @@ obj-$(CONFIG_PVPANIC)   	+= pvpanic/
@@ -26082,15 +26086,15 @@ index ea6ea5bbbc9c..153a3f4837e8 100644
  obj-$(CONFIG_GP_PCI1XXXX)	+= mchp_pci1xxxx/
 diff --git a/drivers/misc/ntsync.c b/drivers/misc/ntsync.c
 new file mode 100644
-index 000000000000..496704268603
+index 000000000..19fd70ac3
 --- /dev/null
 +++ b/drivers/misc/ntsync.c
-@@ -0,0 +1,1146 @@
+@@ -0,0 +1,1166 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * ntsync.c - Kernel driver for NT synchronization primitives
 + *
-+ * Copyright (C) 2024 Elizabeth Figura
++ * Copyright (C) 2024 Elizabeth Figura <zfigura@codeweavers.com>
 + */
 +
 +#include <linux/anon_inodes.h>
@@ -26115,6 +26119,19 @@ index 000000000000..496704268603
 +	NTSYNC_TYPE_MUTEX,
 +	NTSYNC_TYPE_EVENT,
 +};
++
++/*
++ * Individual synchronization primitives are represented by
++ * struct ntsync_obj, and each primitive is backed by a file.
++ *
++ * The whole namespace is represented by a struct ntsync_device also
++ * backed by a file.
++ *
++ * Both rely on struct file for reference counting. Individual
++ * ntsync_obj objects take a reference to the device when created.
++ * Wait operations take a reference to each object being waited on for
++ * the duration of the wait.
++ */
 +
 +struct ntsync_obj {
 +	spinlock_t lock;
@@ -26183,7 +26200,7 @@ index 000000000000..496704268603
 +	__u32 owner;
 +
 +	/*
-+	 * Protected via atomic_cmpxchg(). Only the thread that wins the
++	 * Protected via atomic_try_cmpxchg(). Only the thread that wins the
 +	 * compare-and-swap may actually change object states and wake this
 +	 * task.
 +	 */
@@ -26241,6 +26258,7 @@ index 000000000000..496704268603
 +{
 +	__u32 count = q->count;
 +	bool can_wake = true;
++	int signaled = -1;
 +	__u32 i;
 +
 +	lockdep_assert_held(&dev->wait_all_lock);
@@ -26259,7 +26277,7 @@ index 000000000000..496704268603
 +		}
 +	}
 +
-+	if (can_wake && atomic_cmpxchg(&q->signaled, -1, 0) == -1) {
++	if (can_wake && atomic_try_cmpxchg(&q->signaled, &signaled, 0)) {
 +		for (i = 0; i < count; i++) {
 +			struct ntsync_obj *obj = q->entries[i].obj;
 +
@@ -26308,11 +26326,12 @@ index 000000000000..496704268603
 +
 +	list_for_each_entry(entry, &sem->any_waiters, node) {
 +		struct ntsync_q *q = entry->q;
++		int signaled = -1;
 +
 +		if (!sem->u.sem.count)
 +			break;
 +
-+		if (atomic_cmpxchg(&q->signaled, -1, entry->index) == -1) {
++		if (atomic_try_cmpxchg(&q->signaled, &signaled, entry->index)) {
 +			sem->u.sem.count--;
 +			wake_up_process(q->task);
 +		}
@@ -26327,13 +26346,14 @@ index 000000000000..496704268603
 +
 +	list_for_each_entry(entry, &mutex->any_waiters, node) {
 +		struct ntsync_q *q = entry->q;
++		int signaled = -1;
 +
 +		if (mutex->u.mutex.count == UINT_MAX)
 +			break;
 +		if (mutex->u.mutex.owner && mutex->u.mutex.owner != q->owner)
 +			continue;
 +
-+		if (atomic_cmpxchg(&q->signaled, -1, entry->index) == -1) {
++		if (atomic_try_cmpxchg(&q->signaled, &signaled, entry->index)) {
 +			if (mutex->u.mutex.ownerdead)
 +				q->ownerdead = true;
 +			mutex->u.mutex.ownerdead = false;
@@ -26352,11 +26372,12 @@ index 000000000000..496704268603
 +
 +	list_for_each_entry(entry, &event->any_waiters, node) {
 +		struct ntsync_q *q = entry->q;
++		int signaled = -1;
 +
 +		if (!event->u.event.signaled)
 +			break;
 +
-+		if (atomic_cmpxchg(&q->signaled, -1, entry->index) == -1) {
++		if (atomic_try_cmpxchg(&q->signaled, &signaled, entry->index)) {
 +			if (!event->u.event.manual)
 +				event->u.event.signaled = false;
 +			wake_up_process(q->task);
@@ -26831,6 +26852,9 @@ index 000000000000..496704268603
 +	struct file *file = fget(fd);
 +	struct ntsync_obj *obj;
 +
++	if (!file)
++		return NULL;
++
 +	if (file->f_op != &ntsync_obj_fops) {
 +		fput(file);
 +		return NULL;
@@ -27229,12 +27253,12 @@ index 000000000000..496704268603
 +
 +module_misc_device(ntsync_misc);
 +
-+MODULE_AUTHOR("Elizabeth Figura");
++MODULE_AUTHOR("Elizabeth Figura <zfigura@codeweavers.com>");
 +MODULE_DESCRIPTION("Kernel driver for NT synchronization primitives");
 +MODULE_LICENSE("GPL");
 diff --git a/include/uapi/linux/ntsync.h b/include/uapi/linux/ntsync.h
 new file mode 100644
-index 000000000000..074f26423426
+index 000000000..f21dbac42
 --- /dev/null
 +++ b/include/uapi/linux/ntsync.h
 @@ -0,0 +1,62 @@
@@ -27242,7 +27266,7 @@ index 000000000000..074f26423426
 +/*
 + * Kernel support for NT synchronization primitive emulation
 + *
-+ * Copyright (C) 2021-2022 Elizabeth Figura
++ * Copyright (C) 2021-2022 Elizabeth Figura <zfigura@codeweavers.com>
 + */
 +
 +#ifndef __LINUX_NTSYNC_H
@@ -27276,8 +27300,8 @@ index 000000000000..074f26423426
 +	__u32 count;
 +	__u32 owner;
 +	__u32 index;
-+	__u32 alert;
 +	__u32 flags;
++	__u32 alert;
 +	__u32 pad;
 +};
 +
@@ -27301,7 +27325,7 @@ index 000000000000..074f26423426
 +
 +#endif
 diff --git a/tools/testing/selftests/Makefile b/tools/testing/selftests/Makefile
-index 15b6a111c3be..6c714a4e6478 100644
+index 15b6a111c..6c714a4e6 100644
 --- a/tools/testing/selftests/Makefile
 +++ b/tools/testing/selftests/Makefile
 @@ -15,6 +15,7 @@ TARGETS += cpu-hotplug
@@ -27312,30 +27336,36 @@ index 15b6a111c3be..6c714a4e6478 100644
  TARGETS += drivers/s390x/uvdevice
  TARGETS += drivers/net/bonding
  TARGETS += drivers/net/team
+diff --git a/tools/testing/selftests/drivers/ntsync/.gitignore b/tools/testing/selftests/drivers/ntsync/.gitignore
+new file mode 100644
+index 000000000..848573a3d
+--- /dev/null
++++ b/tools/testing/selftests/drivers/ntsync/.gitignore
+@@ -0,0 +1 @@
++ntsync
 diff --git a/tools/testing/selftests/drivers/ntsync/Makefile b/tools/testing/selftests/drivers/ntsync/Makefile
 new file mode 100644
-index 000000000000..a34da5ccacf0
+index 000000000..dbf2b055c
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/Makefile
-@@ -0,0 +1,8 @@
+@@ -0,0 +1,7 @@
 +# SPDX-LICENSE-IDENTIFIER: GPL-2.0-only
 +TEST_GEN_PROGS := ntsync
 +
-+top_srcdir =../../../../..
-+CFLAGS += -I$(top_srcdir)/usr/include
++CFLAGS += $(KHDR_INCLUDES)
 +LDLIBS += -lpthread
 +
 +include ../../lib.mk
 diff --git a/tools/testing/selftests/drivers/ntsync/config b/tools/testing/selftests/drivers/ntsync/config
 new file mode 100644
-index 000000000000..60539c826d06
+index 000000000..60539c826
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/config
 @@ -0,0 +1 @@
 +CONFIG_WINESYNC=y
 diff --git a/tools/testing/selftests/drivers/ntsync/ntsync.c b/tools/testing/selftests/drivers/ntsync/ntsync.c
 new file mode 100644
-index 000000000000..aba513c9af01
+index 000000000..5fa2c9a07
 --- /dev/null
 +++ b/tools/testing/selftests/drivers/ntsync/ntsync.c
 @@ -0,0 +1,1407 @@
@@ -27343,7 +27373,7 @@ index 000000000000..aba513c9af01
 +/*
 + * Various unit tests for the "ntsync" synchronization primitive driver.
 + *
-+ * Copyright (C) 2021-2022 Elizabeth Figura
++ * Copyright (C) 2021-2022 Elizabeth Figura <zfigura@codeweavers.com>
 + */
 +
 +#define _GNU_SOURCE
@@ -28746,7 +28776,7 @@ index 000000000000..aba513c9af01
 +}
 +
 +TEST_HARNESS_MAIN
--- 
+--
 2.45.0
 
 From dbadac091776bb1533e270aaa8c618ee3121726b Mon Sep 17 00:00:00 2001


### PR DESCRIPTION
Solves wine hang problem with ntsync patch
https://lore.kernel.org/all/20240416010837.333694-1-zfigura@codeweavers.com/ (need the first three patches from v3 version)