### PR TITLE
6.9/nvidia: Make patches usable for open modules

### DIFF
--- a/6.9/misc/nvidia/make-modeset-fbdev-default.patch
+++ b/6.9/misc/nvidia/make-modeset-fbdev-default.patch
@@ -1,5 +1,5 @@
---- a/kernel/nvidia-drm/nvidia-drm-linux.c
-+++ b/kernel/nvidia-drm/nvidia-drm-linux.c
+--- a/nvidia-drm/nvidia-drm-linux.c
++++ b/nvidia-drm/nvidia-drm-linux.c
 @@ -31,13 +31,13 @@
  
  MODULE_PARM_DESC(
@@ -16,8 +16,8 @@
  module_param_named(fbdev, nv_drm_fbdev_module_param, bool, 0400);
  #endif
  
---- a/kernel/nvidia-drm/nvidia-drm-os-interface.c
-+++ b/kernel/nvidia-drm/nvidia-drm-os-interface.c
+--- a/nvidia-drm/nvidia-drm-os-interface.c
++++ b/nvidia-drm/nvidia-drm-os-interface.c
 @@ -41,8 +41,8 @@
  #include <drm/drmP.h>
  #endif

--- a/6.9/misc/nvidia/nvidia-open-gcc-ibt-sls.patch
+++ b/6.9/misc/nvidia/nvidia-open-gcc-ibt-sls.patch
@@ -1,0 +1,10 @@
+--- a/src/nvidia-modeset/Makefile
++++ b/src/nvidia-modeset/Makefile
+@@ -142,6 +142,7 @@ ifeq ($(TARGET_ARCH),x86_64)
+   CONDITIONAL_CFLAGS += $(call TEST_CC_ARG, -fno-jump-tables)
+   CONDITIONAL_CFLAGS += $(call TEST_CC_ARG, -mindirect-branch=thunk-extern)
+   CONDITIONAL_CFLAGS += $(call TEST_CC_ARG, -mindirect-branch-register)
++  CONDITIONAL_CFLAGS += $(call TEST_CC_ARG, -mharden-sls=all)
+ endif
+ 
+ CFLAGS += $(CONDITIONAL_CFLAGS)


### PR DESCRIPTION
For open modules, we have only `kernel-open` directory, not `kernel`.