### PR TITLE
6.10: Update BORE 5.2.8 and Rebase RT patches

### DIFF
--- a/6.10/misc/0001-rt.patch
+++ b/6.10/misc/0001-rt.patch
@@ -1,9 +1,8 @@
-From 427947f8b2e304e89d81c25c688da59089589e48 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Tue, 2 Jul 2024 08:09:59 +0200
+From 68a01fbb219a6fbc354c7b99283681a2ceb3448b Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@proton.me>
+Date: Sat, 3 Aug 2024 15:52:10 +0700
 Subject: [PATCH] rt
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  .../admin-guide/kernel-parameters.txt         |  12 +
  arch/arm/Kconfig                              |   6 +-
@@ -32,7 +31,6 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  drivers/gpu/drm/i915/i915_request.c           |   2 -
  drivers/gpu/drm/i915/i915_trace.h             |   4 +
  drivers/gpu/drm/i915/i915_utils.h             |   9 +-
- drivers/gpu/drm/ttm/tests/ttm_bo_test.c       |   8 +-
  drivers/tty/serial/8250/8250_core.c           |  48 +-
  drivers/tty/serial/8250/8250_port.c           | 157 +++-
  drivers/tty/serial/amba-pl011.c               |   2 +-
@@ -51,13 +49,12 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  include/linux/lockdep.h                       |   3 +
  include/linux/netdevice.h                     |  43 +-
  include/linux/netdevice_xmit.h                |  13 +
- include/linux/perf_event.h                    |  11 +-
+ include/linux/perf_event.h                    |  10 +-
  include/linux/printk.h                        |  38 +-
  include/linux/sched.h                         |  28 +-
  include/linux/sched/idle.h                    |   8 +-
  include/linux/serial_8250.h                   |   6 +
  include/linux/serial_core.h                   | 117 ++-
- include/linux/task_work.h                     |   3 +-
  include/linux/thread_info.h                   |  24 +
  include/linux/trace_events.h                  |   8 +-
  include/net/inet_timewait_sock.h              |  11 +-
@@ -69,10 +66,9 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  kernel/entry/common.c                         |   4 +-
  kernel/entry/kvm.c                            |   2 +-
  kernel/events/callchain.c                     |   2 +-
- kernel/events/core.c                          | 128 ++-
+ kernel/events/core.c                          |  89 +-
  kernel/events/internal.h                      |   4 +-
  kernel/fork.c                                 |   1 +
- kernel/irq/manage.c                           |   2 +-
  kernel/ksysfs.c                               |  12 +
  kernel/locking/lockdep.c                      |  84 +-
  kernel/locking/spinlock.c                     |   8 +
@@ -93,7 +89,6 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  kernel/sched/rt.c                             |   5 +-
  kernel/sched/sched.h                          |   1 +
  kernel/softirq.c                              |  95 +-
- kernel/task_work.c                            |  34 +-
  kernel/time/hrtimer.c                         |   4 +-
  kernel/time/tick-sched.c                      |   2 +-
  kernel/time/timer.c                           |  11 +-
@@ -113,12 +108,11 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  net/ipv4/tcp_sigpool.c                        |  17 +-
  net/ipv6/seg6_local.c                         |  22 +-
  net/xdp/xsk.c                                 |  12 +-
- security/keys/keyctl.c                        |   2 +-
- 109 files changed, 3372 insertions(+), 555 deletions(-)
+ 104 files changed, 3299 insertions(+), 539 deletions(-)
  create mode 100644 include/linux/netdevice_xmit.h
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index c083c4760..1f7289b1c 100644
+index 21c6506ea..01a49075e 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -6610,6 +6610,18 @@
@@ -179,7 +173,7 @@ index ee5115252..92cb5d38b 100644
  	select HAVE_REGS_AND_STACK_ACCESS_API
  	select HAVE_RSEQ
 diff --git a/arch/arm/mm/fault.c b/arch/arm/mm/fault.c
-index 67c425341..0320810ca 100644
+index ab01b51de..cd030e273 100644
 --- a/arch/arm/mm/fault.c
 +++ b/arch/arm/mm/fault.c
 @@ -474,6 +474,9 @@ do_translation_fault(unsigned long addr, unsigned int fsr,
@@ -687,10 +681,10 @@ index 12da7dfd5..38e2cf055 100644
  #define _TIF_SSBD		(1 << TIF_SSBD)
  #define _TIF_SPEC_IB		(1 << TIF_SPEC_IB)
 diff --git a/drivers/acpi/processor_idle.c b/drivers/acpi/processor_idle.c
-index bd6a7857c..d45dfd10b 100644
+index 831fa4a12..5af3ebec0 100644
 --- a/drivers/acpi/processor_idle.c
 +++ b/drivers/acpi/processor_idle.c
-@@ -108,7 +108,7 @@ static const struct dmi_system_id processor_power_dmi_table[] = {
+@@ -107,7 +107,7 @@ static const struct dmi_system_id processor_power_dmi_table[] = {
   */
  static void __cpuidle acpi_safe_halt(void)
  {
@@ -941,7 +935,7 @@ index baf7354cb..d639b51a4 100644
  
  	finish_wait(wq, &wait);
 diff --git a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
-index 21829439e..ed29a2dd6 100644
+index 72090f52f..1c6bb872d 100644
 --- a/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 +++ b/drivers/gpu/drm/i915/gt/intel_execlists_submission.c
 @@ -1303,7 +1303,7 @@ static void execlists_dequeue(struct intel_engine_cs *engine)
@@ -1071,32 +1065,6 @@ index 06ec6ceb6..12cbf0499 100644
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) WARN_ON_ONCE((ATOMIC) && !in_atomic())
  #else
  # define _WAIT_FOR_ATOMIC_CHECK(ATOMIC) do { } while (0)
-diff --git a/drivers/gpu/drm/ttm/tests/ttm_bo_test.c b/drivers/gpu/drm/ttm/tests/ttm_bo_test.c
-index 1f8a4f8ad..9cc367a79 100644
---- a/drivers/gpu/drm/ttm/tests/ttm_bo_test.c
-+++ b/drivers/gpu/drm/ttm/tests/ttm_bo_test.c
-@@ -18,6 +18,12 @@
- 
- #define BO_SIZE		SZ_8K
- 
-+#ifdef CONFIG_PREEMPT_RT
-+#define ww_mutex_base_lock(b)			rt_mutex_lock(b)
-+#else
-+#define ww_mutex_base_lock(b)			mutex_lock(b)
-+#endif
-+
- struct ttm_bo_test_case {
- 	const char *description;
- 	bool interruptible;
-@@ -142,7 +148,7 @@ static void ttm_bo_reserve_deadlock(struct kunit *test)
- 	bo2 = ttm_bo_kunit_init(test, test->priv, BO_SIZE);
- 
- 	ww_acquire_init(&ctx1, &reservation_ww_class);
--	mutex_lock(&bo2->base.resv->lock.base);
-+	ww_mutex_base_lock(&bo2->base.resv->lock.base);
- 
- 	/* The deadlock will be caught by WW mutex, don't warn about it */
- 	lock_release(&bo2->base.resv->lock.base.dep_map, 1);
 diff --git a/drivers/tty/serial/8250/8250_core.c b/drivers/tty/serial/8250/8250_core.c
 index b0adafc44..fd462494f 100644
 --- a/drivers/tty/serial/8250/8250_core.c
@@ -1962,7 +1930,7 @@ index 5669da513..13bed5019 100644
  
  	/* Lower bits of the flags are used as return code on lookup failure */
 diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
-index 5c9bdd3ff..42e91eaa9 100644
+index dac7466de..c012a9e90 100644
 --- a/include/linux/interrupt.h
 +++ b/include/linux/interrupt.h
 @@ -612,6 +612,35 @@ extern void __raise_softirq_irqoff(unsigned int nr);
@@ -2220,10 +2188,10 @@ index 000000000..38325e070
 +
 +#endif
 diff --git a/include/linux/perf_event.h b/include/linux/perf_event.h
-index a5304ae8c..65ece0d5b 100644
+index 393fb1373..65ece0d5b 100644
 --- a/include/linux/perf_event.h
 +++ b/include/linux/perf_event.h
-@@ -781,11 +781,12 @@ struct perf_event {
+@@ -781,9 +781,9 @@ struct perf_event {
  	unsigned int			pending_wakeup;
  	unsigned int			pending_kill;
  	unsigned int			pending_disable;
@@ -2233,11 +2201,8 @@ index a5304ae8c..65ece0d5b 100644
 +	struct irq_work			pending_disable_irq;
  	struct callback_head		pending_task;
  	unsigned int			pending_work;
-+	struct rcuwait			pending_work_wait;
- 
- 	atomic_t			event_limit;
- 
-@@ -962,7 +963,7 @@ struct perf_event_context {
+ 	struct rcuwait			pending_work_wait;
+@@ -963,7 +963,7 @@ struct perf_event_context {
  	struct rcu_head			rcu_head;
  
  	/*
@@ -2246,7 +2211,7 @@ index a5304ae8c..65ece0d5b 100644
  	 *
  	 * The SIGTRAP is targeted at ctx->task, as such it won't do changing
  	 * that until the signal is delivered.
-@@ -970,12 +971,6 @@ struct perf_event_context {
+@@ -971,12 +971,6 @@ struct perf_event_context {
  	local_t				nr_pending;
  };
  
@@ -2337,7 +2302,7 @@ index 65c518447..1da78bc3c 100644
  
  bool this_cpu_in_panic(void);
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 61591ac6e..c582eb3ed 100644
+index 76214d7c8..eb8e246ff 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -36,6 +36,7 @@
@@ -2439,7 +2404,7 @@ index 61591ac6e..c582eb3ed 100644
  {
  	return unlikely(test_tsk_thread_flag(tsk,TIF_NEED_RESCHED));
  }
-@@ -2107,7 +2123,7 @@ static inline bool preempt_model_preemptible(void)
+@@ -2066,7 +2082,7 @@ extern int __cond_resched_rwlock_write(rwlock_t *lock);
  
  static __always_inline bool need_resched(void)
  {
@@ -2699,20 +2664,6 @@ index aea25eef9..4ab65874a 100644
  	spin_unlock_irqrestore(&up->lock, flags);
  }
  
-diff --git a/include/linux/task_work.h b/include/linux/task_work.h
-index 795ef5a68..26b8a47f4 100644
---- a/include/linux/task_work.h
-+++ b/include/linux/task_work.h
-@@ -30,7 +30,8 @@ int task_work_add(struct task_struct *task, struct callback_head *twork,
- 
- struct callback_head *task_work_cancel_match(struct task_struct *task,
- 	bool (*match)(struct callback_head *, void *data), void *data);
--struct callback_head *task_work_cancel(struct task_struct *, task_work_func_t);
-+struct callback_head *task_work_cancel_func(struct task_struct *, task_work_func_t);
-+bool task_work_cancel(struct task_struct *task, struct callback_head *cb);
- void task_work_run(void);
- 
- static inline void exit_task_work(struct task_struct *task)
 diff --git a/include/linux/thread_info.h b/include/linux/thread_info.h
 index 9ea0b2806..5ded1450a 100644
 --- a/include/linux/thread_info.h
@@ -3087,32 +3038,28 @@ index 1273be843..ad57944b6 100644
  static DEFINE_MUTEX(callchain_mutex);
  static struct callchain_cpus_entries *callchain_cpus_entries;
 diff --git a/kernel/events/core.c b/kernel/events/core.c
-index 8f908f077..8bba63ea9 100644
+index b2a6aec11..48976ebeb 100644
 --- a/kernel/events/core.c
 +++ b/kernel/events/core.c
-@@ -2283,21 +2283,6 @@ event_sched_out(struct perf_event *event, struct perf_event_context *ctx)
+@@ -2283,17 +2283,6 @@ event_sched_out(struct perf_event *event, struct perf_event_context *ctx)
  		state = PERF_EVENT_STATE_OFF;
  	}
  
 -	if (event->pending_sigtrap) {
--		bool dec = true;
--
 -		event->pending_sigtrap = 0;
 -		if (state != PERF_EVENT_STATE_OFF &&
--		    !event->pending_work) {
+-		    !event->pending_work &&
+-		    !task_work_add(current, &event->pending_task, TWA_RESUME)) {
 -			event->pending_work = 1;
--			dec = false;
--			WARN_ON_ONCE(!atomic_long_inc_not_zero(&event->refcount));
--			task_work_add(current, &event->pending_task, TWA_RESUME);
--		}
--		if (dec)
+-		} else {
 -			local_dec(&event->ctx->nr_pending);
+-		}
 -	}
 -
  	perf_event_set_state(event, state);
  
  	if (!is_software_event(event))
-@@ -2466,7 +2451,7 @@ static void __perf_event_disable(struct perf_event *event,
+@@ -2462,7 +2451,7 @@ static void __perf_event_disable(struct perf_event *event,
   * hold the top-level event's child_mutex, so any descendant that
   * goes to exit will block in perf_event_exit_event().
   *
@@ -3121,52 +3068,15 @@ index 8f908f077..8bba63ea9 100644
   * is the current context on this CPU and preemption is disabled,
   * hence we can't get into perf_event_task_sched_out for this context.
   */
-@@ -2506,7 +2491,7 @@ EXPORT_SYMBOL_GPL(perf_event_disable);
- void perf_event_disable_inatomic(struct perf_event *event)
- {
- 	event->pending_disable = 1;
--	irq_work_queue(&event->pending_irq);
-+	irq_work_queue(&event->pending_disable_irq);
- }
- 
- #define MAX_INTERRUPTS (~0ULL)
-@@ -5206,9 +5191,35 @@ static bool exclusive_event_installable(struct perf_event *event,
- static void perf_addr_filters_splice(struct perf_event *event,
- 				       struct list_head *head);
- 
-+static void perf_pending_task_sync(struct perf_event *event)
-+{
-+	struct callback_head *head = &event->pending_task;
-+
-+	if (!event->pending_work)
-+		return;
-+	/*
-+	 * If the task is queued to the current task's queue, we
-+	 * obviously can't wait for it to complete. Simply cancel it.
-+	 */
-+	if (task_work_cancel(current, head)) {
-+		event->pending_work = 0;
-+		local_dec(&event->ctx->nr_pending);
-+		return;
-+	}
-+
-+	/*
-+	 * All accesses related to the event are within the same RCU section in
-+	 * perf_pending_task(). The RCU grace period before the event is freed
-+	 * will make sure all those accesses are complete by then.
-+	 */
-+	rcuwait_wait_event(&event->pending_work_wait, !event->pending_work, TASK_UNINTERRUPTIBLE);
-+}
-+
+@@ -5230,6 +5219,7 @@ static void perf_pending_task_sync(struct perf_event *event)
  static void _free_event(struct perf_event *event)
  {
  	irq_work_sync(&event->pending_irq);
 +	irq_work_sync(&event->pending_disable_irq);
-+	perf_pending_task_sync(event);
+ 	perf_pending_task_sync(event);
  
  	unaccount_event(event);
- 
-@@ -6750,7 +6761,7 @@ static void perf_sigtrap(struct perf_event *event)
+@@ -6774,7 +6764,7 @@ static void perf_sigtrap(struct perf_event *event)
  /*
   * Deliver the pending work in-event-context or follow the context.
   */
@@ -3175,7 +3085,7 @@ index 8f908f077..8bba63ea9 100644
  {
  	int cpu = READ_ONCE(event->oncpu);
  
-@@ -6765,11 +6776,6 @@ static void __perf_pending_irq(struct perf_event *event)
+@@ -6789,11 +6779,6 @@ static void __perf_pending_irq(struct perf_event *event)
  	 * Yay, we hit home and are in the context of the event.
  	 */
  	if (cpu == smp_processor_id()) {
@@ -3187,7 +3097,7 @@ index 8f908f077..8bba63ea9 100644
  		if (event->pending_disable) {
  			event->pending_disable = 0;
  			perf_event_disable_local(event);
-@@ -6793,11 +6799,26 @@ static void __perf_pending_irq(struct perf_event *event)
+@@ -6817,11 +6802,26 @@ static void __perf_pending_irq(struct perf_event *event)
  	 *				  irq_work_queue(); // FAILS
  	 *
  	 *  irq_work_run()
@@ -3216,7 +3126,7 @@ index 8f908f077..8bba63ea9 100644
  }
  
  static void perf_pending_irq(struct irq_work *entry)
-@@ -6820,8 +6841,6 @@ static void perf_pending_irq(struct irq_work *entry)
+@@ -6844,8 +6844,6 @@ static void perf_pending_irq(struct irq_work *entry)
  		perf_event_wakeup(event);
  	}
  
@@ -3225,40 +3135,28 @@ index 8f908f077..8bba63ea9 100644
  	if (rctx >= 0)
  		perf_swevent_put_recursion_context(rctx);
  }
-@@ -6831,24 +6850,28 @@ static void perf_pending_task(struct callback_head *head)
- 	struct perf_event *event = container_of(head, struct perf_event, pending_task);
- 	int rctx;
- 
-+	/*
-+	 * All accesses to the event must belong to the same implicit RCU read-side
-+	 * critical section as the ->pending_work reset. See comment in
-+	 * perf_pending_task_sync().
-+	 */
+@@ -6860,7 +6858,7 @@ static void perf_pending_task(struct callback_head *head)
+ 	 * critical section as the ->pending_work reset. See comment in
+ 	 * perf_pending_task_sync().
+ 	 */
+-	preempt_disable_notrace();
 +	rcu_read_lock();
  	/*
  	 * If we 'fail' here, that's OK, it means recursion is already disabled
  	 * and we won't recurse 'further'.
- 	 */
--	preempt_disable_notrace();
- 	rctx = perf_swevent_get_recursion_context();
- 
- 	if (event->pending_work) {
- 		event->pending_work = 0;
- 		perf_sigtrap(event);
+@@ -6873,10 +6871,10 @@ static void perf_pending_task(struct callback_head *head)
  		local_dec(&event->ctx->nr_pending);
-+		rcuwait_wake_up(&event->pending_work_wait);
+ 		rcuwait_wake_up(&event->pending_work_wait);
  	}
 +	rcu_read_unlock();
  
  	if (rctx >= 0)
  		perf_swevent_put_recursion_context(rctx);
 -	preempt_enable_notrace();
--
--	put_event(event);
  }
  
  #ifdef CONFIG_GUEST_PERF_EVENTS
-@@ -9709,13 +9732,28 @@ static int __perf_event_overflow(struct perf_event *event,
+@@ -9735,13 +9733,28 @@ static int __perf_event_overflow(struct perf_event *event,
  
  		if (regs)
  			pending_id = hash32_ptr((void *)instruction_pointer(regs)) ?: 1;
@@ -3290,7 +3188,7 @@ index 8f908f077..8bba63ea9 100644
  			 *
  			 *  1. Where !exclude_kernel, events can overflow again
  			 *     in the kernel without returning to user space.
-@@ -9725,13 +9763,8 @@ static int __perf_event_overflow(struct perf_event *event,
+@@ -9751,20 +9764,15 @@ static int __perf_event_overflow(struct perf_event *event,
  			 *     To approximate progress (with false negatives),
  			 *     check 32-bit hash of the current IP.
  			 */
@@ -3305,7 +3203,15 @@ index 8f908f077..8bba63ea9 100644
  	}
  
  	READ_ONCE(event->overflow_handler)(event, data, regs);
-@@ -9759,11 +9792,7 @@ struct swevent_htable {
+ 
+ 	if (*perf_event_fasync(event) && event->pending_kill) {
+ 		event->pending_wakeup = 1;
+-		irq_work_queue(&event->pending_irq);
++		irq_work_queue(&event->pending_disable_irq);
+ 	}
+ 
+ 	return ret;
+@@ -9785,9 +9793,6 @@ struct swevent_htable {
  	struct swevent_hlist		*swevent_hlist;
  	struct mutex			hlist_mutex;
  	int				hlist_refcount;
@@ -3313,11 +3219,9 @@ index 8f908f077..8bba63ea9 100644
 -	/* Recursion avoidance in each contexts */
 -	int				recursion[PERF_NR_CONTEXTS];
  };
--
- static DEFINE_PER_CPU(struct swevent_htable, swevent_htable);
  
- /*
-@@ -9961,17 +9990,13 @@ DEFINE_PER_CPU(struct pt_regs, __perf_regs[4]);
+ static DEFINE_PER_CPU(struct swevent_htable, swevent_htable);
+@@ -9987,17 +9992,13 @@ DEFINE_PER_CPU(struct pt_regs, __perf_regs[4]);
  
  int perf_swevent_get_recursion_context(void)
  {
@@ -3337,17 +3241,15 @@ index 8f908f077..8bba63ea9 100644
  }
  
  void ___perf_sw_event(u32 event_id, u64 nr, struct pt_regs *regs, u64 addr)
-@@ -11961,7 +11986,9 @@ perf_event_alloc(struct perf_event_attr *attr, int cpu,
+@@ -11987,6 +11988,7 @@ perf_event_alloc(struct perf_event_attr *attr, int cpu,
  
  	init_waitqueue_head(&event->waitq);
  	init_irq_work(&event->pending_irq, perf_pending_irq);
 +	event->pending_disable_irq = IRQ_WORK_INIT_HARD(perf_pending_disable);
  	init_task_work(&event->pending_task, perf_pending_task);
-+	rcuwait_init(&event->pending_work_wait);
+ 	rcuwait_init(&event->pending_work_wait);
  
- 	mutex_init(&event->mmap_mutex);
- 	raw_spin_lock_init(&event->addr_filters.lock);
-@@ -13637,6 +13664,7 @@ int perf_event_init_task(struct task_struct *child, u64 clone_flags)
+@@ -13664,6 +13666,7 @@ int perf_event_init_task(struct task_struct *child, u64 clone_flags)
  {
  	int ret;
  
@@ -3356,7 +3258,7 @@ index 8f908f077..8bba63ea9 100644
  	mutex_init(&child->perf_event_mutex);
  	INIT_LIST_HEAD(&child->perf_event_list);
 diff --git a/kernel/events/internal.h b/kernel/events/internal.h
-index 5150d5f84..f0daaa6f2 100644
+index 386d21c7e..451514442 100644
 --- a/kernel/events/internal.h
 +++ b/kernel/events/internal.h
 @@ -208,7 +208,7 @@ arch_perf_out_copy_user(void *dst, const void *src, unsigned long n)
@@ -3389,19 +3291,6 @@ index 18750b83c..cbeb77ed0 100644
  
  	/* Perform scheduler related setup. Assign this task to a CPU. */
  	retval = sched_fork(clone_flags, p);
-diff --git a/kernel/irq/manage.c b/kernel/irq/manage.c
-index 71b0fc2d0..dd53298ef 100644
---- a/kernel/irq/manage.c
-+++ b/kernel/irq/manage.c
-@@ -1337,7 +1337,7 @@ static int irq_thread(void *data)
- 	 * synchronize_hardirq(). So neither IRQTF_RUNTHREAD nor the
- 	 * oneshot mask bit can be set.
- 	 */
--	task_work_cancel(current, irq_thread_dtor);
-+	task_work_cancel_func(current, irq_thread_dtor);
- 	return 0;
- }
- 
 diff --git a/kernel/ksysfs.c b/kernel/ksysfs.c
 index 07fb5987b..f01bf89f4 100644
 --- a/kernel/ksysfs.c
@@ -6427,10 +6316,10 @@ index 460efecd0..833a75167 100644
  
  	/*
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index bcf2c4cc0..8c3c8929b 100644
+index ebf21373f..a8a19ee33 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
-@@ -899,14 +899,15 @@ static inline void hrtick_rq_init(struct rq *rq)
+@@ -898,14 +898,15 @@ static inline void hrtick_rq_init(struct rq *rq)
  
  #if defined(CONFIG_SMP) && defined(TIF_POLLING_NRFLAG)
  /*
@@ -6449,7 +6338,7 @@ index bcf2c4cc0..8c3c8929b 100644
  }
  
  /*
-@@ -923,7 +924,7 @@ static bool set_nr_if_polling(struct task_struct *p)
+@@ -922,7 +923,7 @@ static bool set_nr_if_polling(struct task_struct *p)
  	do {
  		if (!(val & _TIF_POLLING_NRFLAG))
  			return false;
@@ -6458,7 +6347,7 @@ index bcf2c4cc0..8c3c8929b 100644
  			return true;
  	} while (!try_cmpxchg(&ti->flags, &val, val | _TIF_NEED_RESCHED));
  
-@@ -931,9 +932,9 @@ static bool set_nr_if_polling(struct task_struct *p)
+@@ -930,9 +931,9 @@ static bool set_nr_if_polling(struct task_struct *p)
  }
  
  #else
@@ -6470,7 +6359,7 @@ index bcf2c4cc0..8c3c8929b 100644
  	return true;
  }
  
-@@ -1038,28 +1039,47 @@ void wake_up_q(struct wake_q_head *head)
+@@ -1037,28 +1038,47 @@ void wake_up_q(struct wake_q_head *head)
   * might also involve a cross-CPU call to trigger the scheduler on
   * the target CPU.
   */
@@ -6526,7 +6415,7 @@ index bcf2c4cc0..8c3c8929b 100644
  }
  
  void resched_cpu(int cpu)
-@@ -1154,7 +1174,7 @@ static void wake_up_idle_cpu(int cpu)
+@@ -1153,7 +1173,7 @@ static void wake_up_idle_cpu(int cpu)
  	 * and testing of the above solutions didn't appear to report
  	 * much benefits.
  	 */
@@ -6595,7 +6484,7 @@ index c1eb9a1af..272078fa8 100644
  }
  late_initcall(sched_init_debug);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index a241e0d45..573e3784f 100644
+index 1fee282d4..c66303be8 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -987,8 +987,10 @@ static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
@@ -6663,7 +6552,7 @@ index a241e0d45..573e3784f 100644
  static void update_curr_fair(struct rq *rq)
  {
  	update_curr(cfs_rq_of(&rq->curr->se));
-@@ -5525,7 +5541,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
+@@ -5524,7 +5540,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
  	/*
  	 * Update run-time statistics of the 'current'.
  	 */
@@ -6672,7 +6561,7 @@ index a241e0d45..573e3784f 100644
  
  	/*
  	 * Ensure that runnable average is periodically updated.
-@@ -5539,7 +5555,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
+@@ -5538,7 +5554,7 @@ entity_tick(struct cfs_rq *cfs_rq, struct sched_entity *curr, int queued)
  	 * validating it and just reschedule.
  	 */
  	if (queued) {
@@ -6681,7 +6570,7 @@ index a241e0d45..573e3784f 100644
  		return;
  	}
  	/*
-@@ -5685,7 +5701,7 @@ static void __account_cfs_rq_runtime(struct cfs_rq *cfs_rq, u64 delta_exec)
+@@ -5684,7 +5700,7 @@ static void __account_cfs_rq_runtime(struct cfs_rq *cfs_rq, u64 delta_exec)
  	 * hierarchy can be throttled
  	 */
  	if (!assign_cfs_rq_runtime(cfs_rq) && likely(cfs_rq->curr))
@@ -6690,7 +6579,7 @@ index a241e0d45..573e3784f 100644
  }
  
  static __always_inline
-@@ -5945,7 +5961,7 @@ void unthrottle_cfs_rq(struct cfs_rq *cfs_rq)
+@@ -5944,7 +5960,7 @@ void unthrottle_cfs_rq(struct cfs_rq *cfs_rq)
  
  	/* Determine whether we need to wake up potentially idle CPU: */
  	if (rq->curr == rq->idle && rq->cfs.nr_running)
@@ -6699,7 +6588,7 @@ index a241e0d45..573e3784f 100644
  }
  
  #ifdef CONFIG_SMP
-@@ -6660,7 +6676,7 @@ static void hrtick_start_fair(struct rq *rq, struct task_struct *p)
+@@ -6659,7 +6675,7 @@ static void hrtick_start_fair(struct rq *rq, struct task_struct *p)
  
  		if (delta < 0) {
  			if (task_current(rq, p))
@@ -6708,7 +6597,7 @@ index a241e0d45..573e3784f 100644
  			return;
  		}
  		hrtick_start(rq, delta);
-@@ -8392,7 +8408,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8391,7 +8407,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	 * prevents us from potentially nominating it as a false LAST_BUDDY
  	 * below.
  	 */
@@ -6717,7 +6606,7 @@ index a241e0d45..573e3784f 100644
  		return;
  
  	/* Idle tasks are by definition preempted by non-idle tasks. */
-@@ -8434,7 +8450,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8433,7 +8449,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	return;
  
  preempt:
@@ -6726,7 +6615,7 @@ index a241e0d45..573e3784f 100644
  }
  
  #ifdef CONFIG_SMP
-@@ -12586,7 +12602,7 @@ static inline void task_tick_core(struct rq *rq, struct task_struct *curr)
+@@ -12579,7 +12595,7 @@ static inline void task_tick_core(struct rq *rq, struct task_struct *curr)
  	 */
  	if (rq->core->core_forceidle_count && rq->cfs.nr_running == 1 &&
  	    __entity_slice_used(&curr->se, MIN_NR_TASKS_DURING_FORCEIDLE))
@@ -6735,7 +6624,7 @@ index a241e0d45..573e3784f 100644
  }
  
  /*
-@@ -12753,7 +12769,7 @@ prio_changed_fair(struct rq *rq, struct task_struct *p, int oldprio)
+@@ -12746,7 +12762,7 @@ prio_changed_fair(struct rq *rq, struct task_struct *p, int oldprio)
  	 */
  	if (task_current(rq, p)) {
  		if (p->prio > oldprio)
@@ -6786,11 +6675,11 @@ index aa4c1c874..f38ffe14a 100644
  		rd->rto_cpu = -1;
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 6e6a45087..7f2ec404e 100644
+index 556466836..7ff06ff58 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -2466,6 +2466,7 @@ extern void init_sched_fair_class(void);
- extern void reweight_task(struct task_struct *p, int prio);
+@@ -2467,6 +2467,7 @@ extern void init_sched_fair_class(void);
+ extern void reweight_task(struct task_struct *p, const struct load_weight *lw);
  
  extern void resched_curr(struct rq *rq);
 +extern void resched_curr_lazy(struct rq *rq);
@@ -6929,69 +6818,6 @@ index 025820177..00e32e279 100644
  	return 0;
  }
  early_initcall(spawn_ksoftirqd);
-diff --git a/kernel/task_work.c b/kernel/task_work.c
-index 95a7e1b7f..2134ac805 100644
---- a/kernel/task_work.c
-+++ b/kernel/task_work.c
-@@ -120,9 +120,9 @@ static bool task_work_func_match(struct callback_head *cb, void *data)
- }
- 
- /**
-- * task_work_cancel - cancel a pending work added by task_work_add()
-- * @task: the task which should execute the work
-- * @func: identifies the work to remove
-+ * task_work_cancel_func - cancel a pending work matching a function added by task_work_add()
-+ * @task: the task which should execute the func's work
-+ * @func: identifies the func to match with a work to remove
-  *
-  * Find the last queued pending work with ->func == @func and remove
-  * it from queue.
-@@ -131,11 +131,35 @@ static bool task_work_func_match(struct callback_head *cb, void *data)
-  * The found work or NULL if not found.
-  */
- struct callback_head *
--task_work_cancel(struct task_struct *task, task_work_func_t func)
-+task_work_cancel_func(struct task_struct *task, task_work_func_t func)
- {
- 	return task_work_cancel_match(task, task_work_func_match, func);
- }
- 
-+static bool task_work_match(struct callback_head *cb, void *data)
-+{
-+	return cb == data;
-+}
-+
-+/**
-+ * task_work_cancel - cancel a pending work added by task_work_add()
-+ * @task: the task which should execute the work
-+ * @cb: the callback to remove if queued
-+ *
-+ * Remove a callback from a task's queue if queued.
-+ *
-+ * RETURNS:
-+ * True if the callback was queued and got cancelled, false otherwise.
-+ */
-+bool task_work_cancel(struct task_struct *task, struct callback_head *cb)
-+{
-+	struct callback_head *ret;
-+
-+	ret = task_work_cancel_match(task, task_work_match, cb);
-+
-+	return ret == cb;
-+}
-+
- /**
-  * task_work_run - execute the works added by task_work_add()
-  *
-@@ -168,7 +192,7 @@ void task_work_run(void)
- 		if (!work)
- 			break;
- 		/*
--		 * Synchronize with task_work_cancel(). It can not remove
-+		 * Synchronize with task_work_cancel_match(). It can not remove
- 		 * the first entry == work, cmpxchg(task_works) must fail.
- 		 * But it can remove another entry from the ->next list.
- 		 */
 diff --git a/kernel/time/hrtimer.c b/kernel/time/hrtimer.c
 index b8ee32020..fd78166a2 100644
 --- a/kernel/time/hrtimer.c
@@ -7571,7 +7397,7 @@ index b7b518bc2..4984dd9b3 100644
  
  #endif
 diff --git a/net/core/filter.c b/net/core/filter.c
-index 9933851c6..a8dd866ed 100644
+index 110692c1d..83cb84b48 100644
 --- a/net/core/filter.c
 +++ b/net/core/filter.c
 @@ -1658,9 +1658,12 @@ struct bpf_scratchpad {
@@ -7659,7 +7485,7 @@ index 9933851c6..a8dd866ed 100644
  
  	if (unlikely((plen && plen < sizeof(*params)) || flags))
  		return TC_ACT_SHOT;
-@@ -4293,30 +4297,13 @@ void xdp_do_check_flushed(struct napi_struct *napi)
+@@ -4300,30 +4304,13 @@ void xdp_do_check_flushed(struct napi_struct *napi)
  }
  #endif
  
@@ -7691,7 +7517,7 @@ index 9933851c6..a8dd866ed 100644
  
  	master = netdev_master_upper_dev_get_rcu(xdp->rxq->dev);
  	slave = master->netdev_ops->ndo_xdp_get_xmit_slave(master, xdp);
-@@ -4388,7 +4375,7 @@ static __always_inline int __xdp_do_redirect_frame(struct bpf_redirect_info *ri,
+@@ -4395,7 +4382,7 @@ static __always_inline int __xdp_do_redirect_frame(struct bpf_redirect_info *ri,
  			map = READ_ONCE(ri->map);
  
  			/* The map pointer is cleared when the map is being torn
@@ -7700,7 +7526,7 @@ index 9933851c6..a8dd866ed 100644
  			 */
  			if (unlikely(!map)) {
  				err = -ENOENT;
-@@ -4433,7 +4420,7 @@ static __always_inline int __xdp_do_redirect_frame(struct bpf_redirect_info *ri,
+@@ -4440,7 +4427,7 @@ static __always_inline int __xdp_do_redirect_frame(struct bpf_redirect_info *ri,
  int xdp_do_redirect(struct net_device *dev, struct xdp_buff *xdp,
  		    struct bpf_prog *xdp_prog)
  {
@@ -7709,7 +7535,7 @@ index 9933851c6..a8dd866ed 100644
  	enum bpf_map_type map_type = ri->map_type;
  
  	if (map_type == BPF_MAP_TYPE_XSKMAP)
-@@ -4447,7 +4434,7 @@ EXPORT_SYMBOL_GPL(xdp_do_redirect);
+@@ -4454,7 +4441,7 @@ EXPORT_SYMBOL_GPL(xdp_do_redirect);
  int xdp_do_redirect_frame(struct net_device *dev, struct xdp_buff *xdp,
  			  struct xdp_frame *xdpf, struct bpf_prog *xdp_prog)
  {
@@ -7718,7 +7544,7 @@ index 9933851c6..a8dd866ed 100644
  	enum bpf_map_type map_type = ri->map_type;
  
  	if (map_type == BPF_MAP_TYPE_XSKMAP)
-@@ -4464,7 +4451,7 @@ static int xdp_do_generic_redirect_map(struct net_device *dev,
+@@ -4471,7 +4458,7 @@ static int xdp_do_generic_redirect_map(struct net_device *dev,
  				       enum bpf_map_type map_type, u32 map_id,
  				       u32 flags)
  {
@@ -7727,7 +7553,7 @@ index 9933851c6..a8dd866ed 100644
  	struct bpf_map *map;
  	int err;
  
-@@ -4476,7 +4463,7 @@ static int xdp_do_generic_redirect_map(struct net_device *dev,
+@@ -4483,7 +4470,7 @@ static int xdp_do_generic_redirect_map(struct net_device *dev,
  			map = READ_ONCE(ri->map);
  
  			/* The map pointer is cleared when the map is being torn
@@ -7736,7 +7562,7 @@ index 9933851c6..a8dd866ed 100644
  			 */
  			if (unlikely(!map)) {
  				err = -ENOENT;
-@@ -4518,7 +4505,7 @@ static int xdp_do_generic_redirect_map(struct net_device *dev,
+@@ -4525,7 +4512,7 @@ static int xdp_do_generic_redirect_map(struct net_device *dev,
  int xdp_do_generic_redirect(struct net_device *dev, struct sk_buff *skb,
  			    struct xdp_buff *xdp, struct bpf_prog *xdp_prog)
  {
@@ -7745,7 +7571,7 @@ index 9933851c6..a8dd866ed 100644
  	enum bpf_map_type map_type = ri->map_type;
  	void *fwd = ri->tgt_value;
  	u32 map_id = ri->map_id;
-@@ -4554,7 +4541,7 @@ int xdp_do_generic_redirect(struct net_device *dev, struct sk_buff *skb,
+@@ -4561,7 +4548,7 @@ int xdp_do_generic_redirect(struct net_device *dev, struct sk_buff *skb,
  
  BPF_CALL_2(bpf_xdp_redirect, u32, ifindex, u64, flags)
  {
@@ -7754,7 +7580,7 @@ index 9933851c6..a8dd866ed 100644
  
  	if (unlikely(flags))
  		return XDP_ABORTED;
-@@ -6455,6 +6442,7 @@ BPF_CALL_4(bpf_lwt_seg6_store_bytes, struct sk_buff *, skb, u32, offset,
+@@ -6462,6 +6449,7 @@ BPF_CALL_4(bpf_lwt_seg6_store_bytes, struct sk_buff *, skb, u32, offset,
  	void *srh_tlvs, *srh_end, *ptr;
  	int srhoff = 0;
  
@@ -7762,7 +7588,7 @@ index 9933851c6..a8dd866ed 100644
  	if (srh == NULL)
  		return -EINVAL;
  
-@@ -6511,6 +6499,7 @@ BPF_CALL_4(bpf_lwt_seg6_action, struct sk_buff *, skb,
+@@ -6518,6 +6506,7 @@ BPF_CALL_4(bpf_lwt_seg6_action, struct sk_buff *, skb,
  	int hdroff = 0;
  	int err;
  
@@ -7770,7 +7596,7 @@ index 9933851c6..a8dd866ed 100644
  	switch (action) {
  	case SEG6_LOCAL_ACTION_END_X:
  		if (!seg6_bpf_has_valid_srh(skb))
-@@ -6587,6 +6576,7 @@ BPF_CALL_3(bpf_lwt_seg6_adjust_srh, struct sk_buff *, skb, u32, offset,
+@@ -6594,6 +6583,7 @@ BPF_CALL_3(bpf_lwt_seg6_adjust_srh, struct sk_buff *, skb, u32, offset,
  	int srhoff = 0;
  	int ret;
  
@@ -8077,7 +7903,7 @@ index e28075f00..a70a3a16e 100644
  	inet_twsk_put(tw);
  }
 diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
-index b71095839..40227a964 100644
+index a541659b6..212a97f88 100644
 --- a/net/ipv4/tcp_ipv4.c
 +++ b/net/ipv4/tcp_ipv4.c
 @@ -93,7 +93,9 @@ static int tcp_v4_md5_hash_hdr(char *md5_hash, const struct tcp_md5sig_key *key,
@@ -8091,7 +7917,7 @@ index b71095839..40227a964 100644
  
  static u32 tcp_v4_init_seq(const struct sk_buff *skb)
  {
-@@ -885,7 +887,9 @@ static void tcp_v4_send_reset(const struct sock *sk, struct sk_buff *skb,
+@@ -880,7 +882,9 @@ static void tcp_v4_send_reset(const struct sock *sk, struct sk_buff *skb,
  	arg.tos = ip_hdr(skb)->tos;
  	arg.uid = sock_net_uid(net, sk && sk_fullsock(sk) ? sk : NULL);
  	local_bh_disable();
@@ -8102,7 +7928,7 @@ index b71095839..40227a964 100644
  	sock_net_set(ctl_sk, net);
  	if (sk) {
  		ctl_sk->sk_mark = (sk->sk_state == TCP_TIME_WAIT) ?
-@@ -910,6 +914,7 @@ static void tcp_v4_send_reset(const struct sock *sk, struct sk_buff *skb,
+@@ -905,6 +909,7 @@ static void tcp_v4_send_reset(const struct sock *sk, struct sk_buff *skb,
  	sock_net_set(ctl_sk, &init_net);
  	__TCP_INC_STATS(net, TCP_MIB_OUTSEGS);
  	__TCP_INC_STATS(net, TCP_MIB_OUTRSTS);
@@ -8110,7 +7936,7 @@ index b71095839..40227a964 100644
  	local_bh_enable();
  
  #ifdef CONFIG_TCP_MD5SIG
-@@ -1005,7 +1010,8 @@ static void tcp_v4_send_ack(const struct sock *sk,
+@@ -1000,7 +1005,8 @@ static void tcp_v4_send_ack(const struct sock *sk,
  	arg.tos = tos;
  	arg.uid = sock_net_uid(net, sk_fullsock(sk) ? sk : NULL);
  	local_bh_disable();
@@ -8120,7 +7946,7 @@ index b71095839..40227a964 100644
  	sock_net_set(ctl_sk, net);
  	ctl_sk->sk_mark = (sk->sk_state == TCP_TIME_WAIT) ?
  			   inet_twsk(sk)->tw_mark : READ_ONCE(sk->sk_mark);
-@@ -1020,6 +1026,7 @@ static void tcp_v4_send_ack(const struct sock *sk,
+@@ -1015,6 +1021,7 @@ static void tcp_v4_send_ack(const struct sock *sk,
  
  	sock_net_set(ctl_sk, &init_net);
  	__TCP_INC_STATS(net, TCP_MIB_OUTSEGS);
@@ -8128,7 +7954,7 @@ index b71095839..40227a964 100644
  	local_bh_enable();
  }
  
-@@ -3620,7 +3627,7 @@ void __init tcp_v4_init(void)
+@@ -3615,7 +3622,7 @@ void __init tcp_v4_init(void)
  		 */
  		inet_sk(sk)->pmtudisc = IP_PMTUDISC_DO;
  
@@ -8138,7 +7964,7 @@ index b71095839..40227a964 100644
  	if (register_pernet_subsys(&tcp_sk_ops))
  		panic("Failed to create the TCP control socket.\n");
 diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
-index e4c861c07..511bf3ad5 100644
+index 6eb1d369c..b69cff4f9 100644
 --- a/net/ipv4/tcp_minisocks.c
 +++ b/net/ipv4/tcp_minisocks.c
 @@ -344,11 +344,10 @@ void tcp_time_wait(struct sock *sk, int state, int timeo)
@@ -8337,19 +8163,6 @@ index 7d1c0986f..ed062e038 100644
  	return 0;
  
  out_pernet:
-diff --git a/security/keys/keyctl.c b/security/keys/keyctl.c
-index 4bc3e9398..ab927a142 100644
---- a/security/keys/keyctl.c
-+++ b/security/keys/keyctl.c
-@@ -1694,7 +1694,7 @@ long keyctl_session_to_parent(void)
- 		goto unlock;
- 
- 	/* cancel an already pending keyring replacement */
--	oldwork = task_work_cancel(parent, key_change_session_keyring);
-+	oldwork = task_work_cancel_func(parent, key_change_session_keyring);
- 
- 	/* the replacement session keyring is applied just prior to userspace
- 	 * restarting */
 -- 
-2.45.2.606.g9005149a4a
+2.46.0
 

--- a/6.10/sched/0001-bore-cachy-ext.patch
+++ b/6.10/sched/0001-bore-cachy-ext.patch
@@ -1,25 +1,24 @@
-From 72b3c9064df81c05b51cf175f7e0fc2714096869 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Tue, 23 Jul 2024 18:38:21 +0200
-Subject: [PATCH] bore-cachy-ext
+From dfa885904c840912033b2eb96618d339e949c0a2 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@proton.me>
+Date: Sat, 3 Aug 2024 15:17:26 +0700
+Subject: [PATCH] bore-cachy
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  include/linux/sched.h   |  10 ++
  init/Kconfig            |  17 ++
  kernel/Kconfig.hz       |  16 ++
  kernel/sched/core.c     | 143 +++++++++++++++++
  kernel/sched/debug.c    |  60 ++++++-
- kernel/sched/fair.c     | 336 +++++++++++++++++++++++++++++++++++++---
+ kernel/sched/fair.c     | 335 +++++++++++++++++++++++++++++++++++++---
  kernel/sched/features.h |  22 ++-
  kernel/sched/sched.h    |   7 +
- 8 files changed, 584 insertions(+), 27 deletions(-)
+ 8 files changed, 583 insertions(+), 27 deletions(-)
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 829e50def..87745c94d 100644
+index 76214d7c8..9f65d367b 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -549,6 +549,16 @@ struct sched_entity {
+@@ -547,6 +547,16 @@ struct sched_entity {
  	u64				sum_exec_runtime;
  	u64				prev_sum_exec_runtime;
  	u64				vruntime;
@@ -91,10 +90,10 @@ index 0f78364ef..b50189ee5 100644
  config SCHED_HRTICK
  	def_bool HIGH_RES_TIMERS
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 410bb7127..e2643cdf8 100644
+index ebf21373f..5d1c97612 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
-@@ -4543,6 +4543,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
+@@ -4512,6 +4512,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
  	return try_to_wake_up(p, state, 0);
  }
  
@@ -233,7 +232,7 @@ index 410bb7127..e2643cdf8 100644
  /*
   * Perform scheduler related setup for a newly forked process p.
   * p is forked by current.
-@@ -4559,6 +4691,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
+@@ -4528,6 +4660,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
  	p->se.prev_sum_exec_runtime	= 0;
  	p->se.nr_migrations		= 0;
  	p->se.vruntime			= 0;
@@ -243,7 +242,7 @@ index 410bb7127..e2643cdf8 100644
  	p->se.vlag			= 0;
  	p->se.slice			= sysctl_sched_base_slice;
  	INIT_LIST_HEAD(&p->se.group_node);
-@@ -4893,6 +5028,9 @@ void sched_cancel_fork(struct task_struct *p)
+@@ -4843,6 +4978,9 @@ void sched_cgroup_fork(struct task_struct *p, struct kernel_clone_args *kargs)
  
  void sched_post_fork(struct task_struct *p)
  {
@@ -251,22 +250,22 @@ index 410bb7127..e2643cdf8 100644
 +	sched_post_fork_bore(p);
 +#endif // CONFIG_SCHED_BORE
  	uclamp_post_fork(p);
- 	scx_post_fork(p);
  }
-@@ -10044,6 +10182,11 @@ void __init sched_init(void)
- 	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
+ 
+@@ -9930,6 +10068,11 @@ void __init sched_init(void)
+ 	BUG_ON(&dl_sched_class != &stop_sched_class + 1);
  #endif
  
 +#ifdef CONFIG_SCHED_BORE
 +	sched_init_bore();
-+	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.6 by Masahito Suzuki");
++	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.8 by Masahito Suzuki");
 +#endif // CONFIG_SCHED_BORE
 +
  	wait_bit_init();
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index c057ef46c..3cab39e34 100644
+index c1eb9a1af..e2da8d773 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -167,7 +167,52 @@ static const struct file_operations sched_feat_fops = {
@@ -373,7 +372,7 @@ index c057ef46c..3cab39e34 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 32f68ec1e..a26450ee1 100644
+index 1fee282d4..4c8d7fbd5 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -19,6 +19,9 @@
@@ -386,7 +385,7 @@ index 32f68ec1e..a26450ee1 100644
   */
  #include <linux/energy_model.h>
  #include <linux/mmap_lock.h>
-@@ -64,28 +67,133 @@
+@@ -64,28 +67,145 @@
   *   SCHED_TUNABLESCALING_LOG - scaled logarithmical, *1+ilog(ncpus)
   *   SCHED_TUNABLESCALING_LINEAR - scaled linear, *ncpus
   *
@@ -475,7 +474,19 @@ index 32f68ec1e..a26450ee1 100644
 +	return __unscale_slice(delta, se->burst_score);
 +}
 +
-+void reweight_task(struct task_struct *p, int prio);
++static void reweight_entity(
++	struct cfs_rq *cfs_rq, struct sched_entity *se, unsigned long weight);
++
++static void renice_task(struct task_struct *p, int prio)
++{
++	struct sched_entity *se = &p->se;
++	struct cfs_rq *cfs_rq = cfs_rq_of(se);
++	struct load_weight *load = &se->load;
++	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
++
++	reweight_entity(cfs_rq, se, weight);
++	load->inv_weight = sched_prio_to_wmult[prio];
++}
 +
 +static void update_burst_score(struct sched_entity *se) {
 +	if (!entity_is_task(se)) return;
@@ -491,7 +502,7 @@ index 32f68ec1e..a26450ee1 100644
 +
 +	u8 new_prio = min(39, prio + se->burst_score);
 +	if (new_prio != prev_prio)
-+		reweight_task(p, new_prio);
++		renice_task(p, new_prio);
 +}
 +
 +static void update_burst_penalty(struct sched_entity *se) {
@@ -531,7 +542,7 @@ index 32f68ec1e..a26450ee1 100644
  
  static int __init setup_sched_thermal_decay_shift(char *str)
  {
-@@ -130,12 +238,8 @@ int __weak arch_asym_cpu_priority(int cpu)
+@@ -130,12 +250,8 @@ int __weak arch_asym_cpu_priority(int cpu)
   *
   * (default: 5 msec, units: microseconds)
   */
@@ -544,7 +555,7 @@ index 32f68ec1e..a26450ee1 100644
  
  #ifdef CONFIG_NUMA_BALANCING
  /* Restrict the NUMA promotion throughput (MB/s) for each target node. */
-@@ -144,6 +248,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
+@@ -144,6 +260,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
  
  #ifdef CONFIG_SYSCTL
  static struct ctl_table sched_fair_sysctls[] = {
@@ -637,7 +648,7 @@ index 32f68ec1e..a26450ee1 100644
  #ifdef CONFIG_CFS_BANDWIDTH
  	{
  		.procname       = "sched_cfs_bandwidth_slice_us",
-@@ -201,6 +391,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
+@@ -201,6 +403,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
   */
@@ -651,7 +662,7 @@ index 32f68ec1e..a26450ee1 100644
  static unsigned int get_update_sysctl_factor(void)
  {
  	unsigned int cpus = min_t(unsigned int, num_online_cpus(), 8);
-@@ -231,6 +428,7 @@ static void update_sysctl(void)
+@@ -231,6 +440,7 @@ static void update_sysctl(void)
  	SET_SYSCTL(sched_base_slice);
  #undef SET_SYSCTL
  }
@@ -659,7 +670,7 @@ index 32f68ec1e..a26450ee1 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -708,6 +906,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
+@@ -708,6 +918,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
  
  	vlag = avruntime - se->vruntime;
  	limit = calc_delta_fair(max_t(u64, 2*se->slice, TICK_NSEC), se);
@@ -669,7 +680,7 @@ index 32f68ec1e..a26450ee1 100644
  
  	return clamp(vlag, -limit, limit);
  }
-@@ -868,6 +1069,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -868,6 +1081,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
  	return __node_2_se(left);
  }
  
@@ -709,7 +720,7 @@ index 32f68ec1e..a26450ee1 100644
  /*
   * Earliest Eligible Virtual Deadline First
   *
-@@ -887,28 +1121,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -887,28 +1133,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   *
   * Which allows tree pruning through eligibility.
   */
@@ -745,7 +756,7 @@ index 32f68ec1e..a26450ee1 100644
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -967,6 +1200,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -967,6 +1212,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
   * Scheduling class statistics methods:
   */
  #ifdef CONFIG_SMP
@@ -753,7 +764,7 @@ index 32f68ec1e..a26450ee1 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -978,6 +1212,7 @@ int sched_update_scaling(void)
+@@ -978,6 +1224,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -761,7 +772,7 @@ index 32f68ec1e..a26450ee1 100644
  #endif
  #endif
  
-@@ -1178,7 +1413,13 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1178,7 +1425,13 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	if (unlikely(delta_exec <= 0))
  		return;
  
@@ -775,7 +786,7 @@ index 32f68ec1e..a26450ee1 100644
  	update_deadline(cfs_rq, curr);
  	update_min_vruntime(cfs_rq);
  
-@@ -5193,6 +5434,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5192,6 +5445,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	s64 lag = 0;
  
  	se->slice = sysctl_sched_base_slice;
@@ -787,7 +798,7 @@ index 32f68ec1e..a26450ee1 100644
  	vslice = calc_delta_fair(se->slice, se);
  
  	/*
-@@ -5203,6 +5449,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5202,6 +5460,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 *
  	 * EEVDF: placement strategy #1 / #2
  	 */
@@ -797,7 +808,7 @@ index 32f68ec1e..a26450ee1 100644
  	if (sched_feat(PLACE_LAG) && cfs_rq->nr_running) {
  		struct sched_entity *curr = cfs_rq->curr;
  		unsigned long load;
-@@ -5278,7 +5527,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5277,7 +5538,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 * on average, halfway through their slice, as such start tasks
  	 * off with half a slice to ease into the competition.
  	 */
@@ -809,7 +820,7 @@ index 32f68ec1e..a26450ee1 100644
  		vslice /= 2;
  
  	/*
-@@ -5492,7 +5745,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
+@@ -5491,7 +5756,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
  	    cfs_rq->next && entity_eligible(cfs_rq, cfs_rq->next))
  		return cfs_rq->next;
  
@@ -818,7 +829,7 @@ index 32f68ec1e..a26450ee1 100644
  }
  
  static bool check_cfs_rq_runtime(struct cfs_rq *cfs_rq);
-@@ -6860,6 +7113,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -6859,6 +7124,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	bool was_sched_idle = sched_idle_rq(rq);
  
  	util_est_dequeue(&rq->cfs, p);
@@ -833,7 +844,7 @@ index 32f68ec1e..a26450ee1 100644
  
  	for_each_sched_entity(se) {
  		cfs_rq = cfs_rq_of(se);
-@@ -8428,7 +8689,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8427,7 +8700,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	/*
  	 * XXX pick_eevdf(cfs_rq) != se ?
  	 */
@@ -842,7 +853,7 @@ index 32f68ec1e..a26450ee1 100644
  		goto preempt;
  
  	return;
-@@ -8646,16 +8907,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -8645,16 +8918,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -868,7 +879,7 @@ index 32f68ec1e..a26450ee1 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -12713,6 +12983,9 @@ static void task_fork_fair(struct task_struct *p)
+@@ -12722,6 +13004,9 @@ static void task_fork_fair(struct task_struct *p)
  	curr = cfs_rq->curr;
  	if (curr)
  		update_curr(cfs_rq);
@@ -878,23 +889,6 @@ index 32f68ec1e..a26450ee1 100644
  	place_entity(cfs_rq, se, ENQUEUE_INITIAL);
  	rq_unlock(rq, &rf);
  }
-@@ -13296,3 +13569,16 @@ __init void init_sched_fair_class(void)
- #endif /* SMP */
- 
- }
-+
-+#ifdef CONFIG_SCHED_BORE
-+void reweight_task(struct task_struct *p, int prio)
-+{
-+	struct sched_entity *se = &p->se;
-+	struct cfs_rq *cfs_rq = cfs_rq_of(se);
-+	struct load_weight *load = &se->load;
-+	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
-+
-+	reweight_entity(cfs_rq, se, weight);
-+	load->inv_weight = sched_prio_to_wmult[prio];
-+}
-+#endif // CONFIG_SCHED_BORE
 diff --git a/kernel/sched/features.h b/kernel/sched/features.h
 index 143f55df8..3aad8900c 100644
 --- a/kernel/sched/features.h
@@ -930,10 +924,10 @@ index 143f55df8..3aad8900c 100644
  /*
   * Prefer to schedule the task we woke last (assuming it failed
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index fbcd2ddbf..e187aaa59 100644
+index 556466836..4b1d5ef83 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -2041,7 +2041,11 @@ static inline void dirty_sched_domain_sysctl(int cpu)
+@@ -1969,7 +1969,11 @@ static inline void dirty_sched_domain_sysctl(int cpu)
  }
  #endif
  
@@ -945,7 +939,7 @@ index fbcd2ddbf..e187aaa59 100644
  
  static inline const struct cpumask *task_user_cpus(struct task_struct *p)
  {
-@@ -2672,6 +2676,9 @@ extern const_debug unsigned int sysctl_sched_nr_migrate;
+@@ -2554,6 +2558,9 @@ extern const_debug unsigned int sysctl_sched_nr_migrate;
  extern const_debug unsigned int sysctl_sched_migration_cost;
  
  extern unsigned int sysctl_sched_base_slice;
@@ -956,5 +950,5 @@ index fbcd2ddbf..e187aaa59 100644
  #ifdef CONFIG_SCHED_DEBUG
  extern int sysctl_resched_latency_warn_ms;
 -- 
-2.45.2.606.g9005149a4a
+2.46.0
 

--- a/6.10/sched/0001-bore-cachy-rt.patch
+++ b/6.10/sched/0001-bore-cachy-rt.patch
@@ -1,25 +1,24 @@
-From 9493cbff19ce42e6e52254e0afc959024597570e Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Tue, 23 Jul 2024 18:39:04 +0200
+From dfa885904c840912033b2eb96618d339e949c0a2 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@proton.me>
+Date: Sat, 3 Aug 2024 15:17:26 +0700
 Subject: [PATCH] bore-cachy-rt
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  include/linux/sched.h   |  10 ++
- init/Kconfig            |  17 +++
+ init/Kconfig            |  17 ++
  kernel/Kconfig.hz       |  16 ++
- kernel/sched/core.c     | 143 ++++++++++++++++++
- kernel/sched/debug.c    |  60 +++++++-
- kernel/sched/fair.c     | 323 ++++++++++++++++++++++++++++++++++++----
+ kernel/sched/core.c     | 143 +++++++++++++++++
+ kernel/sched/debug.c    |  60 ++++++-
+ kernel/sched/fair.c     | 335 +++++++++++++++++++++++++++++++++++++---
  kernel/sched/features.h |  22 ++-
  kernel/sched/sched.h    |   7 +
- 8 files changed, 571 insertions(+), 27 deletions(-)
+ 8 files changed, 583 insertions(+), 27 deletions(-)
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 913f76cf0..aa22b9400 100644
+index 76214d7c8..9f65d367b 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -549,6 +549,16 @@ struct sched_entity {
+@@ -547,6 +547,16 @@ struct sched_entity {
  	u64				sum_exec_runtime;
  	u64				prev_sum_exec_runtime;
  	u64				vruntime;
@@ -91,10 +90,10 @@ index 0f78364ef..b50189ee5 100644
  config SCHED_HRTICK
  	def_bool HIGH_RES_TIMERS
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 0d8f36c80..ad8cc7d11 100644
+index ebf21373f..5d1c97612 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
-@@ -4535,6 +4535,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
+@@ -4512,6 +4512,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
  	return try_to_wake_up(p, state, 0);
  }
  
@@ -233,7 +232,7 @@ index 0d8f36c80..ad8cc7d11 100644
  /*
   * Perform scheduler related setup for a newly forked process p.
   * p is forked by current.
-@@ -4551,6 +4683,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
+@@ -4528,6 +4660,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
  	p->se.prev_sum_exec_runtime	= 0;
  	p->se.nr_migrations		= 0;
  	p->se.vruntime			= 0;
@@ -243,7 +242,7 @@ index 0d8f36c80..ad8cc7d11 100644
  	p->se.vlag			= 0;
  	p->se.slice			= sysctl_sched_base_slice;
  	INIT_LIST_HEAD(&p->se.group_node);
-@@ -4866,6 +5001,9 @@ void sched_cgroup_fork(struct task_struct *p, struct kernel_clone_args *kargs)
+@@ -4843,6 +4978,9 @@ void sched_cgroup_fork(struct task_struct *p, struct kernel_clone_args *kargs)
  
  void sched_post_fork(struct task_struct *p)
  {
@@ -253,20 +252,20 @@ index 0d8f36c80..ad8cc7d11 100644
  	uclamp_post_fork(p);
  }
  
-@@ -9968,6 +10106,11 @@ void __init sched_init(void)
+@@ -9930,6 +10068,11 @@ void __init sched_init(void)
  	BUG_ON(&dl_sched_class != &stop_sched_class + 1);
  #endif
  
 +#ifdef CONFIG_SCHED_BORE
 +	sched_init_bore();
-+	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.6 by Masahito Suzuki");
++	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.8 by Masahito Suzuki");
 +#endif // CONFIG_SCHED_BORE
 +
  	wait_bit_init();
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 272078fa8..ea2a35c2a 100644
+index c1eb9a1af..e2da8d773 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -167,7 +167,52 @@ static const struct file_operations sched_feat_fops = {
@@ -331,7 +330,7 @@ index 272078fa8..ea2a35c2a 100644
  #endif /* SMP */
  
  #ifdef CONFIG_PREEMPT_DYNAMIC
-@@ -364,13 +409,20 @@ static __init int sched_init_debug(void)
+@@ -347,13 +392,20 @@ static __init int sched_init_debug(void)
  	debugfs_create_file("preempt", 0644, debugfs_sched, NULL, &sched_dynamic_fops);
  #endif
  
@@ -352,7 +351,7 @@ index 272078fa8..ea2a35c2a 100644
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
  
-@@ -615,6 +667,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
+@@ -596,6 +648,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
@@ -362,7 +361,7 @@ index 272078fa8..ea2a35c2a 100644
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, " %d %d", task_node(p), task_numa_group_id(p));
  #endif
-@@ -1088,6 +1143,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
+@@ -1069,6 +1124,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  
  	P(se.load.weight);
  #ifdef CONFIG_SMP
@@ -373,7 +372,7 @@ index 272078fa8..ea2a35c2a 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 6048ed306..9a0999928 100644
+index 1fee282d4..4c8d7fbd5 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -19,6 +19,9 @@
@@ -386,7 +385,7 @@ index 6048ed306..9a0999928 100644
   */
  #include <linux/energy_model.h>
  #include <linux/mmap_lock.h>
-@@ -64,28 +67,133 @@
+@@ -64,28 +67,145 @@
   *   SCHED_TUNABLESCALING_LOG - scaled logarithmical, *1+ilog(ncpus)
   *   SCHED_TUNABLESCALING_LINEAR - scaled linear, *ncpus
   *
@@ -475,7 +474,19 @@ index 6048ed306..9a0999928 100644
 +	return __unscale_slice(delta, se->burst_score);
 +}
 +
-+void reweight_task(struct task_struct *p, int prio);
++static void reweight_entity(
++	struct cfs_rq *cfs_rq, struct sched_entity *se, unsigned long weight);
++
++static void renice_task(struct task_struct *p, int prio)
++{
++	struct sched_entity *se = &p->se;
++	struct cfs_rq *cfs_rq = cfs_rq_of(se);
++	struct load_weight *load = &se->load;
++	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
++
++	reweight_entity(cfs_rq, se, weight);
++	load->inv_weight = sched_prio_to_wmult[prio];
++}
 +
 +static void update_burst_score(struct sched_entity *se) {
 +	if (!entity_is_task(se)) return;
@@ -491,7 +502,7 @@ index 6048ed306..9a0999928 100644
 +
 +	u8 new_prio = min(39, prio + se->burst_score);
 +	if (new_prio != prev_prio)
-+		reweight_task(p, new_prio);
++		renice_task(p, new_prio);
 +}
 +
 +static void update_burst_penalty(struct sched_entity *se) {
@@ -531,7 +542,7 @@ index 6048ed306..9a0999928 100644
  
  static int __init setup_sched_thermal_decay_shift(char *str)
  {
-@@ -130,12 +238,8 @@ int __weak arch_asym_cpu_priority(int cpu)
+@@ -130,12 +250,8 @@ int __weak arch_asym_cpu_priority(int cpu)
   *
   * (default: 5 msec, units: microseconds)
   */
@@ -544,7 +555,7 @@ index 6048ed306..9a0999928 100644
  
  #ifdef CONFIG_NUMA_BALANCING
  /* Restrict the NUMA promotion throughput (MB/s) for each target node. */
-@@ -144,6 +248,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
+@@ -144,6 +260,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
  
  #ifdef CONFIG_SYSCTL
  static struct ctl_table sched_fair_sysctls[] = {
@@ -637,7 +648,7 @@ index 6048ed306..9a0999928 100644
  #ifdef CONFIG_CFS_BANDWIDTH
  	{
  		.procname       = "sched_cfs_bandwidth_slice_us",
-@@ -201,6 +391,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
+@@ -201,6 +403,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
   */
@@ -651,7 +662,7 @@ index 6048ed306..9a0999928 100644
  static unsigned int get_update_sysctl_factor(void)
  {
  	unsigned int cpus = min_t(unsigned int, num_online_cpus(), 8);
-@@ -231,6 +428,7 @@ static void update_sysctl(void)
+@@ -231,6 +440,7 @@ static void update_sysctl(void)
  	SET_SYSCTL(sched_base_slice);
  #undef SET_SYSCTL
  }
@@ -659,7 +670,7 @@ index 6048ed306..9a0999928 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -708,6 +906,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
+@@ -708,6 +918,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
  
  	vlag = avruntime - se->vruntime;
  	limit = calc_delta_fair(max_t(u64, 2*se->slice, TICK_NSEC), se);
@@ -669,7 +680,7 @@ index 6048ed306..9a0999928 100644
  
  	return clamp(vlag, -limit, limit);
  }
-@@ -868,6 +1069,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -868,6 +1081,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
  	return __node_2_se(left);
  }
  
@@ -709,7 +720,7 @@ index 6048ed306..9a0999928 100644
  /*
   * Earliest Eligible Virtual Deadline First
   *
-@@ -887,28 +1121,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -887,28 +1133,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   *
   * Which allows tree pruning through eligibility.
   */
@@ -745,7 +756,7 @@ index 6048ed306..9a0999928 100644
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -967,6 +1200,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -967,6 +1212,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
   * Scheduling class statistics methods:
   */
  #ifdef CONFIG_SMP
@@ -753,7 +764,7 @@ index 6048ed306..9a0999928 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -978,6 +1212,7 @@ int sched_update_scaling(void)
+@@ -978,6 +1224,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -761,7 +772,7 @@ index 6048ed306..9a0999928 100644
  #endif
  #endif
  
-@@ -1189,7 +1424,13 @@ static void __update_curr(struct cfs_rq *cfs_rq, bool tick)
+@@ -1178,7 +1425,13 @@ static void __update_curr(struct cfs_rq *cfs_rq, bool tick)
  	if (unlikely(delta_exec <= 0))
  		return;
  
@@ -775,7 +786,7 @@ index 6048ed306..9a0999928 100644
  	update_deadline(cfs_rq, curr, tick);
  	update_min_vruntime(cfs_rq);
  
-@@ -5209,6 +5450,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5192,6 +5445,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	s64 lag = 0;
  
  	se->slice = sysctl_sched_base_slice;
@@ -787,7 +798,7 @@ index 6048ed306..9a0999928 100644
  	vslice = calc_delta_fair(se->slice, se);
  
  	/*
-@@ -5219,6 +5465,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5202,6 +5460,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 *
  	 * EEVDF: placement strategy #1 / #2
  	 */
@@ -797,7 +808,7 @@ index 6048ed306..9a0999928 100644
  	if (sched_feat(PLACE_LAG) && cfs_rq->nr_running) {
  		struct sched_entity *curr = cfs_rq->curr;
  		unsigned long load;
-@@ -5294,7 +5543,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5277,7 +5538,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 * on average, halfway through their slice, as such start tasks
  	 * off with half a slice to ease into the competition.
  	 */
@@ -809,7 +820,7 @@ index 6048ed306..9a0999928 100644
  		vslice /= 2;
  
  	/*
-@@ -5508,7 +5761,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
+@@ -5491,7 +5756,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
  	    cfs_rq->next && entity_eligible(cfs_rq, cfs_rq->next))
  		return cfs_rq->next;
  
@@ -818,7 +829,7 @@ index 6048ed306..9a0999928 100644
  }
  
  static bool check_cfs_rq_runtime(struct cfs_rq *cfs_rq);
-@@ -6876,6 +7129,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -6859,6 +7124,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	bool was_sched_idle = sched_idle_rq(rq);
  
  	util_est_dequeue(&rq->cfs, p);
@@ -833,7 +844,7 @@ index 6048ed306..9a0999928 100644
  
  	for_each_sched_entity(se) {
  		cfs_rq = cfs_rq_of(se);
-@@ -8444,7 +8705,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8427,7 +8700,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	/*
  	 * XXX pick_eevdf(cfs_rq) != se ?
  	 */
@@ -842,7 +853,7 @@ index 6048ed306..9a0999928 100644
  		goto preempt;
  
  	return;
-@@ -8662,16 +8923,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -8645,16 +8918,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -868,7 +879,7 @@ index 6048ed306..9a0999928 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -12739,6 +13009,9 @@ static void task_fork_fair(struct task_struct *p)
+@@ -12722,6 +13004,9 @@ static void task_fork_fair(struct task_struct *p)
  	curr = cfs_rq->curr;
  	if (curr)
  		update_curr(cfs_rq);
@@ -879,7 +890,7 @@ index 6048ed306..9a0999928 100644
  	rq_unlock(rq, &rf);
  }
 diff --git a/kernel/sched/features.h b/kernel/sched/features.h
-index 6de570ab3..dee3cb051 100644
+index 143f55df8..3aad8900c 100644
 --- a/kernel/sched/features.h
 +++ b/kernel/sched/features.h
 @@ -5,8 +5,28 @@
@@ -913,7 +924,7 @@ index 6de570ab3..dee3cb051 100644
  /*
   * Prefer to schedule the task we woke last (assuming it failed
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index e18743eeb..5644f1adb 100644
+index 556466836..4b1d5ef83 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -1969,7 +1969,11 @@ static inline void dirty_sched_domain_sysctl(int cpu)
@@ -928,7 +939,7 @@ index e18743eeb..5644f1adb 100644
  
  static inline const struct cpumask *task_user_cpus(struct task_struct *p)
  {
-@@ -2555,6 +2559,9 @@ extern const_debug unsigned int sysctl_sched_nr_migrate;
+@@ -2554,6 +2558,9 @@ extern const_debug unsigned int sysctl_sched_nr_migrate;
  extern const_debug unsigned int sysctl_sched_migration_cost;
  
  extern unsigned int sysctl_sched_base_slice;
@@ -939,5 +950,5 @@ index e18743eeb..5644f1adb 100644
  #ifdef CONFIG_SCHED_DEBUG
  extern int sysctl_resched_latency_warn_ms;
 -- 
-2.45.2.606.g9005149a4a
+2.46.0
 

--- a/6.10/sched/0001-bore-cachy.patch
+++ b/6.10/sched/0001-bore-cachy.patch
@@ -1,22 +1,21 @@
-From 82346bc0a1c0e3908d52988e5323e9ea84a3830c Mon Sep 17 00:00:00 2001
-From: Peter Jung <admin@ptr1337.dev>
-Date: Sat, 3 Aug 2024 09:48:45 +0200
+From dfa885904c840912033b2eb96618d339e949c0a2 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@proton.me>
+Date: Sat, 3 Aug 2024 15:17:26 +0700
 Subject: [PATCH] bore-cachy
 
-Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
  include/linux/sched.h   |  10 ++
- init/Kconfig            |  17 +++
+ init/Kconfig            |  17 ++
  kernel/Kconfig.hz       |  16 ++
- kernel/sched/core.c     | 143 ++++++++++++++++++
- kernel/sched/debug.c    |  60 +++++++-
- kernel/sched/fair.c     | 323 ++++++++++++++++++++++++++++++++++++----
+ kernel/sched/core.c     | 143 +++++++++++++++++
+ kernel/sched/debug.c    |  60 ++++++-
+ kernel/sched/fair.c     | 335 +++++++++++++++++++++++++++++++++++++---
  kernel/sched/features.h |  22 ++-
  kernel/sched/sched.h    |   7 +
- 8 files changed, 571 insertions(+), 27 deletions(-)
+ 8 files changed, 583 insertions(+), 27 deletions(-)
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 76214d7c819d..9f65d367bb31 100644
+index 76214d7c8..9f65d367b 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -547,6 +547,16 @@ struct sched_entity {
@@ -37,7 +36,7 @@ index 76214d7c819d..9f65d367bb31 100644
  	u64				slice;
  
 diff --git a/init/Kconfig b/init/Kconfig
-index 3ba6142f2f42..2966dec64df7 100644
+index 3ba6142f2..2966dec64 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1303,6 +1303,23 @@ config CHECKPOINT_RESTORE
@@ -65,7 +64,7 @@ index 3ba6142f2f42..2966dec64df7 100644
  	bool "Automatic process group scheduling"
  	select CGROUPS
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index 0f78364efd4f..b50189ee5b93 100644
+index 0f78364ef..b50189ee5 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -79,5 +79,21 @@ config HZ
@@ -91,7 +90,7 @@ index 0f78364efd4f..b50189ee5b93 100644
  config SCHED_HRTICK
  	def_bool HIGH_RES_TIMERS
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index ebf21373f663..240d1780da90 100644
+index ebf21373f..5d1c97612 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -4512,6 +4512,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
@@ -259,14 +258,14 @@ index ebf21373f663..240d1780da90 100644
  
 +#ifdef CONFIG_SCHED_BORE
 +	sched_init_bore();
-+	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.6 by Masahito Suzuki");
++	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.8 by Masahito Suzuki");
 +#endif // CONFIG_SCHED_BORE
 +
  	wait_bit_init();
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index c1eb9a1afd13..e2da8d773877 100644
+index c1eb9a1af..e2da8d773 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -167,7 +167,52 @@ static const struct file_operations sched_feat_fops = {
@@ -373,7 +372,7 @@ index c1eb9a1afd13..e2da8d773877 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 1fee282d40aa..052607af89a9 100644
+index 1fee282d4..4c8d7fbd5 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -19,6 +19,9 @@
@@ -386,7 +385,7 @@ index 1fee282d40aa..052607af89a9 100644
   */
  #include <linux/energy_model.h>
  #include <linux/mmap_lock.h>
-@@ -64,28 +67,133 @@
+@@ -64,28 +67,145 @@
   *   SCHED_TUNABLESCALING_LOG - scaled logarithmical, *1+ilog(ncpus)
   *   SCHED_TUNABLESCALING_LINEAR - scaled linear, *ncpus
   *
@@ -475,7 +474,19 @@ index 1fee282d40aa..052607af89a9 100644
 +	return __unscale_slice(delta, se->burst_score);
 +}
 +
-+void reweight_task(struct task_struct *p, int prio);
++static void reweight_entity(
++	struct cfs_rq *cfs_rq, struct sched_entity *se, unsigned long weight);
++
++static void renice_task(struct task_struct *p, int prio)
++{
++	struct sched_entity *se = &p->se;
++	struct cfs_rq *cfs_rq = cfs_rq_of(se);
++	struct load_weight *load = &se->load;
++	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
++
++	reweight_entity(cfs_rq, se, weight);
++	load->inv_weight = sched_prio_to_wmult[prio];
++}
 +
 +static void update_burst_score(struct sched_entity *se) {
 +	if (!entity_is_task(se)) return;
@@ -491,7 +502,7 @@ index 1fee282d40aa..052607af89a9 100644
 +
 +	u8 new_prio = min(39, prio + se->burst_score);
 +	if (new_prio != prev_prio)
-+		reweight_task(p, new_prio);
++		renice_task(p, new_prio);
 +}
 +
 +static void update_burst_penalty(struct sched_entity *se) {
@@ -531,7 +542,7 @@ index 1fee282d40aa..052607af89a9 100644
  
  static int __init setup_sched_thermal_decay_shift(char *str)
  {
-@@ -130,12 +238,8 @@ int __weak arch_asym_cpu_priority(int cpu)
+@@ -130,12 +250,8 @@ int __weak arch_asym_cpu_priority(int cpu)
   *
   * (default: 5 msec, units: microseconds)
   */
@@ -544,7 +555,7 @@ index 1fee282d40aa..052607af89a9 100644
  
  #ifdef CONFIG_NUMA_BALANCING
  /* Restrict the NUMA promotion throughput (MB/s) for each target node. */
-@@ -144,6 +248,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
+@@ -144,6 +260,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
  
  #ifdef CONFIG_SYSCTL
  static struct ctl_table sched_fair_sysctls[] = {
@@ -637,7 +648,7 @@ index 1fee282d40aa..052607af89a9 100644
  #ifdef CONFIG_CFS_BANDWIDTH
  	{
  		.procname       = "sched_cfs_bandwidth_slice_us",
-@@ -201,6 +391,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
+@@ -201,6 +403,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
   */
@@ -651,7 +662,7 @@ index 1fee282d40aa..052607af89a9 100644
  static unsigned int get_update_sysctl_factor(void)
  {
  	unsigned int cpus = min_t(unsigned int, num_online_cpus(), 8);
-@@ -231,6 +428,7 @@ static void update_sysctl(void)
+@@ -231,6 +440,7 @@ static void update_sysctl(void)
  	SET_SYSCTL(sched_base_slice);
  #undef SET_SYSCTL
  }
@@ -659,7 +670,7 @@ index 1fee282d40aa..052607af89a9 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -708,6 +906,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
+@@ -708,6 +918,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
  
  	vlag = avruntime - se->vruntime;
  	limit = calc_delta_fair(max_t(u64, 2*se->slice, TICK_NSEC), se);
@@ -669,7 +680,7 @@ index 1fee282d40aa..052607af89a9 100644
  
  	return clamp(vlag, -limit, limit);
  }
-@@ -868,6 +1069,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -868,6 +1081,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
  	return __node_2_se(left);
  }
  
@@ -709,7 +720,7 @@ index 1fee282d40aa..052607af89a9 100644
  /*
   * Earliest Eligible Virtual Deadline First
   *
-@@ -887,28 +1121,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -887,28 +1133,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   *
   * Which allows tree pruning through eligibility.
   */
@@ -745,7 +756,7 @@ index 1fee282d40aa..052607af89a9 100644
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -967,6 +1200,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -967,6 +1212,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
   * Scheduling class statistics methods:
   */
  #ifdef CONFIG_SMP
@@ -753,7 +764,7 @@ index 1fee282d40aa..052607af89a9 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -978,6 +1212,7 @@ int sched_update_scaling(void)
+@@ -978,6 +1224,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -761,7 +772,7 @@ index 1fee282d40aa..052607af89a9 100644
  #endif
  #endif
  
-@@ -1178,7 +1413,13 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1178,7 +1425,13 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	if (unlikely(delta_exec <= 0))
  		return;
  
@@ -775,7 +786,7 @@ index 1fee282d40aa..052607af89a9 100644
  	update_deadline(cfs_rq, curr);
  	update_min_vruntime(cfs_rq);
  
-@@ -5192,6 +5433,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5192,6 +5445,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	s64 lag = 0;
  
  	se->slice = sysctl_sched_base_slice;
@@ -787,7 +798,7 @@ index 1fee282d40aa..052607af89a9 100644
  	vslice = calc_delta_fair(se->slice, se);
  
  	/*
-@@ -5202,6 +5448,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5202,6 +5460,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 *
  	 * EEVDF: placement strategy #1 / #2
  	 */
@@ -797,7 +808,7 @@ index 1fee282d40aa..052607af89a9 100644
  	if (sched_feat(PLACE_LAG) && cfs_rq->nr_running) {
  		struct sched_entity *curr = cfs_rq->curr;
  		unsigned long load;
-@@ -5277,7 +5526,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5277,7 +5538,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 * on average, halfway through their slice, as such start tasks
  	 * off with half a slice to ease into the competition.
  	 */
@@ -809,7 +820,7 @@ index 1fee282d40aa..052607af89a9 100644
  		vslice /= 2;
  
  	/*
-@@ -5491,7 +5744,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
+@@ -5491,7 +5756,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
  	    cfs_rq->next && entity_eligible(cfs_rq, cfs_rq->next))
  		return cfs_rq->next;
  
@@ -818,7 +829,7 @@ index 1fee282d40aa..052607af89a9 100644
  }
  
  static bool check_cfs_rq_runtime(struct cfs_rq *cfs_rq);
-@@ -6859,6 +7112,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -6859,6 +7124,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	bool was_sched_idle = sched_idle_rq(rq);
  
  	util_est_dequeue(&rq->cfs, p);
@@ -833,7 +844,7 @@ index 1fee282d40aa..052607af89a9 100644
  
  	for_each_sched_entity(se) {
  		cfs_rq = cfs_rq_of(se);
-@@ -8427,7 +8688,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8427,7 +8700,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	/*
  	 * XXX pick_eevdf(cfs_rq) != se ?
  	 */
@@ -842,7 +853,7 @@ index 1fee282d40aa..052607af89a9 100644
  		goto preempt;
  
  	return;
-@@ -8645,16 +8906,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -8645,16 +8918,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -868,7 +879,7 @@ index 1fee282d40aa..052607af89a9 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -12722,6 +12992,9 @@ static void task_fork_fair(struct task_struct *p)
+@@ -12722,6 +13004,9 @@ static void task_fork_fair(struct task_struct *p)
  	curr = cfs_rq->curr;
  	if (curr)
  		update_curr(cfs_rq);
@@ -879,7 +890,7 @@ index 1fee282d40aa..052607af89a9 100644
  	rq_unlock(rq, &rf);
  }
 diff --git a/kernel/sched/features.h b/kernel/sched/features.h
-index 143f55df890b..3aad8900c35e 100644
+index 143f55df8..3aad8900c 100644
 --- a/kernel/sched/features.h
 +++ b/kernel/sched/features.h
 @@ -5,8 +5,28 @@
@@ -913,7 +924,7 @@ index 143f55df890b..3aad8900c35e 100644
  /*
   * Prefer to schedule the task we woke last (assuming it failed
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 556466836cd5..4b1d5ef83345 100644
+index 556466836..4b1d5ef83 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -1969,7 +1969,11 @@ static inline void dirty_sched_domain_sysctl(int cpu)
@@ -939,5 +950,5 @@ index 556466836cd5..4b1d5ef83345 100644
  #ifdef CONFIG_SCHED_DEBUG
  extern int sysctl_resched_latency_warn_ms;
 -- 
-2.46.0.rc1
+2.46.0
 

--- a/6.10/sched/0001-bore.patch
+++ b/6.10/sched/0001-bore.patch
@@ -1,22 +1,21 @@
-From 2425b187da6e8ccdff94f8010113be4f23d8a075 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Tue, 23 Jul 2024 18:36:54 +0200
+From 3816495f5635104fae1dda21b743f750c2914196 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@proton.me>
+Date: Sat, 3 Aug 2024 15:23:30 +0700
 Subject: [PATCH] bore
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  include/linux/sched.h   |  10 ++
  init/Kconfig            |  17 +++
- kernel/Kconfig.hz       |  16 +++
+ kernel/Kconfig.hz       |  16 ++
  kernel/sched/core.c     | 143 ++++++++++++++++++
  kernel/sched/debug.c    |  60 +++++++-
- kernel/sched/fair.c     | 310 ++++++++++++++++++++++++++++++++++++++--
+ kernel/sched/fair.c     | 322 ++++++++++++++++++++++++++++++++++++++--
  kernel/sched/features.h |  22 ++-
  kernel/sched/sched.h    |   7 +
- 8 files changed, 571 insertions(+), 14 deletions(-)
+ 8 files changed, 583 insertions(+), 14 deletions(-)
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index a5f4b48fc..df62c56b1 100644
+index 76214d7c8..9f65d367b 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -547,6 +547,16 @@ struct sched_entity {
@@ -91,10 +90,10 @@ index 38ef6d068..5f6eecd1e 100644
  config SCHED_HRTICK
  	def_bool HIGH_RES_TIMERS
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 59ce0841e..fa1681a2a 100644
+index ebf21373f..5d1c97612 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
-@@ -4515,6 +4515,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
+@@ -4512,6 +4512,138 @@ int wake_up_state(struct task_struct *p, unsigned int state)
  	return try_to_wake_up(p, state, 0);
  }
  
@@ -233,7 +232,7 @@ index 59ce0841e..fa1681a2a 100644
  /*
   * Perform scheduler related setup for a newly forked process p.
   * p is forked by current.
-@@ -4531,6 +4663,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
+@@ -4528,6 +4660,9 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
  	p->se.prev_sum_exec_runtime	= 0;
  	p->se.nr_migrations		= 0;
  	p->se.vruntime			= 0;
@@ -243,7 +242,7 @@ index 59ce0841e..fa1681a2a 100644
  	p->se.vlag			= 0;
  	p->se.slice			= sysctl_sched_base_slice;
  	INIT_LIST_HEAD(&p->se.group_node);
-@@ -4846,6 +4981,9 @@ void sched_cgroup_fork(struct task_struct *p, struct kernel_clone_args *kargs)
+@@ -4843,6 +4978,9 @@ void sched_cgroup_fork(struct task_struct *p, struct kernel_clone_args *kargs)
  
  void sched_post_fork(struct task_struct *p)
  {
@@ -253,13 +252,13 @@ index 59ce0841e..fa1681a2a 100644
  	uclamp_post_fork(p);
  }
  
-@@ -9933,6 +10071,11 @@ void __init sched_init(void)
+@@ -9930,6 +10068,11 @@ void __init sched_init(void)
  	BUG_ON(&dl_sched_class != &stop_sched_class + 1);
  #endif
  
 +#ifdef CONFIG_SCHED_BORE
 +	sched_init_bore();
-+	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.6 by Masahito Suzuki");
++	printk(KERN_INFO "BORE (Burst-Oriented Response Enhancer) CPU Scheduler modification 5.2.8 by Masahito Suzuki");
 +#endif // CONFIG_SCHED_BORE
 +
  	wait_bit_init();
@@ -373,7 +372,7 @@ index c1eb9a1af..e2da8d773 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 24dda708b..4cc33bb39 100644
+index 483c137b9..4c8d7fbd5 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -19,6 +19,9 @@
@@ -386,7 +385,7 @@ index 24dda708b..4cc33bb39 100644
   */
  #include <linux/energy_model.h>
  #include <linux/mmap_lock.h>
-@@ -64,20 +67,134 @@
+@@ -64,20 +67,146 @@
   *   SCHED_TUNABLESCALING_LOG - scaled logarithmical, *1+ilog(ncpus)
   *   SCHED_TUNABLESCALING_LINEAR - scaled linear, *ncpus
   *
@@ -466,7 +465,19 @@ index 24dda708b..4cc33bb39 100644
 +	return __unscale_slice(delta, se->burst_score);
 +}
 +
-+void reweight_task(struct task_struct *p, int prio);
++static void reweight_entity(
++	struct cfs_rq *cfs_rq, struct sched_entity *se, unsigned long weight);
++
++static void renice_task(struct task_struct *p, int prio)
++{
++	struct sched_entity *se = &p->se;
++	struct cfs_rq *cfs_rq = cfs_rq_of(se);
++	struct load_weight *load = &se->load;
++	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
++
++	reweight_entity(cfs_rq, se, weight);
++	load->inv_weight = sched_prio_to_wmult[prio];
++}
 +
 +static void update_burst_score(struct sched_entity *se) {
 +	if (!entity_is_task(se)) return;
@@ -482,7 +493,7 @@ index 24dda708b..4cc33bb39 100644
 +
 +	u8 new_prio = min(39, prio + se->burst_score);
 +	if (new_prio != prev_prio)
-+		reweight_task(p, new_prio);
++		renice_task(p, new_prio);
 +}
 +
 +static void update_burst_penalty(struct sched_entity *se) {
@@ -523,7 +534,7 @@ index 24dda708b..4cc33bb39 100644
  static int __init setup_sched_thermal_decay_shift(char *str)
  {
  	pr_warn("Ignoring the deprecated sched_thermal_decay_shift= option\n");
-@@ -131,6 +248,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
+@@ -131,6 +260,92 @@ static unsigned int sysctl_numa_balancing_promote_rate_limit = 65536;
  
  #ifdef CONFIG_SYSCTL
  static struct ctl_table sched_fair_sysctls[] = {
@@ -616,7 +627,7 @@ index 24dda708b..4cc33bb39 100644
  #ifdef CONFIG_CFS_BANDWIDTH
  	{
  		.procname       = "sched_cfs_bandwidth_slice_us",
-@@ -188,6 +391,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
+@@ -188,6 +403,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
   */
@@ -630,7 +641,7 @@ index 24dda708b..4cc33bb39 100644
  static unsigned int get_update_sysctl_factor(void)
  {
  	unsigned int cpus = min_t(unsigned int, num_online_cpus(), 8);
-@@ -218,6 +428,7 @@ static void update_sysctl(void)
+@@ -218,6 +440,7 @@ static void update_sysctl(void)
  	SET_SYSCTL(sched_base_slice);
  #undef SET_SYSCTL
  }
@@ -638,7 +649,7 @@ index 24dda708b..4cc33bb39 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -695,6 +906,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
+@@ -695,6 +918,9 @@ static s64 entity_lag(u64 avruntime, struct sched_entity *se)
  
  	vlag = avruntime - se->vruntime;
  	limit = calc_delta_fair(max_t(u64, 2*se->slice, TICK_NSEC), se);
@@ -648,7 +659,7 @@ index 24dda708b..4cc33bb39 100644
  
  	return clamp(vlag, -limit, limit);
  }
-@@ -855,6 +1069,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -855,6 +1081,39 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
  	return __node_2_se(left);
  }
  
@@ -688,7 +699,7 @@ index 24dda708b..4cc33bb39 100644
  /*
   * Earliest Eligible Virtual Deadline First
   *
-@@ -874,28 +1121,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -874,28 +1133,27 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   *
   * Which allows tree pruning through eligibility.
   */
@@ -724,7 +735,7 @@ index 24dda708b..4cc33bb39 100644
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -954,6 +1200,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -954,6 +1212,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
   * Scheduling class statistics methods:
   */
  #ifdef CONFIG_SMP
@@ -732,7 +743,7 @@ index 24dda708b..4cc33bb39 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -965,6 +1212,7 @@ int sched_update_scaling(void)
+@@ -965,6 +1224,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -740,7 +751,7 @@ index 24dda708b..4cc33bb39 100644
  #endif
  #endif
  
-@@ -1165,7 +1413,13 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1165,7 +1425,13 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	if (unlikely(delta_exec <= 0))
  		return;
  
@@ -754,7 +765,7 @@ index 24dda708b..4cc33bb39 100644
  	update_deadline(cfs_rq, curr);
  	update_min_vruntime(cfs_rq);
  
-@@ -5180,6 +5434,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5179,6 +5445,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	s64 lag = 0;
  
  	se->slice = sysctl_sched_base_slice;
@@ -766,7 +777,7 @@ index 24dda708b..4cc33bb39 100644
  	vslice = calc_delta_fair(se->slice, se);
  
  	/*
-@@ -5190,6 +5449,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5189,6 +5460,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 *
  	 * EEVDF: placement strategy #1 / #2
  	 */
@@ -776,7 +787,7 @@ index 24dda708b..4cc33bb39 100644
  	if (sched_feat(PLACE_LAG) && cfs_rq->nr_running) {
  		struct sched_entity *curr = cfs_rq->curr;
  		unsigned long load;
-@@ -5265,7 +5527,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5264,7 +5538,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	 * on average, halfway through their slice, as such start tasks
  	 * off with half a slice to ease into the competition.
  	 */
@@ -788,7 +799,7 @@ index 24dda708b..4cc33bb39 100644
  		vslice /= 2;
  
  	/*
-@@ -5479,7 +5745,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
+@@ -5478,7 +5756,7 @@ pick_next_entity(struct cfs_rq *cfs_rq)
  	    cfs_rq->next && entity_eligible(cfs_rq, cfs_rq->next))
  		return cfs_rq->next;
  
@@ -797,7 +808,7 @@ index 24dda708b..4cc33bb39 100644
  }
  
  static bool check_cfs_rq_runtime(struct cfs_rq *cfs_rq);
-@@ -6847,6 +7113,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -6846,6 +7124,14 @@ static void dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	bool was_sched_idle = sched_idle_rq(rq);
  
  	util_est_dequeue(&rq->cfs, p);
@@ -812,7 +823,7 @@ index 24dda708b..4cc33bb39 100644
  
  	for_each_sched_entity(se) {
  		cfs_rq = cfs_rq_of(se);
-@@ -8415,7 +8689,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+@@ -8414,7 +8700,7 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
  	/*
  	 * XXX pick_eevdf(cfs_rq) != se ?
  	 */
@@ -821,7 +832,7 @@ index 24dda708b..4cc33bb39 100644
  		goto preempt;
  
  	return;
-@@ -8633,16 +8907,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -8632,16 +8918,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -847,7 +858,7 @@ index 24dda708b..4cc33bb39 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -12710,6 +12993,9 @@ static void task_fork_fair(struct task_struct *p)
+@@ -12709,6 +13004,9 @@ static void task_fork_fair(struct task_struct *p)
  	curr = cfs_rq->curr;
  	if (curr)
  		update_curr(cfs_rq);
@@ -892,7 +903,7 @@ index 143f55df8..3aad8900c 100644
  /*
   * Prefer to schedule the task we woke last (assuming it failed
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index ef20c6100..deb748f31 100644
+index 38aeedd8a..aa0ae3fb9 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -1969,7 +1969,11 @@ static inline void dirty_sched_domain_sysctl(int cpu)
@@ -918,5 +929,5 @@ index ef20c6100..deb748f31 100644
  #ifdef CONFIG_SCHED_DEBUG
  extern int sysctl_resched_latency_warn_ms;
 -- 
-2.45.2.606.g9005149a4a
+2.46.0
 


### PR DESCRIPTION
Update BORE patches to 5.2.8. With this version, bore-cachy-ext.patch isn't needed anymore, but I still kept it until the PKGBUILDs are refactored. I also rebased RT patches to update bore-cachy-rt.patch