### PR TITLE
6.12: Update amd-pstate

### DIFF
--- a/6.12/0001-amd-cache-optimizer.patch
+++ b/6.12/0001-amd-cache-optimizer.patch
@@ -1,7 +1,7 @@
 From e794346770e7ceb5d7a886444cfd04736e423af5 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:33:22 +0100
-Subject: [PATCH 01/11] amd-cache-optimizer
+Subject: [PATCH 01/10] amd-cache-optimizer
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -289,5 +289,5 @@ index 000000000000..679613d02b9a
 +MODULE_DESCRIPTION("AMD 3D V-Cache Performance Optimizer Driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0002-amd-pstate.patch
+++ b/6.12/0002-amd-pstate.patch
@@ -1,7 +1,7 @@
-From 487312dd5a0d3b07abc7e4cd55e52008d8a6258d Mon Sep 17 00:00:00 2001
+From b9c92ae371d8f560fd2313f3504fc5ae30b4485d Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:33:33 +0100
-Subject: [PATCH 02/11] amd-pstate
+Subject: [PATCH 02/10] amd-pstate
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -17,9 +17,9 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  arch/x86/kernel/smpboot.c                |   5 +-
  arch/x86/mm/init.c                       |  23 ++-
  drivers/cpufreq/amd-pstate-ut.c          |   6 +-
- drivers/cpufreq/amd-pstate.c             | 227 ++++++++++-------------
+ drivers/cpufreq/amd-pstate.c             | 231 ++++++++++-------------
  tools/arch/x86/include/asm/cpufeatures.h |   2 +-
- 14 files changed, 212 insertions(+), 151 deletions(-)
+ 14 files changed, 214 insertions(+), 153 deletions(-)
 
 diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
 index 913fd3a7bac6..a7c93191b7c6 100644
@@ -343,7 +343,7 @@ index f66701514d90..a261d7300951 100644
  		}
  
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index b63863f77c67..18f79360cc68 100644
+index b63863f77c67..d7630bab2516 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -233,7 +233,7 @@ static int amd_pstate_get_energy_pref_index(struct amd_cpudata *cpudata)
@@ -590,7 +590,16 @@ index b63863f77c67..18f79360cc68 100644
  	if (ret) {
  		pr_err("failed to enable cppc during amd-pstate driver registration, return %d\n",
  		       ret);
-@@ -1507,26 +1526,13 @@ static void amd_pstate_epp_cpu_exit(struct cpufreq_policy *policy)
+@@ -1485,6 +1504,8 @@ static int amd_pstate_epp_cpu_init(struct cpufreq_policy *policy)
+ 		WRITE_ONCE(cpudata->cppc_cap1_cached, value);
+ 	}
+ 
++	current_pstate_driver->adjust_perf = NULL;
++
+ 	return 0;
+ 
+ free_cpudata1:
+@@ -1507,26 +1528,13 @@ static void amd_pstate_epp_cpu_exit(struct cpufreq_policy *policy)
  static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
  {
  	struct amd_cpudata *cpudata = policy->driver_data;
@@ -620,7 +629,7 @@ index b63863f77c67..18f79360cc68 100644
  
  	max_perf = clamp_t(unsigned long, max_perf, cpudata->min_limit_perf,
  			cpudata->max_limit_perf);
-@@ -1535,7 +1541,7 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
+@@ -1535,7 +1543,7 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
  	value = READ_ONCE(cpudata->cppc_req_cached);
  
  	if (cpudata->policy == CPUFREQ_POLICY_PERFORMANCE)
@@ -629,7 +638,7 @@ index b63863f77c67..18f79360cc68 100644
  
  	/* Initial min/max values for CPPC Performance Controls Register */
  	value &= ~AMD_CPPC_MIN_PERF(~0L);
-@@ -1563,12 +1569,6 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
+@@ -1563,12 +1571,6 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
  	if (cpudata->policy == CPUFREQ_POLICY_PERFORMANCE)
  		epp = 0;
  
@@ -642,7 +651,7 @@ index b63863f77c67..18f79360cc68 100644
  	WRITE_ONCE(cpudata->cppc_req_cached, value);
  	return amd_pstate_set_epp(cpudata, epp);
  }
-@@ -1605,7 +1605,7 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
+@@ -1605,7 +1607,7 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
  	u64 value, max_perf;
  	int ret;
  
@@ -651,7 +660,7 @@ index b63863f77c67..18f79360cc68 100644
  	if (ret)
  		pr_err("failed to enable amd pstate during resume, return %d\n", ret);
  
-@@ -1616,8 +1616,9 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
+@@ -1616,8 +1618,9 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
  		wrmsrl_on_cpu(cpudata->cpu, MSR_AMD_CPPC_REQ, value);
  	} else {
  		perf_ctrls.max_perf = max_perf;
@@ -662,7 +671,7 @@ index b63863f77c67..18f79360cc68 100644
  	}
  }
  
-@@ -1657,9 +1658,11 @@ static void amd_pstate_epp_offline(struct cpufreq_policy *policy)
+@@ -1657,9 +1660,11 @@ static void amd_pstate_epp_offline(struct cpufreq_policy *policy)
  		wrmsrl_on_cpu(cpudata->cpu, MSR_AMD_CPPC_REQ, value);
  	} else {
  		perf_ctrls.desired_perf = 0;
@@ -675,7 +684,7 @@ index b63863f77c67..18f79360cc68 100644
  	}
  	mutex_unlock(&amd_pstate_limits_lock);
  }
-@@ -1679,13 +1682,6 @@ static int amd_pstate_epp_cpu_offline(struct cpufreq_policy *policy)
+@@ -1679,13 +1684,6 @@ static int amd_pstate_epp_cpu_offline(struct cpufreq_policy *policy)
  	return 0;
  }
  
@@ -689,7 +698,7 @@ index b63863f77c67..18f79360cc68 100644
  static int amd_pstate_epp_suspend(struct cpufreq_policy *policy)
  {
  	struct amd_cpudata *cpudata = policy->driver_data;
-@@ -1699,7 +1695,7 @@ static int amd_pstate_epp_suspend(struct cpufreq_policy *policy)
+@@ -1699,7 +1697,7 @@ static int amd_pstate_epp_suspend(struct cpufreq_policy *policy)
  	cpudata->suspended = true;
  
  	/* disable CPPC in lowlevel firmware */
@@ -698,7 +707,7 @@ index b63863f77c67..18f79360cc68 100644
  	if (ret)
  		pr_err("failed to suspend, return %d\n", ret);
  
-@@ -1741,7 +1737,7 @@ static struct cpufreq_driver amd_pstate_driver = {
+@@ -1741,7 +1739,7 @@ static struct cpufreq_driver amd_pstate_driver = {
  
  static struct cpufreq_driver amd_pstate_epp_driver = {
  	.flags		= CPUFREQ_CONST_LOOPS,
@@ -707,7 +716,7 @@ index b63863f77c67..18f79360cc68 100644
  	.setpolicy	= amd_pstate_epp_set_policy,
  	.init		= amd_pstate_epp_cpu_init,
  	.exit		= amd_pstate_epp_cpu_exit,
-@@ -1755,26 +1751,7 @@ static struct cpufreq_driver amd_pstate_epp_driver = {
+@@ -1755,26 +1753,7 @@ static struct cpufreq_driver amd_pstate_epp_driver = {
  	.attr		= amd_pstate_epp_attr,
  };
  
@@ -735,7 +744,7 @@ index b63863f77c67..18f79360cc68 100644
   * CPPC function is not supported for family ID 17H with model_ID ranging from 0x10 to 0x2F.
   * show the debug message that helps to check if the CPU has CPPC support for loading issue.
   */
-@@ -1864,10 +1841,10 @@ static int __init amd_pstate_init(void)
+@@ -1864,10 +1843,10 @@ static int __init amd_pstate_init(void)
  	if (cppc_state == AMD_PSTATE_UNDEFINED) {
  		/* Disable on the following configs by default:
  		 * 1. Undefined platforms
@@ -748,7 +757,7 @@ index b63863f77c67..18f79360cc68 100644
  			pr_info("driver load is disabled, boot with specific mode to enable this\n");
  			return -ENODEV;
  		}
-@@ -1875,19 +1852,15 @@ static int __init amd_pstate_init(void)
+@@ -1875,50 +1854,31 @@ static int __init amd_pstate_init(void)
  		cppc_state = CONFIG_X86_AMD_PSTATE_DEFAULT_MODE;
  	}
  
@@ -766,17 +775,13 @@ index b63863f77c67..18f79360cc68 100644
 -		break;
 -	default:
 -		return -EINVAL;
-+	}
-+
-+	ret = amd_pstate_register_driver(cppc_state);
-+	if (ret) {
-+		pr_err("failed to register with return %d\n", ret);
-+		return ret;
  	}
  
  	/* capability check */
-@@ -1897,9 +1870,9 @@ static int __init amd_pstate_init(void)
- 			current_pstate_driver->adjust_perf = amd_pstate_adjust_perf;
+ 	if (cpu_feature_enabled(X86_FEATURE_CPPC)) {
+ 		pr_debug("AMD CPPC MSR based functionality is supported\n");
+-		if (cppc_state != AMD_PSTATE_ACTIVE)
+-			current_pstate_driver->adjust_perf = amd_pstate_adjust_perf;
  	} else {
  		pr_debug("AMD CPPC shared memory based functionality is supported\n");
 -		static_call_update(amd_pstate_enable, cppc_enable);
@@ -787,27 +792,32 @@ index b63863f77c67..18f79360cc68 100644
 +		static_call_update(amd_pstate_update_perf, shmem_update_perf);
  	}
  
- 	if (amd_pstate_prefcore) {
-@@ -1908,19 +1881,6 @@ static int __init amd_pstate_init(void)
- 			return ret;
- 	}
- 
--	/* enable amd pstate feature */
--	ret = amd_pstate_enable(true);
--	if (ret) {
--		pr_err("failed to enable driver mode(%d)\n", cppc_state);
--		return ret;
+-	if (amd_pstate_prefcore) {
+-		ret = amd_detect_prefcore(&amd_pstate_prefcore);
+-		if (ret)
+-			return ret;
 -	}
 -
+-	/* enable amd pstate feature */
+-	ret = amd_pstate_enable(true);
++	ret = amd_pstate_register_driver(cppc_state);
+ 	if (ret) {
+-		pr_err("failed to enable driver mode(%d)\n", cppc_state);
++		pr_err("failed to register with return %d\n", ret);
+ 		return ret;
+ 	}
+ 
 -	ret = cpufreq_register_driver(current_pstate_driver);
 -	if (ret) {
 -		pr_err("failed to register with return %d\n", ret);
 -		goto disable_driver;
--	}
--
++	if (amd_pstate_prefcore) {
++		ret = amd_detect_prefcore(&amd_pstate_prefcore);
++		if (ret)
++			return ret;
+ 	}
+ 
  	dev_root = bus_get_dev_root(&cpu_subsys);
- 	if (dev_root) {
- 		ret = sysfs_create_group(&dev_root->kobj, &amd_pstate_global_attr_group);
 @@ -1935,8 +1895,7 @@ static int __init amd_pstate_init(void)
  
  global_attr_free:
@@ -832,5 +842,5 @@ index dd4682857c12..23698d0f4bb4 100644
  /*
   * BUG word(s)
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0003-bbr3.patch
+++ b/6.12/0003-bbr3.patch
@@ -1,7 +1,7 @@
-From 6ad50608febea8ce4fd907d57e4146f745b2ddb6 Mon Sep 17 00:00:00 2001
+From bcd12930b7588197e983e8e41cfe6139ec39d3f3 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:33:43 +0100
-Subject: [PATCH 03/11] bbr3
+Subject: [PATCH 03/10] bbr3
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -3382,5 +3382,5 @@ index 79064580c8c0..697270ce1ea6 100644
  	event = icsk->icsk_pending;
  
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0004-cachy.patch
+++ b/6.12/0004-cachy.patch
@@ -1,7 +1,7 @@
-From effb72aa045ca5a5e554e483ef6808ef27778b14 Mon Sep 17 00:00:00 2001
+From 9d24c4ebe90acae0226de6cd7913c0965aff8b9e Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:34:28 +0100
-Subject: [PATCH 04/11] cachy
+Subject: [PATCH 04/10] cachy
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -6826,5 +6826,5 @@ index 2b698f8419fe..fd039c41d1c8 100644
  		release_sock(sk);
  		if (reqsk_queue_empty(&icsk->icsk_accept_queue))
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0005-crypto.patch
+++ b/6.12/0005-crypto.patch
@@ -1,7 +1,7 @@
-From 10594d75e7075191a82145e0e7237a9e54292cfa Mon Sep 17 00:00:00 2001
+From ead3830c93e6570185a096bbf9804a75cc6fdd4e Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:34:40 +0100
-Subject: [PATCH 05/11] crypto
+Subject: [PATCH 05/10] crypto
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -1601,5 +1601,5 @@ index bbcff1fb78cb..752812bc4991 100644
  	## PCLMULQDQ tables
  	## Table is 128 entries x 2 words (8 bytes) each
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0006-fixes.patch
+++ b/6.12/0006-fixes.patch
@@ -1,7 +1,7 @@
-From 19590e0601a87a13a8eca587fd2e6aef18e75b8e Mon Sep 17 00:00:00 2001
+From b672406089933621d6d099c119a8a0b9ed439ff5 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:34:49 +0100
-Subject: [PATCH 06/11] fixes
+Subject: [PATCH 06/10] fixes
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -455,5 +455,5 @@ index dc5d2a6fcfc4..4a93fd433689 100644
  	}
  	mutex_unlock(&shrinker_mutex);
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0007-ksm.patch
+++ b/6.12/0007-ksm.patch
@@ -1,7 +1,7 @@
-From 442d6e6f979896c20a01d4c9cc8a4117277cc9f3 Mon Sep 17 00:00:00 2001
+From 9211810253dacaf1f017c2c021bb515bc0ac96f7 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:35:00 +0100
-Subject: [PATCH 07/11] ksm
+Subject: [PATCH 07/10] ksm
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -429,5 +429,5 @@ index 01071182763e..7394bad8178e 100644
 +464  common	process_ksm_disable	sys_process_ksm_disable		sys_process_ksm_disable
 +465  common	process_ksm_status	sys_process_ksm_status		sys_process_ksm_status
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0008-ntsync.patch
+++ b/6.12/0008-ntsync.patch
@@ -1,7 +1,7 @@
-From 54d0180316e24ab57ee2886f3b5bcf63f5806773 Mon Sep 17 00:00:00 2001
+From b9dd96713157acae8c2657e3821a07d8640fbaed Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:35:15 +0100
-Subject: [PATCH 08/11] ntsync
+Subject: [PATCH 08/10] ntsync
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -3085,5 +3085,5 @@ index 000000000000..5fa2c9a0768c
 +
 +TEST_HARNESS_MAIN
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0009-openvpn-dco.patch
+++ b/6.12/0009-openvpn-dco.patch
@@ -1,7 +1,7 @@
-From 9e73add0e4133388891245205851ddb769daab1c Mon Sep 17 00:00:00 2001
+From ee2dd29bf1dc8eff73ccd1cb9f31fab0c837f3cf Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:35:28 +0100
-Subject: [PATCH 09/11] openvpn-dco
+Subject: [PATCH 09/10] openvpn-dco
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -9946,5 +9946,5 @@ index 000000000000..32f14bd9347a
 +4 10.10.4.2 1 5.5.5.5
 +5 10.10.5.2 1 5.5.5.6
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/0010-zstd.patch
+++ b/6.12/0010-zstd.patch
@@ -1,7 +1,7 @@
-From c799b45059e93edb95506856b776ec6aadd06bed Mon Sep 17 00:00:00 2001
+From 3580fd890324b54420c9e4d286a2f99ffe2fa4d5 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:36:55 +0100
-Subject: [PATCH 11/11] zstd
+Subject: [PATCH 10/10] zstd
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -18648,5 +18648,5 @@ index 469fc3059be0..0ae819f0c927 100644
  EXPORT_SYMBOL(zstd_reset_dstream);
  
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/6.12/all/0001-cachyos-base-all.patch
+++ b/6.12/all/0001-cachyos-base-all.patch
@@ -1,7 +1,7 @@
 From e794346770e7ceb5d7a886444cfd04736e423af5 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:33:22 +0100
-Subject: [PATCH 01/11] amd-cache-optimizer
+Subject: [PATCH 01/10] amd-cache-optimizer
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -289,12 +289,12 @@ index 000000000000..679613d02b9a
 +MODULE_DESCRIPTION("AMD 3D V-Cache Performance Optimizer Driver");
 +MODULE_LICENSE("GPL");
 -- 
-2.47.0.rc0
+2.47.0
 
-From 487312dd5a0d3b07abc7e4cd55e52008d8a6258d Mon Sep 17 00:00:00 2001
+From b9c92ae371d8f560fd2313f3504fc5ae30b4485d Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:33:33 +0100
-Subject: [PATCH 02/11] amd-pstate
+Subject: [PATCH 02/10] amd-pstate
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -310,9 +310,9 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  arch/x86/kernel/smpboot.c                |   5 +-
  arch/x86/mm/init.c                       |  23 ++-
  drivers/cpufreq/amd-pstate-ut.c          |   6 +-
- drivers/cpufreq/amd-pstate.c             | 227 ++++++++++-------------
+ drivers/cpufreq/amd-pstate.c             | 231 ++++++++++-------------
  tools/arch/x86/include/asm/cpufeatures.h |   2 +-
- 14 files changed, 212 insertions(+), 151 deletions(-)
+ 14 files changed, 214 insertions(+), 153 deletions(-)
 
 diff --git a/arch/x86/include/asm/cpufeatures.h b/arch/x86/include/asm/cpufeatures.h
 index 913fd3a7bac6..a7c93191b7c6 100644
@@ -636,7 +636,7 @@ index f66701514d90..a261d7300951 100644
  		}
  
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index b63863f77c67..18f79360cc68 100644
+index b63863f77c67..d7630bab2516 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -233,7 +233,7 @@ static int amd_pstate_get_energy_pref_index(struct amd_cpudata *cpudata)
@@ -883,7 +883,16 @@ index b63863f77c67..18f79360cc68 100644
  	if (ret) {
  		pr_err("failed to enable cppc during amd-pstate driver registration, return %d\n",
  		       ret);
-@@ -1507,26 +1526,13 @@ static void amd_pstate_epp_cpu_exit(struct cpufreq_policy *policy)
+@@ -1485,6 +1504,8 @@ static int amd_pstate_epp_cpu_init(struct cpufreq_policy *policy)
+ 		WRITE_ONCE(cpudata->cppc_cap1_cached, value);
+ 	}
+ 
++	current_pstate_driver->adjust_perf = NULL;
++
+ 	return 0;
+ 
+ free_cpudata1:
+@@ -1507,26 +1528,13 @@ static void amd_pstate_epp_cpu_exit(struct cpufreq_policy *policy)
  static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
  {
  	struct amd_cpudata *cpudata = policy->driver_data;
@@ -913,7 +922,7 @@ index b63863f77c67..18f79360cc68 100644
  
  	max_perf = clamp_t(unsigned long, max_perf, cpudata->min_limit_perf,
  			cpudata->max_limit_perf);
-@@ -1535,7 +1541,7 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
+@@ -1535,7 +1543,7 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
  	value = READ_ONCE(cpudata->cppc_req_cached);
  
  	if (cpudata->policy == CPUFREQ_POLICY_PERFORMANCE)
@@ -922,7 +931,7 @@ index b63863f77c67..18f79360cc68 100644
  
  	/* Initial min/max values for CPPC Performance Controls Register */
  	value &= ~AMD_CPPC_MIN_PERF(~0L);
-@@ -1563,12 +1569,6 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
+@@ -1563,12 +1571,6 @@ static int amd_pstate_epp_update_limit(struct cpufreq_policy *policy)
  	if (cpudata->policy == CPUFREQ_POLICY_PERFORMANCE)
  		epp = 0;
  
@@ -935,7 +944,7 @@ index b63863f77c67..18f79360cc68 100644
  	WRITE_ONCE(cpudata->cppc_req_cached, value);
  	return amd_pstate_set_epp(cpudata, epp);
  }
-@@ -1605,7 +1605,7 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
+@@ -1605,7 +1607,7 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
  	u64 value, max_perf;
  	int ret;
  
@@ -944,7 +953,7 @@ index b63863f77c67..18f79360cc68 100644
  	if (ret)
  		pr_err("failed to enable amd pstate during resume, return %d\n", ret);
  
-@@ -1616,8 +1616,9 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
+@@ -1616,8 +1618,9 @@ static void amd_pstate_epp_reenable(struct amd_cpudata *cpudata)
  		wrmsrl_on_cpu(cpudata->cpu, MSR_AMD_CPPC_REQ, value);
  	} else {
  		perf_ctrls.max_perf = max_perf;
@@ -955,7 +964,7 @@ index b63863f77c67..18f79360cc68 100644
  	}
  }
  
-@@ -1657,9 +1658,11 @@ static void amd_pstate_epp_offline(struct cpufreq_policy *policy)
+@@ -1657,9 +1660,11 @@ static void amd_pstate_epp_offline(struct cpufreq_policy *policy)
  		wrmsrl_on_cpu(cpudata->cpu, MSR_AMD_CPPC_REQ, value);
  	} else {
  		perf_ctrls.desired_perf = 0;
@@ -968,7 +977,7 @@ index b63863f77c67..18f79360cc68 100644
  	}
  	mutex_unlock(&amd_pstate_limits_lock);
  }
-@@ -1679,13 +1682,6 @@ static int amd_pstate_epp_cpu_offline(struct cpufreq_policy *policy)
+@@ -1679,13 +1684,6 @@ static int amd_pstate_epp_cpu_offline(struct cpufreq_policy *policy)
  	return 0;
  }
  
@@ -982,7 +991,7 @@ index b63863f77c67..18f79360cc68 100644
  static int amd_pstate_epp_suspend(struct cpufreq_policy *policy)
  {
  	struct amd_cpudata *cpudata = policy->driver_data;
-@@ -1699,7 +1695,7 @@ static int amd_pstate_epp_suspend(struct cpufreq_policy *policy)
+@@ -1699,7 +1697,7 @@ static int amd_pstate_epp_suspend(struct cpufreq_policy *policy)
  	cpudata->suspended = true;
  
  	/* disable CPPC in lowlevel firmware */
@@ -991,7 +1000,7 @@ index b63863f77c67..18f79360cc68 100644
  	if (ret)
  		pr_err("failed to suspend, return %d\n", ret);
  
-@@ -1741,7 +1737,7 @@ static struct cpufreq_driver amd_pstate_driver = {
+@@ -1741,7 +1739,7 @@ static struct cpufreq_driver amd_pstate_driver = {
  
  static struct cpufreq_driver amd_pstate_epp_driver = {
  	.flags		= CPUFREQ_CONST_LOOPS,
@@ -1000,7 +1009,7 @@ index b63863f77c67..18f79360cc68 100644
  	.setpolicy	= amd_pstate_epp_set_policy,
  	.init		= amd_pstate_epp_cpu_init,
  	.exit		= amd_pstate_epp_cpu_exit,
-@@ -1755,26 +1751,7 @@ static struct cpufreq_driver amd_pstate_epp_driver = {
+@@ -1755,26 +1753,7 @@ static struct cpufreq_driver amd_pstate_epp_driver = {
  	.attr		= amd_pstate_epp_attr,
  };
  
@@ -1028,7 +1037,7 @@ index b63863f77c67..18f79360cc68 100644
   * CPPC function is not supported for family ID 17H with model_ID ranging from 0x10 to 0x2F.
   * show the debug message that helps to check if the CPU has CPPC support for loading issue.
   */
-@@ -1864,10 +1841,10 @@ static int __init amd_pstate_init(void)
+@@ -1864,10 +1843,10 @@ static int __init amd_pstate_init(void)
  	if (cppc_state == AMD_PSTATE_UNDEFINED) {
  		/* Disable on the following configs by default:
  		 * 1. Undefined platforms
@@ -1041,7 +1050,7 @@ index b63863f77c67..18f79360cc68 100644
  			pr_info("driver load is disabled, boot with specific mode to enable this\n");
  			return -ENODEV;
  		}
-@@ -1875,19 +1852,15 @@ static int __init amd_pstate_init(void)
+@@ -1875,50 +1854,31 @@ static int __init amd_pstate_init(void)
  		cppc_state = CONFIG_X86_AMD_PSTATE_DEFAULT_MODE;
  	}
  
@@ -1059,17 +1068,13 @@ index b63863f77c67..18f79360cc68 100644
 -		break;
 -	default:
 -		return -EINVAL;
-+	}
-+
-+	ret = amd_pstate_register_driver(cppc_state);
-+	if (ret) {
-+		pr_err("failed to register with return %d\n", ret);
-+		return ret;
  	}
  
  	/* capability check */
-@@ -1897,9 +1870,9 @@ static int __init amd_pstate_init(void)
- 			current_pstate_driver->adjust_perf = amd_pstate_adjust_perf;
+ 	if (cpu_feature_enabled(X86_FEATURE_CPPC)) {
+ 		pr_debug("AMD CPPC MSR based functionality is supported\n");
+-		if (cppc_state != AMD_PSTATE_ACTIVE)
+-			current_pstate_driver->adjust_perf = amd_pstate_adjust_perf;
  	} else {
  		pr_debug("AMD CPPC shared memory based functionality is supported\n");
 -		static_call_update(amd_pstate_enable, cppc_enable);
@@ -1080,27 +1085,32 @@ index b63863f77c67..18f79360cc68 100644
 +		static_call_update(amd_pstate_update_perf, shmem_update_perf);
  	}
  
- 	if (amd_pstate_prefcore) {
-@@ -1908,19 +1881,6 @@ static int __init amd_pstate_init(void)
- 			return ret;
- 	}
- 
--	/* enable amd pstate feature */
--	ret = amd_pstate_enable(true);
--	if (ret) {
--		pr_err("failed to enable driver mode(%d)\n", cppc_state);
--		return ret;
+-	if (amd_pstate_prefcore) {
+-		ret = amd_detect_prefcore(&amd_pstate_prefcore);
+-		if (ret)
+-			return ret;
 -	}
 -
+-	/* enable amd pstate feature */
+-	ret = amd_pstate_enable(true);
++	ret = amd_pstate_register_driver(cppc_state);
+ 	if (ret) {
+-		pr_err("failed to enable driver mode(%d)\n", cppc_state);
++		pr_err("failed to register with return %d\n", ret);
+ 		return ret;
+ 	}
+ 
 -	ret = cpufreq_register_driver(current_pstate_driver);
 -	if (ret) {
 -		pr_err("failed to register with return %d\n", ret);
 -		goto disable_driver;
--	}
--
++	if (amd_pstate_prefcore) {
++		ret = amd_detect_prefcore(&amd_pstate_prefcore);
++		if (ret)
++			return ret;
+ 	}
+ 
  	dev_root = bus_get_dev_root(&cpu_subsys);
- 	if (dev_root) {
- 		ret = sysfs_create_group(&dev_root->kobj, &amd_pstate_global_attr_group);
 @@ -1935,8 +1895,7 @@ static int __init amd_pstate_init(void)
  
  global_attr_free:
@@ -1125,12 +1135,12 @@ index dd4682857c12..23698d0f4bb4 100644
  /*
   * BUG word(s)
 -- 
-2.47.0.rc0
+2.47.0
 
-From 6ad50608febea8ce4fd907d57e4146f745b2ddb6 Mon Sep 17 00:00:00 2001
+From bcd12930b7588197e983e8e41cfe6139ec39d3f3 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:33:43 +0100
-Subject: [PATCH 03/11] bbr3
+Subject: [PATCH 03/10] bbr3
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -4511,12 +4521,12 @@ index 79064580c8c0..697270ce1ea6 100644
  	event = icsk->icsk_pending;
  
 -- 
-2.47.0.rc0
+2.47.0
 
-From effb72aa045ca5a5e554e483ef6808ef27778b14 Mon Sep 17 00:00:00 2001
+From 9d24c4ebe90acae0226de6cd7913c0965aff8b9e Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:34:28 +0100
-Subject: [PATCH 04/11] cachy
+Subject: [PATCH 04/10] cachy
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -11341,12 +11351,12 @@ index 2b698f8419fe..fd039c41d1c8 100644
  		release_sock(sk);
  		if (reqsk_queue_empty(&icsk->icsk_accept_queue))
 -- 
-2.47.0.rc0
+2.47.0
 
-From 10594d75e7075191a82145e0e7237a9e54292cfa Mon Sep 17 00:00:00 2001
+From ead3830c93e6570185a096bbf9804a75cc6fdd4e Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:34:40 +0100
-Subject: [PATCH 05/11] crypto
+Subject: [PATCH 05/10] crypto
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -12946,12 +12956,12 @@ index bbcff1fb78cb..752812bc4991 100644
  	## PCLMULQDQ tables
  	## Table is 128 entries x 2 words (8 bytes) each
 -- 
-2.47.0.rc0
+2.47.0
 
-From 19590e0601a87a13a8eca587fd2e6aef18e75b8e Mon Sep 17 00:00:00 2001
+From b672406089933621d6d099c119a8a0b9ed439ff5 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:34:49 +0100
-Subject: [PATCH 06/11] fixes
+Subject: [PATCH 06/10] fixes
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -13405,12 +13415,12 @@ index dc5d2a6fcfc4..4a93fd433689 100644
  	}
  	mutex_unlock(&shrinker_mutex);
 -- 
-2.47.0.rc0
+2.47.0
 
-From 442d6e6f979896c20a01d4c9cc8a4117277cc9f3 Mon Sep 17 00:00:00 2001
+From 9211810253dacaf1f017c2c021bb515bc0ac96f7 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:35:00 +0100
-Subject: [PATCH 07/11] ksm
+Subject: [PATCH 07/10] ksm
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -13838,12 +13848,12 @@ index 01071182763e..7394bad8178e 100644
 +464  common	process_ksm_disable	sys_process_ksm_disable		sys_process_ksm_disable
 +465  common	process_ksm_status	sys_process_ksm_status		sys_process_ksm_status
 -- 
-2.47.0.rc0
+2.47.0
 
-From 54d0180316e24ab57ee2886f3b5bcf63f5806773 Mon Sep 17 00:00:00 2001
+From b9dd96713157acae8c2657e3821a07d8640fbaed Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:35:15 +0100
-Subject: [PATCH 08/11] ntsync
+Subject: [PATCH 08/10] ntsync
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -16927,12 +16937,12 @@ index 000000000000..5fa2c9a0768c
 +
 +TEST_HARNESS_MAIN
 -- 
-2.47.0.rc0
+2.47.0
 
-From 9e73add0e4133388891245205851ddb769daab1c Mon Sep 17 00:00:00 2001
+From ee2dd29bf1dc8eff73ccd1cb9f31fab0c837f3cf Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:35:28 +0100
-Subject: [PATCH 09/11] openvpn-dco
+Subject: [PATCH 09/10] openvpn-dco
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -26877,12 +26887,12 @@ index 000000000000..32f14bd9347a
 +4 10.10.4.2 1 5.5.5.5
 +5 10.10.5.2 1 5.5.5.6
 -- 
-2.47.0.rc0
+2.47.0
 
-From c799b45059e93edb95506856b776ec6aadd06bed Mon Sep 17 00:00:00 2001
+From 3580fd890324b54420c9e4d286a2f99ffe2fa4d5 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 28 Oct 2024 14:36:55 +0100
-Subject: [PATCH 11/11] zstd
+Subject: [PATCH 10/10] zstd
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -45529,5 +45539,5 @@ index 469fc3059be0..0ae819f0c927 100644
  EXPORT_SYMBOL(zstd_reset_dstream);
  
 -- 
-2.47.0.rc0
+2.47.0
 

--- a/Files
+++ b/Files
@@ -517,7 +517,7 @@
 │   ├── 0007-ksm.patch
 │   ├── 0008-ntsync.patch
 │   ├── 0009-openvpn-dco.patch
-│   ├── 0011-zstd.patch
+│   ├── 0010-zstd.patch
 │   ├── all
 │   │   └── 0001-cachyos-base-all.patch
 │   ├── misc


### PR DESCRIPTION
Due to e238968a2087 ("cpufreq/amd-pstate: Remove the redundant amd_pstate_set_driver() call"), a few users couldn't boot to the system. Coincidentally, AMD has posted fixes for this. Update so users can have a functional system

Also see: https://lore.kernel.org/lkml/20241028145542.1739160-1-superm1@kernel.org/t/#m01d28de7af80ce6921f5bde7e67e7906932f8ab9