### PR TITLE
6.12: Make 0001-rt.patch compatible with 6.12.1

### DIFF
--- a/6.12/misc/0001-rt.patch
+++ b/6.12/misc/0001-rt.patch
@@ -480,8 +480,8 @@ index fe782cd77388..9c0df9c1fa94 100644
  
  config PREEMPT_RT
  	bool "Fully Preemptible Kernel (Real-Time)"
--	depends on EXPERT && ARCH_SUPPORTS_RT
-+	depends on EXPERT && ARCH_SUPPORTS_RT && !COMPILE_TEST
+-	depends on ARCH_SUPPORTS_RT
++	depends on ARCH_SUPPORTS_RT && !COMPILE_TEST
  	select PREEMPTION
  	help
  	  This option turns the kernel into a real-time kernel by replacing


### PR DESCRIPTION
In the release version, PREEMPT_RT no longer depends on EXPERT, so I fixed that part.
This pull request is dependent on https://github.com/CachyOS/linux-cachyos/pull/335 .