### PR TITLE
Revert mainline 6a23b5676a; bt game controllers fix

### DIFF
--- a/6.15/0006-cachy.patch
+++ b/6.15/0006-cachy.patch
@@ -81,6 +81,7 @@ Signed-off-by: Eric Naim <dnaim@cachyos.org>
  mm/swap.c                                     |    5 +
  mm/vmpressure.c                               |    4 +
  mm/vmscan.c                                   |  148 +-
+ net/bluetooth/l2cap_core.c                    |    3 +--
  net/ipv4/inet_connection_sock.c               |    2 +-
  scripts/Makefile.autofdo                      |    2 +-
  scripts/Makefile.build                        |   52 +-
@@ -89,7 +90,7 @@ Signed-off-by: Eric Naim <dnaim@cachyos.org>
  scripts/Makefile.vmlinux_o                    |   16 +-
  scripts/Makefile.vmlinux_thinlink             |   53 +
  scripts/head-object-list.txt                  |    1 +
- 84 files changed, 8000 insertions(+), 68 deletions(-)
+ 85 files changed, 8001 insertions(+), 70 deletions(-)
  create mode 100644 block/adios.c
  create mode 100644 drivers/media/v4l2-core/v4l2loopback.c
  create mode 100644 drivers/media/v4l2-core/v4l2loopback.h
@@ -9360,6 +9361,20 @@ index 3783e45bfc92..4f991a6ae689 100644
  	shrink_node_memcgs(pgdat, sc);
  
  	flush_reclaim_state(sc);
+diff --git a/net/bluetooth/l2cap_core.c b/net/bluetooth/l2cap_core.c
+index 5ca7ac43c58d4b..e1e6eb5727ca32 100644
+--- a/net/bluetooth/l2cap_core.c
++++ b/net/bluetooth/l2cap_core.c
+@@ -3991,8 +3991,7 @@ static void l2cap_connect(struct l2cap_conn *conn, struct l2cap_cmd_hdr *cmd,
+ 
+ /* Check if the ACL is secure enough (if not SDP) */
+ if (psm != cpu_to_le16(L2CAP_PSM_SDP) &&
+-    (!hci_conn_check_link_mode(conn->hcon) ||
+-    !l2cap_check_enc_key_size(conn->hcon))) {
++!hci_conn_check_link_mode(conn->hcon)) {
+ conn->disc_reason = HCI_ERROR_AUTH_FAILURE;
+ result = L2CAP_CR_SEC_BLOCK;
+ goto response;
 diff --git a/net/ipv4/inet_connection_sock.c b/net/ipv4/inet_connection_sock.c
 index dd5cf8914a28..b216088a6abd 100644
 --- a/net/ipv4/inet_connection_sock.c


### PR DESCRIPTION
Fix hid_playstation module broken when used with bluetooth Linux mainline regression, causing several disconnects.  
May fix further bluetooth instabilities following 6a23b5676a.

See http://bugzilla.kernel.org/show_bug.cgi?id=220061

We may sync with >=6.12