### PR TITLE
Update patchset for 6.15 and 6.16

### DIFF
--- a/6.15/0001-amd-pstate.patch
+++ b/6.15/0001-amd-pstate.patch
@@ -1,7 +1,7 @@
-From 2d2b5a7fc5d45efd8066f9560dedfd57da82b0dc Mon Sep 17 00:00:00 2001
+From 9388ac844aa7a58ff39126c62a18b16f38535fa9 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:35 +0200
-Subject: [PATCH 1/7] amd-pstate
+Subject: [PATCH 1/6] amd-pstate
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -14,7 +14,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  6 files changed, 158 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index b961f3a3b..12331e127 100644
+index b961f3a3b580..12331e127d96 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -389,7 +389,8 @@ static inline int amd_pstate_cppc_enable(struct cpufreq_policy *policy)
@@ -247,7 +247,7 @@ index b961f3a3b..12331e127 100644
  	.update_limits	= amd_pstate_update_limits,
  	.set_boost	= amd_pstate_set_boost,
 diff --git a/drivers/cpufreq/amd-pstate.h b/drivers/cpufreq/amd-pstate.h
-index fbe1c08d3..2f7ae364d 100644
+index fbe1c08d3f06..2f7ae364d331 100644
 --- a/drivers/cpufreq/amd-pstate.h
 +++ b/drivers/cpufreq/amd-pstate.h
 @@ -30,6 +30,7 @@
@@ -267,7 +267,7 @@ index fbe1c08d3..2f7ae364d 100644
  	u64	val;
  };
 diff --git a/include/linux/sched/topology.h b/include/linux/sched/topology.h
-index 7b4301b72..198bb5cc1 100644
+index 7b4301b7235f..198bb5cc1774 100644
 --- a/include/linux/sched/topology.h
 +++ b/include/linux/sched/topology.h
 @@ -195,6 +195,8 @@ struct sched_domain_topology_level {
@@ -291,7 +291,7 @@ index 7b4301b72..198bb5cc1 100644
  
  #if defined(CONFIG_ENERGY_MODEL) && defined(CONFIG_CPU_FREQ_GOV_SCHEDUTIL)
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 56ae54e0c..557246880 100644
+index 56ae54e0ce6a..557246880a7e 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -588,6 +588,10 @@ static void register_sd(struct sched_domain *sd, struct dentry *parent)
@@ -306,7 +306,7 @@ index 56ae54e0c..557246880 100644
  
  void update_sched_domain_debugfs(void)
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 23264fe11..9bf6931c8 100644
+index 138d9f4658d5..1a1caae2b2f7 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -10267,7 +10267,7 @@ sched_group_asym(struct lb_env *env, struct sg_lb_stats *sgs, struct sched_group
@@ -329,7 +329,7 @@ index 23264fe11..9bf6931c8 100644
  	case group_misfit_task:
  		/*
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
-index f1ebc60d9..8426de317 100644
+index f1ebc60d967f..8426de317835 100644
 --- a/kernel/sched/topology.c
 +++ b/kernel/sched/topology.c
 @@ -1333,6 +1333,64 @@ static void init_sched_groups_capacity(int cpu, struct sched_domain *sd)
@@ -397,3 +397,6 @@ index f1ebc60d9..8426de317 100644
  /*
   * Set of available CPUs grouped by their corresponding capacities
   * Each list entry contains a CPU mask reflecting CPUs that share the same
+-- 
+2.50.1
+

--- a/6.15/0001-amd-pstate.patch
+++ b/6.15/0001-amd-pstate.patch
@@ -1,7 +1,7 @@
-From 9388ac844aa7a58ff39126c62a18b16f38535fa9 Mon Sep 17 00:00:00 2001
+From 2d2b5a7fc5d45efd8066f9560dedfd57da82b0dc Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:35 +0200
-Subject: [PATCH 1/6] amd-pstate
+Subject: [PATCH 1/7] amd-pstate
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -14,7 +14,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  6 files changed, 158 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index b961f3a3b580..12331e127d96 100644
+index b961f3a3b..12331e127 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -389,7 +389,8 @@ static inline int amd_pstate_cppc_enable(struct cpufreq_policy *policy)
@@ -247,7 +247,7 @@ index b961f3a3b580..12331e127d96 100644
  	.update_limits	= amd_pstate_update_limits,
  	.set_boost	= amd_pstate_set_boost,
 diff --git a/drivers/cpufreq/amd-pstate.h b/drivers/cpufreq/amd-pstate.h
-index fbe1c08d3f06..2f7ae364d331 100644
+index fbe1c08d3..2f7ae364d 100644
 --- a/drivers/cpufreq/amd-pstate.h
 +++ b/drivers/cpufreq/amd-pstate.h
 @@ -30,6 +30,7 @@
@@ -267,7 +267,7 @@ index fbe1c08d3f06..2f7ae364d331 100644
  	u64	val;
  };
 diff --git a/include/linux/sched/topology.h b/include/linux/sched/topology.h
-index 7b4301b7235f..198bb5cc1774 100644
+index 7b4301b72..198bb5cc1 100644
 --- a/include/linux/sched/topology.h
 +++ b/include/linux/sched/topology.h
 @@ -195,6 +195,8 @@ struct sched_domain_topology_level {
@@ -291,7 +291,7 @@ index 7b4301b7235f..198bb5cc1774 100644
  
  #if defined(CONFIG_ENERGY_MODEL) && defined(CONFIG_CPU_FREQ_GOV_SCHEDUTIL)
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 56ae54e0ce6a..557246880a7e 100644
+index 56ae54e0c..557246880 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -588,6 +588,10 @@ static void register_sd(struct sched_domain *sd, struct dentry *parent)
@@ -306,7 +306,7 @@ index 56ae54e0ce6a..557246880a7e 100644
  
  void update_sched_domain_debugfs(void)
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 138d9f4658d5..1a1caae2b2f7 100644
+index 23264fe11..9bf6931c8 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -10267,7 +10267,7 @@ sched_group_asym(struct lb_env *env, struct sg_lb_stats *sgs, struct sched_group
@@ -329,7 +329,7 @@ index 138d9f4658d5..1a1caae2b2f7 100644
  	case group_misfit_task:
  		/*
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
-index f1ebc60d967f..8426de317835 100644
+index f1ebc60d9..8426de317 100644
 --- a/kernel/sched/topology.c
 +++ b/kernel/sched/topology.c
 @@ -1333,6 +1333,64 @@ static void init_sched_groups_capacity(int cpu, struct sched_domain *sd)
@@ -397,6 +397,3 @@ index f1ebc60d967f..8426de317835 100644
  /*
   * Set of available CPUs grouped by their corresponding capacities
   * Each list entry contains a CPU mask reflecting CPUs that share the same
--- 
-2.50.1
-

--- a/6.15/0002-asus.patch
+++ b/6.15/0002-asus.patch
@@ -1,41 +1,35 @@
-From 027f2f2ba77622cfdd2efe1cd8bb36d403fbaa2d Mon Sep 17 00:00:00 2001
+From dda5925222fd6d8f6236a3fb5d90b888c8dc3d67 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:48 +0200
-Subject: [PATCH 2/6] asus
+Subject: [PATCH 2/7] asus
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
  .../ABI/testing/sysfs-platform-asus-wmi       |   17 +
- drivers/hid/Kconfig                           |    2 +
- drivers/hid/Makefile                          |    2 +
- drivers/hid/asus-ally-hid/Kconfig             |    8 +
- drivers/hid/asus-ally-hid/Makefile            |    6 +
- .../hid/asus-ally-hid/asus-ally-hid-config.c  | 2347 +++++++++++++++++
- .../hid/asus-ally-hid/asus-ally-hid-core.c    |  600 +++++
- .../hid/asus-ally-hid/asus-ally-hid-input.c   |  345 +++
- drivers/hid/asus-ally-hid/asus-ally-rgb.c     |  356 +++
- drivers/hid/asus-ally-hid/asus-ally.h         |  314 +++
- drivers/hid/hid-asus.c                        |    9 +
- drivers/hid/hid-ids.h                         |    1 +
+ drivers/hid/Kconfig                           |   10 +
+ drivers/hid/Makefile                          |    1 +
+ drivers/hid/hid-asus-ally.c                   | 2197 +++++++++++++++++
+ drivers/hid/hid-asus-ally.h                   |  398 +++
+ drivers/hid/hid-asus.c                        |  415 +++-
+ drivers/hid/hid-asus.h                        |   13 +
+ drivers/hid/hid-ids.h                         |    3 +-
  drivers/platform/x86/Kconfig                  |   23 +
  drivers/platform/x86/Makefile                 |    1 +
- drivers/platform/x86/asus-armoury.c           | 1202 +++++++++
- drivers/platform/x86/asus-armoury.h           | 1278 +++++++++
- drivers/platform/x86/asus-wmi.c               |  359 ++-
- include/linux/platform_data/x86/asus-wmi.h    |   39 +
- 18 files changed, 6805 insertions(+), 104 deletions(-)
- create mode 100644 drivers/hid/asus-ally-hid/Kconfig
- create mode 100644 drivers/hid/asus-ally-hid/Makefile
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-hid-config.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-hid-core.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-hid-input.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-rgb.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally.h
+ drivers/platform/x86/asus-armoury.c           | 1174 +++++++++
+ drivers/platform/x86/asus-armoury.h           | 1278 ++++++++++
+ drivers/platform/x86/asus-nb-wmi.c            |   30 +-
+ drivers/platform/x86/asus-wmi.c               |  474 +++-
+ drivers/platform/x86/asus-wmi.h               |    3 +-
+ include/linux/platform_data/x86/asus-wmi.h    |   70 +
+ 16 files changed, 5892 insertions(+), 215 deletions(-)
+ create mode 100644 drivers/hid/hid-asus-ally.c
+ create mode 100644 drivers/hid/hid-asus-ally.h
+ create mode 100644 drivers/hid/hid-asus.h
  create mode 100644 drivers/platform/x86/asus-armoury.c
  create mode 100644 drivers/platform/x86/asus-armoury.h
 
 diff --git a/Documentation/ABI/testing/sysfs-platform-asus-wmi b/Documentation/ABI/testing/sysfs-platform-asus-wmi
-index 28144371a0f1..765d50b0d9df 100644
+index 28144371a..765d50b0d 100644
 --- a/Documentation/ABI/testing/sysfs-platform-asus-wmi
 +++ b/Documentation/ABI/testing/sysfs-platform-asus-wmi
 @@ -63,6 +63,7 @@ Date:		Aug 2022
@@ -175,63 +169,51 @@ index 28144371a0f1..765d50b0d9df 100644
  			* 0 - False,
  			* 1 - True
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 43859fc75747..aeb4eabf3007 100644
+index 43859fc75..5bc1f086b 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
-@@ -1425,6 +1425,8 @@ source "drivers/hid/intel-ish-hid/Kconfig"
+@@ -178,6 +178,7 @@ config HID_APPLETB_KBD
+ config HID_ASUS
+ 	tristate "Asus"
+ 	depends on USB_HID
++	depends on LEDS_CLASS_MULTICOLOR
+ 	depends on LEDS_CLASS
+ 	depends on ASUS_WMI || ASUS_WMI=n
+ 	select POWER_SUPPLY
+@@ -191,6 +192,15 @@ config HID_ASUS
+ 	- GL553V series
+ 	- GL753V series
  
- source "drivers/hid/amd-sfh-hid/Kconfig"
- 
-+source "drivers/hid/asus-ally-hid/Kconfig"
++config HID_ASUS_ALLY
++    tristate "Asus Ally gamepad configuration support"
++    depends on USB_HID
++    depends on LEDS_CLASS
++    depends on LEDS_CLASS_MULTICOLOR
++    select POWER_SUPPLY
++    help
++    Support for configuring the Asus ROG Ally gamepad using attributes.
 +
- source "drivers/hid/surface-hid/Kconfig"
- 
- source "drivers/hid/intel-thc-hid/Kconfig"
+ config HID_AUREAL
+ 	tristate "Aureal"
+ 	help
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 10ae5dedbd84..85af5331ebd2 100644
+index 10ae5dedb..958f67193 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
-@@ -172,6 +172,8 @@ obj-$(CONFIG_INTEL_ISH_HID)	+= intel-ish-hid/
- 
- obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
- 
-+obj-$(CONFIG_ASUS_ALLY_HID)  += asus-ally-hid/
-+
- obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
- 
- obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
-diff --git a/drivers/hid/asus-ally-hid/Kconfig b/drivers/hid/asus-ally-hid/Kconfig
+@@ -33,6 +33,7 @@ obj-$(CONFIG_HID_APPLETB_BL)	+= hid-appletb-bl.o
+ obj-$(CONFIG_HID_APPLETB_KBD)	+= hid-appletb-kbd.o
+ obj-$(CONFIG_HID_CREATIVE_SB0540)	+= hid-creative-sb0540.o
+ obj-$(CONFIG_HID_ASUS)		+= hid-asus.o
++obj-$(CONFIG_HID_ASUS_ALLY)	+= hid-asus-ally.o
+ obj-$(CONFIG_HID_AUREAL)	+= hid-aureal.o
+ obj-$(CONFIG_HID_BELKIN)	+= hid-belkin.o
+ obj-$(CONFIG_HID_BETOP_FF)	+= hid-betopff.o
+diff --git a/drivers/hid/hid-asus-ally.c b/drivers/hid/hid-asus-ally.c
 new file mode 100644
-index 000000000000..f83dda32be62
+index 000000000..e78625f70
 --- /dev/null
-+++ b/drivers/hid/asus-ally-hid/Kconfig
-@@ -0,0 +1,8 @@
-+config ASUS_ALLY_HID
-+	tristate "Asus Ally handheld support"
-+	depends on USB_HID
-+	depends on LEDS_CLASS
-+	depends on LEDS_CLASS_MULTICOLOR
-+	select POWER_SUPPLY
-+	help
-+	Support for configuring the Asus ROG Ally gamepad using attributes.
-diff --git a/drivers/hid/asus-ally-hid/Makefile b/drivers/hid/asus-ally-hid/Makefile
-new file mode 100644
-index 000000000000..5c3c304b7b53
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/Makefile
-@@ -0,0 +1,6 @@
-+# SPDX-License-Identifier: GPL-2.0+
-+#
-+# Makefile - ASUS ROG Ally handheld device driver
-+#
-+asus-ally-hid-y := asus-ally-hid-core.o asus-ally-rgb.o asus-ally-hid-input.o asus-ally-hid-config.o
-+obj-$(CONFIG_ASUS_ALLY_HID) := asus-ally-hid.o
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-hid-config.c b/drivers/hid/asus-ally-hid/asus-ally-hid-config.c
-new file mode 100644
-index 000000000000..1624880121c4
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-hid-config.c
-@@ -0,0 +1,2347 @@
++++ b/drivers/hid/hid-asus-ally.c
+@@ -0,0 +1,2197 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + *  HID driver for Asus ROG laptops and Ally
@@ -239,2370 +221,46 @@ index 000000000000..1624880121c4
 + *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
 + */
 +
-+#include <linux/device.h>
-+#include <linux/errno.h>
++#include "linux/compiler_attributes.h"
++#include "linux/device.h"
++#include <linux/platform_data/x86/asus-wmi.h>
++#include <linux/platform_device.h>
++#include "linux/pm.h"
++#include "linux/printk.h"
++#include "linux/slab.h"
 +#include <linux/hid.h>
-+#include <linux/module.h>
-+#include <linux/sysfs.h>
 +#include <linux/types.h>
-+
-+#include "asus-ally.h"
-+#include "../hid-ids.h"
-+
-+enum btn_map_type {
-+	BTN_TYPE_NONE = 0,
-+	BTN_TYPE_PAD = 0x01,
-+	BTN_TYPE_KB = 0x02,
-+	BTN_TYPE_MOUSE = 0x03,
-+	BTN_TYPE_MEDIA = 0x05,
-+};
-+
-+struct btn_code_map {
-+	unsigned char type;
-+	unsigned char value;
-+	const char *name;
-+};
-+
-+static const struct btn_code_map ally_btn_codes[] = {
-+	{ BTN_TYPE_NONE, 0x00, "NONE" },
-+	/* Gamepad button codes */
-+	{ BTN_TYPE_PAD, 0x01, "PAD_A" },
-+	{ BTN_TYPE_PAD, 0x02, "PAD_B" },
-+	{ BTN_TYPE_PAD, 0x03, "PAD_X" },
-+	{ BTN_TYPE_PAD, 0x04, "PAD_Y" },
-+	{ BTN_TYPE_PAD, 0x05, "PAD_LB" },
-+	{ BTN_TYPE_PAD, 0x06, "PAD_RB" },
-+	{ BTN_TYPE_PAD, 0x07, "PAD_LS" },
-+	{ BTN_TYPE_PAD, 0x08, "PAD_RS" },
-+	{ BTN_TYPE_PAD, 0x09, "PAD_DPAD_UP" },
-+	{ BTN_TYPE_PAD, 0x0A, "PAD_DPAD_DOWN" },
-+	{ BTN_TYPE_PAD, 0x0B, "PAD_DPAD_LEFT" },
-+	{ BTN_TYPE_PAD, 0x0C, "PAD_DPAD_RIGHT" },
-+	{ BTN_TYPE_PAD, 0x0D, "PAD_LT" },
-+	{ BTN_TYPE_PAD, 0x0E, "PAD_RT" },
-+	{ BTN_TYPE_PAD, 0x11, "PAD_VIEW" },
-+	{ BTN_TYPE_PAD, 0x12, "PAD_MENU" },
-+	{ BTN_TYPE_PAD, 0x13, "PAD_XBOX" },
-+
-+	/* Keyboard button codes */
-+	{ BTN_TYPE_KB, 0x8E, "KB_M2" },
-+	{ BTN_TYPE_KB, 0x8F, "KB_M1" },
-+	{ BTN_TYPE_KB, 0x76, "KB_ESC" },
-+	{ BTN_TYPE_KB, 0x50, "KB_F1" },
-+	{ BTN_TYPE_KB, 0x60, "KB_F2" },
-+	{ BTN_TYPE_KB, 0x40, "KB_F3" },
-+	{ BTN_TYPE_KB, 0x0C, "KB_F4" },
-+	{ BTN_TYPE_KB, 0x03, "KB_F5" },
-+	{ BTN_TYPE_KB, 0x0B, "KB_F6" },
-+	{ BTN_TYPE_KB, 0x80, "KB_F7" },
-+	{ BTN_TYPE_KB, 0x0A, "KB_F8" },
-+	{ BTN_TYPE_KB, 0x01, "KB_F9" },
-+	{ BTN_TYPE_KB, 0x09, "KB_F10" },
-+	{ BTN_TYPE_KB, 0x78, "KB_F11" },
-+	{ BTN_TYPE_KB, 0x07, "KB_F12" },
-+	{ BTN_TYPE_KB, 0x18, "KB_F14" },
-+	{ BTN_TYPE_KB, 0x10, "KB_F15" },
-+	{ BTN_TYPE_KB, 0x0E, "KB_BACKTICK" },
-+	{ BTN_TYPE_KB, 0x16, "KB_1" },
-+	{ BTN_TYPE_KB, 0x1E, "KB_2" },
-+	{ BTN_TYPE_KB, 0x26, "KB_3" },
-+	{ BTN_TYPE_KB, 0x25, "KB_4" },
-+	{ BTN_TYPE_KB, 0x2E, "KB_5" },
-+	{ BTN_TYPE_KB, 0x36, "KB_6" },
-+	{ BTN_TYPE_KB, 0x3D, "KB_7" },
-+	{ BTN_TYPE_KB, 0x3E, "KB_8" },
-+	{ BTN_TYPE_KB, 0x46, "KB_9" },
-+	{ BTN_TYPE_KB, 0x45, "KB_0" },
-+	{ BTN_TYPE_KB, 0x4E, "KB_HYPHEN" },
-+	{ BTN_TYPE_KB, 0x55, "KB_EQUALS" },
-+	{ BTN_TYPE_KB, 0x66, "KB_BACKSPACE" },
-+	{ BTN_TYPE_KB, 0x0D, "KB_TAB" },
-+	{ BTN_TYPE_KB, 0x15, "KB_Q" },
-+	{ BTN_TYPE_KB, 0x1D, "KB_W" },
-+	{ BTN_TYPE_KB, 0x24, "KB_E" },
-+	{ BTN_TYPE_KB, 0x2D, "KB_R" },
-+	{ BTN_TYPE_KB, 0x2C, "KB_T" },
-+	{ BTN_TYPE_KB, 0x35, "KB_Y" },
-+	{ BTN_TYPE_KB, 0x3C, "KB_U" },
-+	{ BTN_TYPE_KB, 0x44, "KB_O" },
-+	{ BTN_TYPE_KB, 0x4D, "KB_P" },
-+	{ BTN_TYPE_KB, 0x54, "KB_LBRACKET" },
-+	{ BTN_TYPE_KB, 0x5B, "KB_RBRACKET" },
-+	{ BTN_TYPE_KB, 0x5D, "KB_BACKSLASH" },
-+	{ BTN_TYPE_KB, 0x58, "KB_CAPS" },
-+	{ BTN_TYPE_KB, 0x1C, "KB_A" },
-+	{ BTN_TYPE_KB, 0x1B, "KB_S" },
-+	{ BTN_TYPE_KB, 0x23, "KB_D" },
-+	{ BTN_TYPE_KB, 0x2B, "KB_F" },
-+	{ BTN_TYPE_KB, 0x34, "KB_G" },
-+	{ BTN_TYPE_KB, 0x33, "KB_H" },
-+	{ BTN_TYPE_KB, 0x3B, "KB_J" },
-+	{ BTN_TYPE_KB, 0x42, "KB_K" },
-+	{ BTN_TYPE_KB, 0x4B, "KB_L" },
-+	{ BTN_TYPE_KB, 0x4C, "KB_SEMI" },
-+	{ BTN_TYPE_KB, 0x52, "KB_QUOTE" },
-+	{ BTN_TYPE_KB, 0x5A, "KB_RET" },
-+	{ BTN_TYPE_KB, 0x88, "KB_LSHIFT" },
-+	{ BTN_TYPE_KB, 0x1A, "KB_Z" },
-+	{ BTN_TYPE_KB, 0x22, "KB_X" },
-+	{ BTN_TYPE_KB, 0x21, "KB_C" },
-+	{ BTN_TYPE_KB, 0x2A, "KB_V" },
-+	{ BTN_TYPE_KB, 0x32, "KB_B" },
-+	{ BTN_TYPE_KB, 0x31, "KB_N" },
-+	{ BTN_TYPE_KB, 0x3A, "KB_M" },
-+	{ BTN_TYPE_KB, 0x41, "KB_COMMA" },
-+	{ BTN_TYPE_KB, 0x49, "KB_PERIOD" },
-+	{ BTN_TYPE_KB, 0x89, "KB_RSHIFT" },
-+	{ BTN_TYPE_KB, 0x8C, "KB_LCTL" },
-+	{ BTN_TYPE_KB, 0x82, "KB_META" },
-+	{ BTN_TYPE_KB, 0x8A, "KB_LALT" },
-+	{ BTN_TYPE_KB, 0x29, "KB_SPACE" },
-+	{ BTN_TYPE_KB, 0x8B, "KB_RALT" },
-+	{ BTN_TYPE_KB, 0x84, "KB_MENU" },
-+	{ BTN_TYPE_KB, 0x8D, "KB_RCTL" },
-+	{ BTN_TYPE_KB, 0xC3, "KB_PRNTSCN" },
-+	{ BTN_TYPE_KB, 0x7E, "KB_SCRLCK" },
-+	{ BTN_TYPE_KB, 0x91, "KB_PAUSE" },
-+	{ BTN_TYPE_KB, 0xC2, "KB_INS" },
-+	{ BTN_TYPE_KB, 0x94, "KB_HOME" },
-+	{ BTN_TYPE_KB, 0x96, "KB_PGUP" },
-+	{ BTN_TYPE_KB, 0xC0, "KB_DEL" },
-+	{ BTN_TYPE_KB, 0x95, "KB_END" },
-+	{ BTN_TYPE_KB, 0x97, "KB_PGDWN" },
-+	{ BTN_TYPE_KB, 0x98, "KB_UP_ARROW" },
-+	{ BTN_TYPE_KB, 0x99, "KB_DOWN_ARROW" },
-+	{ BTN_TYPE_KB, 0x91, "KB_LEFT_ARROW" },
-+	{ BTN_TYPE_KB, 0x9B, "KB_RIGHT_ARROW" },
-+
-+	/* Numpad button codes */
-+	{ BTN_TYPE_KB, 0x77, "NUMPAD_LOCK" },
-+	{ BTN_TYPE_KB, 0x90, "NUMPAD_FWDSLASH" },
-+	{ BTN_TYPE_KB, 0x7C, "NUMPAD_ASTERISK" },
-+	{ BTN_TYPE_KB, 0x7B, "NUMPAD_HYPHEN" },
-+	{ BTN_TYPE_KB, 0x70, "NUMPAD_0" },
-+	{ BTN_TYPE_KB, 0x69, "NUMPAD_1" },
-+	{ BTN_TYPE_KB, 0x72, "NUMPAD_2" },
-+	{ BTN_TYPE_KB, 0x7A, "NUMPAD_3" },
-+	{ BTN_TYPE_KB, 0x6B, "NUMPAD_4" },
-+	{ BTN_TYPE_KB, 0x73, "NUMPAD_5" },
-+	{ BTN_TYPE_KB, 0x74, "NUMPAD_6" },
-+	{ BTN_TYPE_KB, 0x6C, "NUMPAD_7" },
-+	{ BTN_TYPE_KB, 0x75, "NUMPAD_8" },
-+	{ BTN_TYPE_KB, 0x7D, "NUMPAD_9" },
-+	{ BTN_TYPE_KB, 0x79, "NUMPAD_PLUS" },
-+	{ BTN_TYPE_KB, 0x81, "NUMPAD_ENTER" },
-+	{ BTN_TYPE_KB, 0x71, "NUMPAD_PERIOD" },
-+
-+	/* Mouse button codes */
-+	{ BTN_TYPE_MOUSE, 0x01, "MOUSE_LCLICK" },
-+	{ BTN_TYPE_MOUSE, 0x02, "MOUSE_RCLICK" },
-+	{ BTN_TYPE_MOUSE, 0x03, "MOUSE_MCLICK" },
-+	{ BTN_TYPE_MOUSE, 0x04, "MOUSE_WHEEL_UP" },
-+	{ BTN_TYPE_MOUSE, 0x05, "MOUSE_WHEEL_DOWN" },
-+
-+	/* Media button codes */
-+	{ BTN_TYPE_MEDIA, 0x16, "MEDIA_SCREENSHOT" },
-+	{ BTN_TYPE_MEDIA, 0x19, "MEDIA_SHOW_KEYBOARD" },
-+	{ BTN_TYPE_MEDIA, 0x1C, "MEDIA_SHOW_DESKTOP" },
-+	{ BTN_TYPE_MEDIA, 0x1E, "MEDIA_START_RECORDING" },
-+	{ BTN_TYPE_MEDIA, 0x01, "MEDIA_MIC_OFF" },
-+	{ BTN_TYPE_MEDIA, 0x02, "MEDIA_VOL_DOWN" },
-+	{ BTN_TYPE_MEDIA, 0x03, "MEDIA_VOL_UP" },
-+};
-+
-+static const size_t keymap_len = ARRAY_SIZE(ally_btn_codes);
-+
-+/* Button pair indexes for mapping commands */
-+enum btn_pair_index {
-+	BTN_PAIR_DPAD_UPDOWN    = 0x01,
-+	BTN_PAIR_DPAD_LEFTRIGHT = 0x02,
-+	BTN_PAIR_STICK_LR       = 0x03,
-+	BTN_PAIR_BUMPER_LR      = 0x04,
-+	BTN_PAIR_AB             = 0x05,
-+	BTN_PAIR_XY             = 0x06,
-+	BTN_PAIR_VIEW_MENU      = 0x07,
-+	BTN_PAIR_M1M2           = 0x08,
-+	BTN_PAIR_TRIGGER_LR     = 0x09,
-+};
-+
-+struct button_map {
-+	struct btn_code_map *remap;
-+	struct btn_code_map *macro;
-+};
-+
-+struct button_pair_map {
-+	enum btn_pair_index pair_index;
-+	struct button_map first;
-+	struct button_map second;
-+};
-+
-+/* Store button mapping per gamepad mode */
-+struct ally_button_mapping {
-+	struct button_pair_map button_pairs[9]; /* 9 button pairs */
-+};
-+
-+/* Find a button code map by its name */
-+static const struct btn_code_map *find_button_by_name(const char *name)
-+{
-+	int i;
-+
-+	for (i = 0; i < keymap_len; i++) {
-+		if (strcmp(ally_btn_codes[i].name, name) == 0)
-+			return &ally_btn_codes[i];
-+	}
-+
-+	return NULL;
-+}
-+
-+/* Set button mapping for a button pair */
-+static int ally_set_button_mapping(struct hid_device *hdev, struct ally_handheld *ally,
-+				  struct button_pair_map *mapping)
-+{
-+	unsigned char packet[64] = { 0 };
-+
-+	if (!mapping)
-+		return -EINVAL;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = CMD_SET_MAPPING;
-+	packet[3] = mapping->pair_index;
-+	packet[4] = 0x2C; /* Length */
-+
-+	/* First button mapping */
-+	packet[5] = mapping->first.remap->type;
-+	/* Fill in bytes 6-14 with button code */
-+	if (mapping->first.remap->type) {
-+		unsigned char btn_bytes[10] = {0};
-+		btn_bytes[0] = mapping->first.remap->type;
-+
-+		switch (mapping->first.remap->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			btn_bytes[2] = mapping->first.remap->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			btn_bytes[4] = mapping->first.remap->value;
-+			break;
-+		}
-+		memcpy(&packet[5], btn_bytes, 10);
-+	}
-+
-+	/* Macro mapping for first button if any */
-+	packet[15] = mapping->first.macro->type;
-+	if (mapping->first.macro->type) {
-+		unsigned char macro_bytes[11] = {0};
-+		macro_bytes[0] = mapping->first.macro->type;
-+
-+		switch (mapping->first.macro->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			macro_bytes[2] = mapping->first.macro->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			macro_bytes[4] = mapping->first.macro->value;
-+			break;
-+		}
-+		memcpy(&packet[15], macro_bytes, 11);
-+	}
-+
-+	/* Second button mapping */
-+	packet[27] = mapping->second.remap->type;
-+	/* Fill in bytes 28-36 with button code */
-+	if (mapping->second.remap->type) {
-+		unsigned char btn_bytes[10] = {0};
-+		btn_bytes[0] = mapping->second.remap->type;
-+
-+		switch (mapping->second.remap->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			btn_bytes[2] = mapping->second.remap->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			btn_bytes[4] = mapping->second.remap->value;
-+			break;
-+		}
-+		memcpy(&packet[27], btn_bytes, 10);
-+	}
-+
-+	/* Macro mapping for second button if any */
-+	packet[37] = mapping->second.macro->type;
-+	if (mapping->second.macro->type) {
-+		unsigned char macro_bytes[11] = {0};
-+		macro_bytes[0] = mapping->second.macro->type;
-+
-+		switch (mapping->second.macro->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			macro_bytes[2] = mapping->second.macro->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			macro_bytes[4] = mapping->second.macro->value;
-+			break;
-+		}
-+		memcpy(&packet[37], macro_bytes, 11);
-+	}
-+
-+	return ally_gamepad_send_packet(ally, hdev, packet, sizeof(packet));
-+}
-+
-+/**
-+ * ally_check_capability - Check if a specific capability is supported
-+ * @hdev: HID device
-+ * @flag_code: Capability flag code to check
-+ *
-+ * Returns true if capability is supported, false otherwise
-+ */
-+static bool ally_check_capability(struct hid_device *hdev, u8 flag_code)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	bool result = false;
-+	u8 *hidbuf;
-+	int ret;
-+
-+	hidbuf = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
-+	if (!hidbuf)
-+		return false;
-+
-+	hidbuf[0] = HID_ALLY_SET_REPORT_ID;
-+	hidbuf[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	hidbuf[2] = flag_code;
-+	hidbuf[3] = 0x01;
-+
-+	ret = ally_gamepad_send_receive_packet(ally, hdev, hidbuf, HID_ALLY_REPORT_SIZE);
-+	if (ret < 0)
-+		goto cleanup;
-+
-+	if (hidbuf[1] == HID_ALLY_FEATURE_CODE_PAGE && hidbuf[2] == flag_code)
-+		result = (hidbuf[4] == 0x01);
-+
-+cleanup:
-+	kfree(hidbuf);
-+	return result;
-+}
-+
-+static int ally_detect_capabilities(struct hid_device *hdev,
-+				    struct ally_config *cfg)
-+{
-+	if (!hdev || !cfg)
-+		return -EINVAL;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->is_ally_x =
-+		(hdev->product == USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X);
-+
-+	cfg->xbox_controller_support =
-+		ally_check_capability(hdev, CMD_CHECK_XBOX_SUPPORT);
-+	cfg->user_cal_support =
-+		ally_check_capability(hdev, CMD_CHECK_USER_CAL_SUPPORT);
-+	cfg->turbo_support =
-+		ally_check_capability(hdev, CMD_CHECK_TURBO_SUPPORT);
-+	cfg->resp_curve_support =
-+		ally_check_capability(hdev, CMD_CHECK_RESP_CURVE_SUPPORT);
-+	cfg->dir_to_btn_support =
-+		ally_check_capability(hdev, CMD_CHECK_DIR_TO_BTN_SUPPORT);
-+	cfg->gyro_support =
-+		ally_check_capability(hdev, CMD_CHECK_GYRO_TO_JOYSTICK);
-+	cfg->anti_deadzone_support =
-+		ally_check_capability(hdev, CMD_CHECK_ANTI_DEADZONE);
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	hid_dbg(
-+		hdev,
-+		"Ally capabilities: %s, Xbox: %d, UserCal: %d, Turbo: %d, RespCurve: %d, DirToBtn: %d, Gyro: %d, AntiDZ: %d",
-+		cfg->is_ally_x ? "Ally X" : "Ally",
-+		cfg->xbox_controller_support, cfg->user_cal_support,
-+		cfg->turbo_support, cfg->resp_curve_support,
-+		cfg->dir_to_btn_support, cfg->gyro_support,
-+		cfg->anti_deadzone_support);
-+
-+	return 0;
-+}
-+
-+static int ally_set_xbox_controller(struct hid_device *hdev,
-+				    struct ally_config *cfg, bool enabled)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	u8 buffer[64] = { 0 };
-+	int ret;
-+
-+	if (!cfg || !cfg->xbox_controller_support)
-+		return -ENODEV;
-+
-+	buffer[0] = HID_ALLY_SET_REPORT_ID;
-+	buffer[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	buffer[2] = CMD_SET_XBOX_CONTROLLER;
-+	buffer[3] = 0x01;
-+	buffer[4] = enabled ? 0x01 : 0x00;
-+
-+	ret = ally_gamepad_send_one_byte_packet(
-+		ally, hdev, CMD_SET_XBOX_CONTROLLER,
-+		enabled ? 0x01 : 0x00);
-+	if (ret < 0) return ret;
-+
-+	cfg->xbox_controller_enabled = enabled;
-+	return 0;
-+}
-+
-+static ssize_t xbox_controller_show(struct device *dev,
-+				    struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	if (!cfg->xbox_controller_support)
-+		return sprintf(buf, "Unsupported\n");
-+
-+	return sprintf(buf, "%d\n", cfg->xbox_controller_enabled);
-+}
-+
-+static ssize_t xbox_controller_store(struct device *dev,
-+				     struct device_attribute *attr,
-+				     const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+	bool enabled;
-+	int ret;
-+
-+	cfg = ally->config;
-+	if (!cfg->xbox_controller_support)
-+		return -ENODEV;
-+
-+	ret = kstrtobool(buf, &enabled);
-+	if (ret)
-+		return ret;
-+
-+	ret = ally_set_xbox_controller(hdev, cfg, enabled);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static DEVICE_ATTR_RW(xbox_controller);
-+
-+/**
-+ * ally_set_vibration_intensity - Set vibration intensity values
-+ * @hdev: HID device
-+ * @cfg: Ally config
-+ * @left: Left motor intensity (0-100)
-+ * @right: Right motor intensity (0-100)
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+static int ally_set_vibration_intensity(struct hid_device *hdev,
-+					struct ally_config *cfg, u8 left,
-+					u8 right)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	u8 buffer[64] = { 0 };
-+	int ret;
-+
-+	if (!cfg)
-+		return -ENODEV;
-+
-+	buffer[0] = HID_ALLY_SET_REPORT_ID;
-+	buffer[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	buffer[2] = CMD_SET_VIBRATION_INTENSITY;
-+	buffer[3] = 0x02; /* Length */
-+	buffer[4] = left;
-+	buffer[5] = right;
-+
-+	ret = ally_gamepad_send_two_byte_packet(
-+		ally, hdev, CMD_SET_VIBRATION_INTENSITY, left, right);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->vibration_intensity_left = left;
-+	cfg->vibration_intensity_right = right;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return 0;
-+}
-+
-+static ssize_t vibration_intensity_show(struct device *dev,
-+					struct device_attribute *attr,
-+					char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	return sprintf(buf, "%u,%u\n", cfg->vibration_intensity_left,
-+		       cfg->vibration_intensity_right);
-+}
-+
-+static ssize_t vibration_intensity_store(struct device *dev,
-+					 struct device_attribute *attr,
-+					 const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+	u8 left, right;
-+	int ret;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	ret = sscanf(buf, "%hhu %hhu", &left, &right);
-+	if (ret != 2 || left > 100 || right > 100)
-+		return -EINVAL;
-+
-+	ret = ally_set_vibration_intensity(hdev, cfg, left, right);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static DEVICE_ATTR_RW(vibration_intensity);
-+
-+/**
-+ * ally_set_dzot_ranges - Generic function to set joystick or trigger ranges
-+ * @hdev: HID device
-+ * @cfg: Ally config struct
-+ * @command: Command to use (CMD_SET_JOYSTICK_DEADZONE or CMD_SET_TRIGGER_RANGE)
-+ * @param1: First parameter
-+ * @param2: Second parameter
-+ * @param3: Third parameter
-+ * @param4: Fourth parameter
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+static int ally_set_dzot_ranges(struct hid_device *hdev,
-+					       struct ally_config *cfg,
-+					       u8 command, u8 param1, u8 param2,
-+					       u8 param3, u8 param4)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	u8 packet[HID_ALLY_REPORT_SIZE] = { 0 };
-+	int ret;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = command;
-+	packet[3] = 0x04; /* Length */
-+	packet[4] = param1;
-+	packet[5] = param2;
-+	packet[6] = param3;
-+	packet[7] = param4;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	return ret;
-+}
-+
-+static int ally_validate_joystick_dzot(u8 left_dz, u8 left_ot, u8 right_dz,
-+				       u8 right_ot)
-+{
-+	if (left_dz > 50 || right_dz > 50)
-+		return -EINVAL;
-+
-+	if (left_ot < 70 || left_ot > 100 || right_ot < 70 || right_ot > 100)
-+		return -EINVAL;
-+
-+	return 0;
-+}
-+
-+static int ally_set_joystick_dzot(struct hid_device *hdev,
-+				  struct ally_config *cfg, u8 left_dz,
-+				  u8 left_ot, u8 right_dz, u8 right_ot)
-+{
-+	int ret;
-+
-+	ret = ally_validate_joystick_dzot(left_dz, left_ot, right_dz, right_ot);
-+	if (ret < 0)
-+		return ret;
-+
-+	ret = ally_set_dzot_ranges(hdev, cfg,
-+				  CMD_SET_JOYSTICK_DEADZONE,
-+				  left_dz, left_ot, right_dz,
-+				  right_ot);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->left_deadzone = left_dz;
-+	cfg->left_outer_threshold = left_ot;
-+	cfg->right_deadzone = right_dz;
-+	cfg->right_outer_threshold = right_ot;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return 0;
-+}
-+
-+static ssize_t joystick_deadzone_show(struct device *dev,
-+				      struct device_attribute *attr, char *buf,
-+				      u8 deadzone, u8 outer_threshold)
-+{
-+	return sprintf(buf, "%u %u\n", deadzone, outer_threshold);
-+}
-+
-+static ssize_t joystick_deadzone_store(struct device *dev,
-+				       struct device_attribute *attr,
-+				       const char *buf, size_t count,
-+				       bool is_left, struct ally_config *cfg)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	u8 dz, ot;
-+	int ret;
-+
-+	ret = sscanf(buf, "%hhu %hhu", &dz, &ot);
-+	if (ret != 2)
-+		return -EINVAL;
-+
-+	if (is_left) {
-+		ret = ally_set_joystick_dzot(hdev, cfg, dz, ot,
-+					     cfg->right_deadzone,
-+					     cfg->right_outer_threshold);
-+	} else {
-+		ret = ally_set_joystick_dzot(hdev, cfg, cfg->left_deadzone,
-+					     cfg->left_outer_threshold, dz, ot);
-+	}
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t joystick_left_deadzone_show(struct device *dev,
-+					   struct device_attribute *attr,
-+					   char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return joystick_deadzone_show(dev, attr, buf, cfg->left_deadzone,
-+				      cfg->left_outer_threshold);
-+}
-+
-+static ssize_t joystick_left_deadzone_store(struct device *dev,
-+					    struct device_attribute *attr,
-+					    const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return joystick_deadzone_store(dev, attr, buf, count, true,
-+				       ally->config);
-+}
-+
-+static ssize_t joystick_right_deadzone_show(struct device *dev,
-+					    struct device_attribute *attr,
-+					    char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return joystick_deadzone_show(dev, attr, buf, cfg->right_deadzone,
-+				      cfg->right_outer_threshold);
-+}
-+
-+static ssize_t joystick_right_deadzone_store(struct device *dev,
-+					     struct device_attribute *attr,
-+					     const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return joystick_deadzone_store(dev, attr, buf, count, false,
-+				       ally->config);
-+}
-+
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_index, deadzone_index, "inner outer\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_inner_min, deadzone_inner_min, "0\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_inner_max, deadzone_inner_max, "50\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_outer_min, deadzone_outer_min, "70\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_outer_max, deadzone_outer_max, "100\n");
-+
-+ALLY_DEVICE_ATTR_RW(joystick_left_deadzone, deadzone);
-+ALLY_DEVICE_ATTR_RW(joystick_right_deadzone, deadzone);
-+
-+/**
-+ * ally_set_anti_deadzone - Set anti-deadzone values for joysticks
-+ * @ally: ally handheld structure
-+ * @left_adz: Left joystick anti-deadzone value (0-100)
-+ * @right_adz: Right joystick anti-deadzone value (0-100)
-+ *
-+ * Return: 0 on success, negative on failure
-+ */
-+static int ally_set_anti_deadzone(struct ally_handheld *ally, u8 left_adz,
-+				  u8 right_adz)
-+{
-+	struct hid_device *hdev = ally->cfg_hdev;
-+	int ret;
-+
-+	if (!ally->config->anti_deadzone_support) {
-+		hid_dbg(hdev, "Anti-deadzone not supported on this device\n");
-+		return -EOPNOTSUPP;
-+	}
-+
-+	if (left_adz > 100 || right_adz > 100)
-+		return -EINVAL;
-+
-+	ret = ally_gamepad_send_two_byte_packet(
-+		ally, hdev, CMD_SET_ANTI_DEADZONE, left_adz, right_adz);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set anti-deadzone values: %d\n", ret);
-+		return ret;
-+	}
-+
-+	ally->config->left_anti_deadzone = left_adz;
-+	ally->config->right_anti_deadzone = right_adz;
-+	hid_dbg(hdev, "Set joystick anti-deadzone: left=%d, right=%d\n",
-+		left_adz, right_adz);
-+
-+	return 0;
-+}
-+
-+static ssize_t anti_deadzone_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf,
-+				 u8 anti_deadzone)
-+{
-+	return sprintf(buf, "%u\n", anti_deadzone);
-+}
-+
-+static ssize_t anti_deadzone_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count, bool is_left,
-+				  struct ally_handheld *ally)
-+{
-+	u8 adz;
-+	int ret;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	if (!ally->config->anti_deadzone_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtou8(buf, 10, &adz);
-+	if (ret)
-+		return ret;
-+
-+	if (adz > 100)
-+		return -EINVAL;
-+
-+	if (is_left)
-+		ret = ally_set_anti_deadzone(ally, adz, ally->config->right_anti_deadzone);
-+	else
-+		ret = ally_set_anti_deadzone(ally, ally->config->left_anti_deadzone, adz);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t js_left_anti_deadzone_show(struct device *dev,
-+						struct device_attribute *attr,
-+						char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	return anti_deadzone_show(dev, attr, buf,
-+				  ally->config->left_anti_deadzone);
-+}
-+
-+static ssize_t js_left_anti_deadzone_store(struct device *dev,
-+						 struct device_attribute *attr,
-+						 const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return anti_deadzone_store(dev, attr, buf, count, true, ally);
-+}
-+
-+static ssize_t js_right_anti_deadzone_show(struct device *dev,
-+						 struct device_attribute *attr,
-+						 char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	return anti_deadzone_show(dev, attr, buf,
-+				  ally->config->right_anti_deadzone);
-+}
-+
-+static ssize_t js_right_anti_deadzone_store(struct device *dev,
-+						  struct device_attribute *attr,
-+						  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return anti_deadzone_store(dev, attr, buf, count, false, ally);
-+}
-+
-+ALLY_DEVICE_ATTR_RW(js_left_anti_deadzone, anti_deadzone);
-+ALLY_DEVICE_ATTR_RW(js_right_anti_deadzone, anti_deadzone);
-+ALLY_DEVICE_CONST_ATTR_RO(js_anti_deadzone_min, js_anti_deadzone_min, "0\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_anti_deadzone_max, js_anti_deadzone_max, "100\n");
-+
-+/**
-+ * ally_set_joystick_resp_curve - Set joystick response curve parameters
-+ * @ally: ally handheld structure
-+ * @hdev: HID device
-+ * @side: Which joystick side (0=left, 1=right)
-+ * @curve: Response curve parameter structure
-+ *
-+ * Return: 0 on success, negative on failure
-+ */
-+static int ally_set_joystick_resp_curve(struct ally_handheld *ally,
-+					struct hid_device *hdev, u8 side,
-+					struct joystick_resp_curve *curve)
-+{
-+	u8 packet[HID_ALLY_REPORT_SIZE] = { 0 };
-+	int ret;
-+	struct ally_config *cfg = ally->config;
-+
-+	if (!cfg || !cfg->resp_curve_support) {
-+		hid_dbg(hdev, "Response curve not supported on this device\n");
-+		return -EOPNOTSUPP;
-+	}
-+
-+	if (side > 1) {
-+		return -EINVAL;
-+	}
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = CMD_SET_RESP_CURVE;
-+	packet[3] = 0x09; /* Length */
-+	packet[4] = side;
-+
-+	packet[5] = curve->entry_1.move;
-+	packet[6] = curve->entry_1.resp;
-+	packet[7] = curve->entry_2.move;
-+	packet[8] = curve->entry_2.resp;
-+	packet[9] = curve->entry_3.move;
-+	packet[10] = curve->entry_3.resp;
-+	packet[11] = curve->entry_4.move;
-+	packet[12] = curve->entry_4.resp;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set joystick response curve: %d\n",
-+			ret);
-+		return ret;
-+	}
-+
-+	mutex_lock(&cfg->config_mutex);
-+	if (side == 0) {
-+		memcpy(&cfg->left_curve, curve, sizeof(*curve));
-+	} else {
-+		memcpy(&cfg->right_curve, curve, sizeof(*curve));
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	hid_dbg(hdev, "Set joystick response curve for side %d\n", side);
-+	return 0;
-+}
-+
-+static int response_curve_apply(struct hid_device *hdev, struct ally_handheld *ally, bool is_left)
-+{
-+	struct ally_config *cfg = ally->config;
-+	struct joystick_resp_curve *curve = is_left ? &cfg->left_curve : &cfg->right_curve;
-+
-+	if (!(curve->entry_1.move < curve->entry_2.move &&
-+	      curve->entry_2.move < curve->entry_3.move &&
-+	      curve->entry_3.move < curve->entry_4.move)) {
-+		return -EINVAL;
-+	}
-+
-+	return ally_set_joystick_resp_curve(ally, hdev, is_left ? 0 : 1, curve);
-+}
-+
-+static ssize_t response_curve_apply_left_store(struct device *dev,
-+					      struct device_attribute *attr,
-+					      const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	int ret;
-+	bool apply;
-+
-+	if (!ally->config->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtobool(buf, &apply);
-+	if (ret)
-+		return ret;
-+
-+	if (!apply)
-+		return count;  /* Only apply on "1" or "true" value */
-+
-+	ret = response_curve_apply(hdev, ally, true);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t response_curve_apply_right_store(struct device *dev,
-+					       struct device_attribute *attr,
-+					       const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	int ret;
-+	bool apply;
-+
-+	if (!ally->config->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtobool(buf, &apply);
-+	if (ret)
-+		return ret;
-+
-+	if (!apply)
-+		return count;  /* Only apply on "1" or "true" value */
-+
-+	ret = response_curve_apply(hdev, ally, false);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t response_curve_pct_show(struct device *dev,
-+				      struct device_attribute *attr, char *buf,
-+				      struct joystick_resp_curve *curve, int idx)
-+{
-+	switch (idx) {
-+	case 1: return sprintf(buf, "%u\n", curve->entry_1.resp);
-+	case 2: return sprintf(buf, "%u\n", curve->entry_2.resp);
-+	case 3: return sprintf(buf, "%u\n", curve->entry_3.resp);
-+	case 4: return sprintf(buf, "%u\n", curve->entry_4.resp);
-+	default: return -EINVAL;
-+	}
-+}
-+
-+static ssize_t response_curve_move_show(struct device *dev,
-+				      struct device_attribute *attr, char *buf,
-+				      struct joystick_resp_curve *curve, int idx)
-+{
-+	switch (idx) {
-+	case 1: return sprintf(buf, "%u\n", curve->entry_1.move);
-+	case 2: return sprintf(buf, "%u\n", curve->entry_2.move);
-+	case 3: return sprintf(buf, "%u\n", curve->entry_3.move);
-+	case 4: return sprintf(buf, "%u\n", curve->entry_4.move);
-+	default: return -EINVAL;
-+	}
-+}
-+
-+static ssize_t response_curve_pct_store(struct device *dev,
-+				       struct device_attribute *attr,
-+				       const char *buf, size_t count,
-+				       bool is_left, struct ally_handheld *ally,
-+				       int idx)
-+{
-+	struct ally_config *cfg = ally->config;
-+	struct joystick_resp_curve *curve = is_left ? &cfg->left_curve : &cfg->right_curve;
-+	u8 value;
-+	int ret;
-+
-+	if (!cfg->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtou8(buf, 10, &value);
-+	if (ret)
-+		return ret;
-+
-+	if (value > 100)
-+		return -EINVAL;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	switch (idx) {
-+	case 1: curve->entry_1.resp = value; break;
-+	case 2: curve->entry_2.resp = value; break;
-+	case 3: curve->entry_3.resp = value; break;
-+	case 4: curve->entry_4.resp = value; break;
-+	default: ret = -EINVAL;
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t response_curve_move_store(struct device *dev,
-+				       struct device_attribute *attr,
-+				       const char *buf, size_t count,
-+				       bool is_left, struct ally_handheld *ally,
-+				       int idx)
-+{
-+	struct ally_config *cfg = ally->config;
-+	struct joystick_resp_curve *curve = is_left ? &cfg->left_curve : &cfg->right_curve;
-+	u8 value;
-+	int ret;
-+
-+	if (!cfg->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtou8(buf, 10, &value);
-+	if (ret)
-+		return ret;
-+
-+	if (value > 100)
-+		return -EINVAL;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	switch (idx) {
-+	case 1: curve->entry_1.move = value; break;
-+	case 2: curve->entry_2.move = value; break;
-+	case 3: curve->entry_3.move = value; break;
-+	case 4: curve->entry_4.move = value; break;
-+	default: ret = -EINVAL;
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+#define DEFINE_JS_CURVE_PCT_FOPS(region, side)                             \
-+	static ssize_t response_curve_pct_##region##_##side##_show(              \
-+		struct device *dev, struct device_attribute *attr, char *buf) \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_pct_show(                               \
-+			dev, attr, buf, &ally->config->side##_curve, region);    \
-+	}                                                                     \
-+                                                                              \
-+	static ssize_t response_curve_pct_##region##_##side##_store(             \
-+		struct device *dev, struct device_attribute *attr,            \
-+		const char *buf, size_t count)                                \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_pct_store(dev, attr, buf, count,        \
-+						side##_is_left, ally, region);   \
-+	}
-+
-+#define DEFINE_JS_CURVE_MOVE_FOPS(region, side)                            \
-+	static ssize_t response_curve_move_##region##_##side##_show(             \
-+		struct device *dev, struct device_attribute *attr, char *buf) \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_move_show(                              \
-+			dev, attr, buf, &ally->config->side##_curve, region);    \
-+	}                                                                     \
-+                                                                              \
-+	static ssize_t response_curve_move_##region##_##side##_store(            \
-+		struct device *dev, struct device_attribute *attr,            \
-+		const char *buf, size_t count)                                \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_move_store(dev, attr, buf, count,       \
-+						 side##_is_left, ally, region);  \
-+	}
-+
-+#define DEFINE_JS_CURVE_ATTRS(region, side)                                 \
-+	DEFINE_JS_CURVE_PCT_FOPS(region, side)                              \
-+		DEFINE_JS_CURVE_MOVE_FOPS(region, side)                     \
-+			ALLY_DEVICE_ATTR_RW(response_curve_pct_##region##_##side, \
-+					    response_curve_pct_##region);        \
-+	ALLY_DEVICE_ATTR_RW(response_curve_move_##region##_##side,                \
-+			    response_curve_move_##region)
-+
-+/* Helper defines for "is_left" parameter */
-+#define left_is_left true
-+#define right_is_left false
-+
-+DEFINE_JS_CURVE_ATTRS(1, left);
-+DEFINE_JS_CURVE_ATTRS(2, left);
-+DEFINE_JS_CURVE_ATTRS(3, left);
-+DEFINE_JS_CURVE_ATTRS(4, left);
-+
-+DEFINE_JS_CURVE_ATTRS(1, right);
-+DEFINE_JS_CURVE_ATTRS(2, right);
-+DEFINE_JS_CURVE_ATTRS(3, right);
-+DEFINE_JS_CURVE_ATTRS(4, right);
-+
-+ALLY_DEVICE_ATTR_WO(response_curve_apply_left, response_curve_apply);
-+ALLY_DEVICE_ATTR_WO(response_curve_apply_right, response_curve_apply);
-+
-+static ssize_t deadzone_left_show(struct device *dev,
-+				struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return sprintf(buf, "%u %u\n", cfg->left_deadzone, cfg->left_outer_threshold);
-+}
-+
-+static ssize_t deadzone_right_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return sprintf(buf, "%u %u\n", cfg->right_deadzone, cfg->right_outer_threshold);
-+}
-+
-+DEVICE_ATTR_RO(deadzone_left);
-+DEVICE_ATTR_RO(deadzone_right);
-+ALLY_DEVICE_CONST_ATTR_RO(deadzone_index, deadzone_index, "inner outer\n");
-+
-+static struct attribute *axis_xy_left_attrs[] = {
-+	&dev_attr_joystick_left_deadzone.attr,
-+	&dev_attr_js_deadzone_index.attr,
-+	&dev_attr_js_deadzone_inner_min.attr,
-+	&dev_attr_js_deadzone_inner_max.attr,
-+	&dev_attr_js_deadzone_outer_min.attr,
-+	&dev_attr_js_deadzone_outer_max.attr,
-+	&dev_attr_js_left_anti_deadzone.attr,
-+	&dev_attr_js_anti_deadzone_min.attr,
-+	&dev_attr_js_anti_deadzone_max.attr,
-+	&dev_attr_response_curve_pct_1_left.attr,
-+	&dev_attr_response_curve_pct_2_left.attr,
-+	&dev_attr_response_curve_pct_3_left.attr,
-+	&dev_attr_response_curve_pct_4_left.attr,
-+	&dev_attr_response_curve_move_1_left.attr,
-+	&dev_attr_response_curve_move_2_left.attr,
-+	&dev_attr_response_curve_move_3_left.attr,
-+	&dev_attr_response_curve_move_4_left.attr,
-+	&dev_attr_response_curve_apply_left.attr,
-+	NULL
-+};
-+
-+static struct attribute *axis_xy_right_attrs[] = {
-+	&dev_attr_joystick_right_deadzone.attr,
-+	&dev_attr_js_deadzone_index.attr,
-+	&dev_attr_js_deadzone_inner_min.attr,
-+	&dev_attr_js_deadzone_inner_max.attr,
-+	&dev_attr_js_deadzone_outer_min.attr,
-+	&dev_attr_js_deadzone_outer_max.attr,
-+	&dev_attr_js_right_anti_deadzone.attr,
-+	&dev_attr_js_anti_deadzone_min.attr,
-+	&dev_attr_js_anti_deadzone_max.attr,
-+	&dev_attr_response_curve_pct_1_right.attr,
-+	&dev_attr_response_curve_pct_2_right.attr,
-+	&dev_attr_response_curve_pct_3_right.attr,
-+	&dev_attr_response_curve_pct_4_right.attr,
-+	&dev_attr_response_curve_move_1_right.attr,
-+	&dev_attr_response_curve_move_2_right.attr,
-+	&dev_attr_response_curve_move_3_right.attr,
-+	&dev_attr_response_curve_move_4_right.attr,
-+	&dev_attr_response_curve_apply_right.attr,
-+	NULL
-+};
-+
-+/**
-+ * ally_set_trigger_range - Set trigger range values
-+ * @hdev: HID device
-+ * @cfg: Ally config
-+ * @left_min: Left trigger minimum (0-255)
-+ * @left_max: Left trigger maximum (0-255)
-+ * @right_min: Right trigger minimum (0-255)
-+ * @right_max: Right trigger maximum (0-255)
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+static int ally_set_trigger_range(struct hid_device *hdev,
-+				  struct ally_config *cfg, u8 left_min,
-+				  u8 left_max, u8 right_min, u8 right_max)
-+{
-+	int ret;
-+
-+	if (left_min >= left_max || right_min >= right_max)
-+		return -EINVAL;
-+
-+	ret = ally_set_dzot_ranges(hdev, cfg,
-+						  CMD_SET_TRIGGER_RANGE,
-+						  left_min, left_max, right_min,
-+						  right_max);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->left_trigger_min = left_min;
-+	cfg->left_trigger_max = left_max;
-+	cfg->right_trigger_min = right_min;
-+	cfg->right_trigger_max = right_max;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return 0;
-+}
-+
-+static ssize_t trigger_range_show(struct device *dev,
-+				  struct device_attribute *attr, char *buf,
-+				  u8 min_val, u8 max_val)
-+{
-+	return sprintf(buf, "%u %u\n", min_val, max_val);
-+}
-+
-+static ssize_t trigger_range_store(struct device *dev,
-+				   struct device_attribute *attr,
-+				   const char *buf, size_t count, bool is_left,
-+				   struct ally_config *cfg)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	u8 min_val, max_val;
-+	int ret;
-+
-+	ret = sscanf(buf, "%hhu %hhu", &min_val, &max_val);
-+	if (ret != 2)
-+		return -EINVAL;
-+
-+	if (is_left) {
-+		ret = ally_set_trigger_range(hdev, cfg, min_val, max_val,
-+					     cfg->right_trigger_min,
-+					     cfg->right_trigger_max);
-+	} else {
-+		ret = ally_set_trigger_range(hdev, cfg, cfg->left_trigger_min,
-+					     cfg->left_trigger_max, min_val,
-+					     max_val);
-+	}
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t trigger_left_deadzone_show(struct device *dev,
-+				       struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return trigger_range_show(dev, attr, buf, cfg->left_trigger_min,
-+				  cfg->left_trigger_max);
-+}
-+
-+static ssize_t trigger_left_deadzone_store(struct device *dev,
-+					struct device_attribute *attr,
-+					const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return trigger_range_store(dev, attr, buf, count, true, ally->config);
-+}
-+
-+static ssize_t trigger_right_deadzone_show(struct device *dev,
-+					struct device_attribute *attr,
-+					char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return trigger_range_show(dev, attr, buf, cfg->right_trigger_min,
-+				  cfg->right_trigger_max);
-+}
-+
-+static ssize_t trigger_right_deadzone_store(struct device *dev,
-+					 struct device_attribute *attr,
-+					 const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return trigger_range_store(dev, attr, buf, count, false, ally->config);
-+}
-+
-+ALLY_DEVICE_CONST_ATTR_RO(tr_deadzone_inner_min, deadzone_inner_min, "0\n");
-+ALLY_DEVICE_CONST_ATTR_RO(tr_deadzone_inner_max, deadzone_inner_max, "255\n");
-+
-+ALLY_DEVICE_ATTR_RW(trigger_left_deadzone, deadzone);
-+ALLY_DEVICE_ATTR_RW(trigger_right_deadzone, deadzone);
-+
-+static struct attribute *axis_z_left_attrs[] = {
-+	&dev_attr_trigger_left_deadzone.attr,
-+	&dev_attr_tr_deadzone_inner_min.attr,
-+	&dev_attr_tr_deadzone_inner_max.attr,
-+	NULL
-+};
-+
-+static struct attribute *axis_z_right_attrs[] = {
-+	&dev_attr_trigger_right_deadzone.attr,
-+	&dev_attr_tr_deadzone_inner_min.attr,
-+	&dev_attr_tr_deadzone_inner_max.attr,
-+	NULL
-+};
-+
-+/* Map from string name to enum value */
-+static int get_gamepad_mode_from_name(const char *name)
-+{
-+	int i;
-+
-+	for (i = ALLY_GAMEPAD_MODE_GAMEPAD; i <= ALLY_GAMEPAD_MODE_KEYBOARD;
-+	     i++) {
-+		if (gamepad_mode_names[i] &&
-+		    strcmp(name, gamepad_mode_names[i]) == 0)
-+			return i;
-+	}
-+
-+	return -1;
-+}
-+
-+/**
-+ * ally_set_gamepad_mode - Set the gamepad operating mode
-+ * @ally: ally handheld structure
-+ * @hdev: HID device
-+ * @mode: Gamepad mode to set
-+ *
-+ * Returns: 0 on success, negative on failure
-+ */
-+static int ally_set_gamepad_mode(struct ally_handheld *ally,
-+				 struct hid_device *hdev, u8 mode)
-+{
-+	struct ally_config *cfg = ally->config;
-+	int ret;
-+
-+	if (!cfg)
-+		return -EINVAL;
-+
-+	if (mode < ALLY_GAMEPAD_MODE_GAMEPAD ||
-+	    mode > ALLY_GAMEPAD_MODE_KEYBOARD) {
-+		hid_err(hdev, "Invalid gamepad mode: %u\n", mode);
-+		return -EINVAL;
-+	}
-+
-+	ret = ally_gamepad_send_one_byte_packet(ally, hdev,
-+						CMD_SET_GAMEPAD_MODE, mode);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set gamepad mode: %d\n", ret);
-+		return ret;
-+	}
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->gamepad_mode = mode;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	hid_info(hdev, "Set gamepad mode to %s\n", gamepad_mode_names[mode]);
-+	return 0;
-+}
-+
-+static ssize_t gamepad_mode_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	if (cfg->gamepad_mode >= ALLY_GAMEPAD_MODE_GAMEPAD &&
-+	    cfg->gamepad_mode <= ALLY_GAMEPAD_MODE_KEYBOARD) {
-+		return sprintf(buf, "%s\n",
-+			       gamepad_mode_names[cfg->gamepad_mode]);
-+	} else {
-+		return sprintf(buf, "unknown (%u)\n", cfg->gamepad_mode);
-+	}
-+}
-+
-+static ssize_t gamepad_mode_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	char mode_name[16];
-+	int mode;
-+	int ret;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	if (sscanf(buf, "%15s", mode_name) != 1)
-+		return -EINVAL;
-+
-+	mode = get_gamepad_mode_from_name(mode_name);
-+	if (mode < 0) {
-+		hid_err(hdev, "Unknown gamepad mode: %s\n", mode_name);
-+		return -EINVAL;
-+	}
-+
-+	ret = ally_set_gamepad_mode(ally, hdev, mode);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t gamepad_modes_available_show(struct device *dev,
-+					    struct device_attribute *attr,
-+					    char *buf)
-+{
-+	int i;
-+	int len = 0;
-+
-+	for (i = ALLY_GAMEPAD_MODE_GAMEPAD; i <= ALLY_GAMEPAD_MODE_KEYBOARD;
-+	     i++) {
-+		len += sprintf(buf + len, "%s ", gamepad_mode_names[i]);
-+	}
-+
-+	/* Replace the last space with a newline */
-+	if (len > 0)
-+		buf[len - 1] = '\n';
-+
-+	return len;
-+}
-+
-+DEVICE_ATTR_RW(gamepad_mode);
-+DEVICE_ATTR_RO(gamepad_modes_available);
-+
-+static int ally_set_default_gamepad_mode(struct hid_device *hdev,
-+					 struct ally_config *cfg)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	cfg->gamepad_mode = ALLY_GAMEPAD_MODE_GAMEPAD;
-+
-+	return ally_set_gamepad_mode(ally, hdev, cfg->gamepad_mode);
-+}
-+
-+static struct attribute *ally_config_attrs[] = {
-+	&dev_attr_xbox_controller.attr,
-+	&dev_attr_vibration_intensity.attr,
-+	&dev_attr_gamepad_mode.attr,
-+	&dev_attr_gamepad_modes_available.attr,
-+	NULL
-+};
-+
-+static const struct attribute_group ally_attr_groups[] = {
-+	{
-+		.attrs = ally_config_attrs,
-+	},
-+	{
-+		.name = "axis_xy_left",
-+		.attrs = axis_xy_left_attrs,
-+	},
-+	{
-+		.name = "axis_xy_right",
-+		.attrs = axis_xy_right_attrs,
-+	},
-+	{
-+		.name = "axis_z_left",
-+		.attrs = axis_z_left_attrs,
-+	},
-+	{
-+		.name = "axis_z_right",
-+		.attrs = axis_z_right_attrs,
-+	},
-+};
-+
-+/**
-+ * ally_get_turbo_params - Get turbo parameters for a specific button
-+ * @cfg: Ally config structure
-+ * @button_id: Button identifier from ally_button_id enum
-+ *
-+ * Returns: Pointer to the button's turbo parameters, or NULL if invalid
-+ */
-+static struct button_turbo_params *ally_get_turbo_params(struct ally_config *cfg,
-+                                                       enum ally_button_id button_id)
-+{
-+	struct turbo_config *turbo;
-+
-+	if (!cfg || button_id >= ALLY_BTN_MAX)
-+		return NULL;
-+
-+	turbo = &cfg->turbo;
-+
-+	switch (button_id) {
-+	case ALLY_BTN_A:
-+		return &turbo->btn_a;
-+	case ALLY_BTN_B:
-+		return &turbo->btn_b;
-+	case ALLY_BTN_X:
-+		return &turbo->btn_x;
-+	case ALLY_BTN_Y:
-+		return &turbo->btn_y;
-+	case ALLY_BTN_LB:
-+		return &turbo->btn_lb;
-+	case ALLY_BTN_RB:
-+		return &turbo->btn_rb;
-+	case ALLY_BTN_DU:
-+		return &turbo->btn_du;
-+	case ALLY_BTN_DD:
-+		return &turbo->btn_dd;
-+	case ALLY_BTN_DL:
-+		return &turbo->btn_dl;
-+	case ALLY_BTN_DR:
-+		return &turbo->btn_dr;
-+	case ALLY_BTN_J0B:
-+		return &turbo->btn_j0b;
-+	case ALLY_BTN_J1B:
-+		return &turbo->btn_j1b;
-+	case ALLY_BTN_MENU:
-+		return &turbo->btn_menu;
-+	case ALLY_BTN_VIEW:
-+		return &turbo->btn_view;
-+	case ALLY_BTN_M1:
-+		return &turbo->btn_m1;
-+	case ALLY_BTN_M2:
-+		return &turbo->btn_m2;
-+	default:
-+		return NULL;
-+	}
-+}
-+
-+/**
-+ * ally_set_turbo_params - Set turbo parameters for all buttons
-+ * @hdev: HID device
-+ * @cfg: Ally config structure
-+ *
-+ * Returns: 0 on success, negative on failure
-+ */
-+static int ally_set_turbo_params(struct hid_device *hdev, struct ally_config *cfg)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct turbo_config *turbo = &cfg->turbo;
-+	u8 packet[HID_ALLY_REPORT_SIZE] = { 0 };
-+	int ret;
-+
-+	if (!cfg->turbo_support) {
-+		hid_dbg(hdev, "Turbo functionality not supported on this device\n");
-+		return -EOPNOTSUPP;
-+	}
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = CMD_SET_TURBO_PARAMS;
-+	packet[3] = 0x20; /* Length - 32 bytes for 16 buttons with 2 values each */
-+
-+	packet[4] = turbo->btn_du.turbo;
-+	packet[5] = turbo->btn_du.toggle;
-+	packet[6] = turbo->btn_dd.turbo;
-+	packet[7] = turbo->btn_dd.toggle;
-+	packet[8] = turbo->btn_dl.turbo;
-+	packet[9] = turbo->btn_dl.toggle;
-+	packet[10] = turbo->btn_dr.turbo;
-+	packet[11] = turbo->btn_dr.toggle;
-+	packet[12] = turbo->btn_j0b.turbo;
-+	packet[13] = turbo->btn_j0b.toggle;
-+	packet[14] = turbo->btn_j1b.turbo;
-+	packet[15] = turbo->btn_j1b.toggle;
-+	packet[16] = turbo->btn_lb.turbo;
-+	packet[17] = turbo->btn_lb.toggle;
-+	packet[18] = turbo->btn_rb.turbo;
-+	packet[19] = turbo->btn_rb.toggle;
-+	packet[20] = turbo->btn_a.turbo;
-+	packet[21] = turbo->btn_a.toggle;
-+	packet[22] = turbo->btn_b.turbo;
-+	packet[23] = turbo->btn_b.toggle;
-+	packet[24] = turbo->btn_x.turbo;
-+	packet[25] = turbo->btn_x.toggle;
-+	packet[26] = turbo->btn_y.turbo;
-+	packet[27] = turbo->btn_y.toggle;
-+	packet[28] = turbo->btn_view.turbo;
-+	packet[29] = turbo->btn_view.toggle;
-+	packet[30] = turbo->btn_menu.turbo;
-+	packet[31] = turbo->btn_menu.toggle;
-+	packet[32] = turbo->btn_m2.turbo;
-+	packet[33] = turbo->btn_m2.toggle;
-+	packet[34] = turbo->btn_m1.turbo;
-+	packet[35] = turbo->btn_m1.toggle;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet, HID_ALLY_REPORT_SIZE);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set turbo parameters: %d\n", ret);
-+		return ret;
-+	}
-+
-+	return 0;
-+}
-+
-+struct button_turbo_attr {
-+	struct device_attribute dev_attr;
-+	int button_id;
-+};
-+
-+#define to_button_turbo_attr(x) container_of(x, struct button_turbo_attr, dev_attr)
-+
-+static ssize_t button_turbo_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_turbo_attr *btn_attr = to_button_turbo_attr(attr);
-+	struct button_turbo_params *params;
-+
-+	if (!ally->config->turbo_support)
-+		return sprintf(buf, "Unsupported\n");
-+
-+	params = ally_get_turbo_params(ally->config, btn_attr->button_id);
-+	if (!params)
-+		return -EINVAL;
-+
-+	/* Format: turbo_interval_ms[,toggle_interval_ms] */
-+	if (params->toggle)
-+		return sprintf(buf, "%d,%d\n", params->turbo * 50, params->toggle * 50);
-+	else
-+		return sprintf(buf, "%d\n", params->turbo * 50);
-+}
-+
-+static ssize_t button_turbo_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_turbo_attr *btn_attr = to_button_turbo_attr(attr);
-+	struct button_turbo_params *params;
-+	unsigned int turbo_ms, toggle_ms = 0;
-+	int ret;
-+
-+	if (!ally->config->turbo_support)
-+		return -EOPNOTSUPP;
-+
-+	params = ally_get_turbo_params(ally->config, btn_attr->button_id);
-+	if (!params)
-+		return -EINVAL;
-+
-+	/* Parse input: turbo_interval_ms[,toggle_interval_ms] */
-+	ret = sscanf(buf, "%u,%u", &turbo_ms, &toggle_ms);
-+	if (ret < 1)
-+		return -EINVAL;
-+
-+	if (turbo_ms != 0 && (turbo_ms < 50 || turbo_ms > 1000))
-+		return -EINVAL;
-+
-+	if (ret > 1 && toggle_ms > 0 && (toggle_ms < 50 || toggle_ms > 1000))
-+		return -EINVAL;
-+
-+	mutex_lock(&ally->config->config_mutex);
-+
-+	params->turbo = turbo_ms / 50;
-+	params->toggle = toggle_ms / 50;
-+
-+	ret = ally_set_turbo_params(hdev, ally->config);
-+
-+	mutex_unlock(&ally->config->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+/* Helper to create button turbo attribute */
-+static struct button_turbo_attr *button_turbo_attr_create(int button_id)
-+{
-+	struct button_turbo_attr *attr;
-+
-+	attr = kzalloc(sizeof(*attr), GFP_KERNEL);
-+	if (!attr)
-+		return NULL;
-+
-+	attr->button_id = button_id;
-+	sysfs_attr_init(&attr->dev_attr.attr);
-+	attr->dev_attr.attr.name = "turbo";
-+	attr->dev_attr.attr.mode = 0644;
-+	attr->dev_attr.show = button_turbo_show;
-+	attr->dev_attr.store = button_turbo_store;
-+
-+	return attr;
-+}
-+
-+/* Button remap attribute structure */
-+struct button_remap_attr {
-+	struct device_attribute dev_attr;
-+	enum ally_button_id button_id;
-+	bool is_macro;
-+};
-+
-+#define to_button_remap_attr(x) container_of(x, struct button_remap_attr, dev_attr)
-+
-+/* Get appropriate button pair index and position for a given button */
-+static int get_button_pair_info(enum ally_button_id button_id,
-+				enum btn_pair_index *pair_idx,
-+				bool *is_first)
-+{
-+	switch (button_id) {
-+	case ALLY_BTN_DU:
-+		*pair_idx = BTN_PAIR_DPAD_UPDOWN;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_DD:
-+		*pair_idx = BTN_PAIR_DPAD_UPDOWN;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_DL:
-+		*pair_idx = BTN_PAIR_DPAD_LEFTRIGHT;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_DR:
-+		*pair_idx = BTN_PAIR_DPAD_LEFTRIGHT;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_J0B:
-+		*pair_idx = BTN_PAIR_STICK_LR;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_J1B:
-+		*pair_idx = BTN_PAIR_STICK_LR;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_LB:
-+		*pair_idx = BTN_PAIR_BUMPER_LR;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_RB:
-+		*pair_idx = BTN_PAIR_BUMPER_LR;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_A:
-+		*pair_idx = BTN_PAIR_AB;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_B:
-+		*pair_idx = BTN_PAIR_AB;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_X:
-+		*pair_idx = BTN_PAIR_XY;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_Y:
-+		*pair_idx = BTN_PAIR_XY;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_VIEW:
-+		*pair_idx = BTN_PAIR_VIEW_MENU;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_MENU:
-+		*pair_idx = BTN_PAIR_VIEW_MENU;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_M1:
-+		*pair_idx = BTN_PAIR_M1M2;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_M2:
-+		*pair_idx = BTN_PAIR_M1M2;
-+		*is_first = false;
-+		break;
-+	default:
-+		return -EINVAL;
-+	}
-+
-+	return 0;
-+}
-+
-+static ssize_t button_remap_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_remap_attr *btn_attr = to_button_remap_attr(attr);
-+	struct ally_config *cfg = ally->config;
-+	enum ally_button_id button_id = btn_attr->button_id;
-+	enum btn_pair_index pair_idx;
-+	bool is_first;
-+	struct button_pair_map *pair;
-+	struct button_map *btn_map;
-+	int ret;
-+
-+	if (!cfg)
-+		return -ENODEV;
-+
-+	ret = get_button_pair_info(button_id, &pair_idx, &is_first);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	pair = &((struct ally_button_mapping
-+			  *)(cfg->button_mappings))[cfg->gamepad_mode]
-+			.button_pairs[pair_idx - 1];
-+	btn_map = is_first ? &pair->first : &pair->second;
-+
-+	if (btn_attr->is_macro) {
-+		if (btn_map->macro->type == BTN_TYPE_NONE)
-+			ret = sprintf(buf, "NONE\n");
-+		else
-+			ret = sprintf(buf, "%s\n", btn_map->macro->name);
-+	} else {
-+		if (btn_map->remap->type == BTN_TYPE_NONE)
-+			ret = sprintf(buf, "NONE\n");
-+		else
-+			ret = sprintf(buf, "%s\n", btn_map->remap->name);
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return ret;
-+}
-+
-+static ssize_t button_remap_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_remap_attr *btn_attr = to_button_remap_attr(attr);
-+	struct ally_config *cfg = ally->config;
-+	enum ally_button_id button_id = btn_attr->button_id;
-+	enum btn_pair_index pair_idx;
-+	bool is_first;
-+	struct button_pair_map *pair;
-+	struct button_map *btn_map;
-+	char btn_name[32];
-+	const struct btn_code_map *code;
-+	int ret;
-+
-+	if (!cfg)
-+		return -ENODEV;
-+
-+	if (sscanf(buf, "%31s", btn_name) != 1)
-+		return -EINVAL;
-+
-+	/* Handle "NONE" specially */
-+	if (strcmp(btn_name, "NONE") == 0) {
-+		code = &ally_btn_codes[0]; /* NONE entry */
-+	} else {
-+		code = find_button_by_name(btn_name);
-+		if (!code)
-+			return -EINVAL;
-+	}
-+
-+	ret = get_button_pair_info(button_id, &pair_idx, &is_first);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	/* Access the mapping for current gamepad mode */
-+	pair = &((struct ally_button_mapping
-+			  *)(cfg->button_mappings))[cfg->gamepad_mode]
-+			.button_pairs[pair_idx - 1];
-+	btn_map = is_first ? &pair->first : &pair->second;
-+
-+	if (btn_attr->is_macro) {
-+		btn_map->macro = (struct btn_code_map *)code;
-+	} else {
-+		btn_map->remap = (struct btn_code_map *)code;
-+	}
-+
-+	/* Update pair index */
-+	pair->pair_index = pair_idx;
-+
-+	/* Send mapping to device */
-+	ret = ally_set_button_mapping(hdev, ally, pair);
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+/* Helper to create button remap attribute */
-+static struct button_remap_attr *button_remap_attr_create(enum ally_button_id button_id, bool is_macro)
-+{
-+	struct button_remap_attr *attr;
-+
-+	attr = kzalloc(sizeof(*attr), GFP_KERNEL);
-+	if (!attr)
-+		return NULL;
-+
-+	attr->button_id = button_id;
-+	attr->is_macro = is_macro;
-+	sysfs_attr_init(&attr->dev_attr.attr);
-+	attr->dev_attr.attr.name = is_macro ? "macro" : "remap";
-+	attr->dev_attr.attr.mode = 0644;
-+	attr->dev_attr.show = button_remap_show;
-+	attr->dev_attr.store = button_remap_store;
-+
-+	return attr;
-+}
-+
-+/* Structure to hold button sysfs information */
-+struct button_sysfs_entry {
-+	struct attribute_group group;
-+	struct attribute *attrs[4]; /* turbo + remap + macro + NULL terminator */
-+	struct button_turbo_attr *turbo_attr;
-+	struct button_remap_attr *remap_attr;
-+	struct button_remap_attr *macro_attr;
-+};
-+
-+static void ally_set_default_gamepad_mapping(struct ally_button_mapping *mappings)
-+{
-+	struct ally_button_mapping *map = &mappings[ALLY_GAMEPAD_MODE_GAMEPAD];
-+	int i;
-+
-+	/* Set all pair indexes and initialize to NONE */
-+	for (i = 0; i < 9; i++) {
-+		map->button_pairs[i].pair_index = i + 1;
-+		map->button_pairs[i].first.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].first.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+	}
-+
-+	/* Set direct mappings using array indices */
-+	map->button_pairs[BTN_PAIR_AB - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[1]; /* PAD_A */
-+	map->button_pairs[BTN_PAIR_AB - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[2]; /* PAD_B */
-+
-+	map->button_pairs[BTN_PAIR_XY - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[3]; /* PAD_X */
-+	map->button_pairs[BTN_PAIR_XY - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[4]; /* PAD_Y */
-+
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[5]; /* PAD_LB */
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[6]; /* PAD_RB */
-+
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[7]; /* PAD_LS */
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[8]; /* PAD_RS */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[9]; /* PAD_DPAD_UP */
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[10]; /* PAD_DPAD_DOWN */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[11]; /* PAD_DPAD_LEFT */
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[12]; /* PAD_DPAD_RIGHT */
-+
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[13]; /* PAD_LT */
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[14]; /* PAD_RT */
-+
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[15]; /* PAD_VIEW */
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[16]; /* PAD_MENU */
-+
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[19]; /* KB_M1 */
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[18]; /* KB_M2 */
-+}
-+
-+static void ally_set_default_keyboard_mapping(struct ally_button_mapping *mappings)
-+{
-+	struct ally_button_mapping *map = &mappings[ALLY_GAMEPAD_MODE_KEYBOARD];
-+	int i;
-+
-+	/* Set all pair indexes and initialize to NONE */
-+	for (i = 0; i < 9; i++) {
-+		map->button_pairs[i].pair_index = i + 1;
-+		map->button_pairs[i].first.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].first.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+	}
-+
-+	/* Set direct mappings using array indices */
-+	map->button_pairs[BTN_PAIR_AB - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[1]; /* PAD_A */
-+	map->button_pairs[BTN_PAIR_AB - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[2]; /* PAD_B */
-+
-+	map->button_pairs[BTN_PAIR_XY - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[3]; /* PAD_X */
-+	map->button_pairs[BTN_PAIR_XY - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[4]; /* PAD_Y */
-+
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[5]; /* PAD_LB */
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[6]; /* PAD_RB */
-+
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[7]; /* PAD_LS */
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[8]; /* PAD_RS */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[9]; /* PAD_DPAD_UP */
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[10]; /* PAD_DPAD_DOWN */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[11]; /* PAD_DPAD_LEFT */
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[12]; /* PAD_DPAD_RIGHT */
-+
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[13]; /* PAD_LT */
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[14]; /* PAD_RT */
-+
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[15]; /* PAD_VIEW */
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[16]; /* PAD_MENU */
-+
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[19]; /* KB_M1 */
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[18]; /* KB_M2 */
-+}
-+
-+/**
-+ * ally_create_button_attributes - Create button attributes
-+ * @hdev: HID device
-+ * @cfg: Ally config structure
-+ *
-+ * Returns: 0 on success, negative on failure
-+ */
-+static int ally_create_button_attributes(struct hid_device *hdev,
-+					 struct ally_config *cfg)
-+{
-+	struct button_sysfs_entry *entries;
-+	int i, j, ret;
-+	struct ally_button_mapping *mappings;
-+
-+	entries = devm_kcalloc(&hdev->dev, ALLY_BTN_MAX, sizeof(*entries),
-+			       GFP_KERNEL);
-+	if (!entries)
-+		return -ENOMEM;
-+
-+	/* Allocate mappings for each gamepad mode (1-based indexing) */
-+	mappings = devm_kcalloc(&hdev->dev, ALLY_GAMEPAD_MODE_KEYBOARD + 1,
-+				sizeof(*mappings), GFP_KERNEL);
-+	if (!mappings) {
-+		ret = -ENOMEM;
-+		goto err_free_entries;
-+	}
-+
-+	cfg->button_entries = entries;
-+	cfg->button_mappings = mappings;
-+	ally_set_default_gamepad_mapping(mappings);
-+	ally_set_default_keyboard_mapping(mappings);
-+
-+	for (i = 0; i < ALLY_BTN_MAX; i++) {
-+		if (cfg->turbo_support) {
-+			entries[i].turbo_attr = button_turbo_attr_create(i);
-+			if (!entries[i].turbo_attr) {
-+				ret = -ENOMEM;
-+				goto err_cleanup;
-+			}
-+		}
-+
-+		entries[i].remap_attr = button_remap_attr_create(i, false);
-+		if (!entries[i].remap_attr) {
-+			ret = -ENOMEM;
-+			goto err_cleanup;
-+		}
-+
-+		entries[i].macro_attr = button_remap_attr_create(i, true);
-+		if (!entries[i].macro_attr) {
-+			ret = -ENOMEM;
-+			goto err_cleanup;
-+		}
-+
-+		/* Set up attributes array based on what's supported */
-+		if (cfg->turbo_support) {
-+			entries[i].attrs[0] =
-+				&entries[i].turbo_attr->dev_attr.attr;
-+			entries[i].attrs[1] =
-+				&entries[i].remap_attr->dev_attr.attr;
-+			entries[i].attrs[2] =
-+				&entries[i].macro_attr->dev_attr.attr;
-+			entries[i].attrs[3] = NULL;
-+		} else {
-+			entries[i].attrs[0] =
-+				&entries[i].remap_attr->dev_attr.attr;
-+			entries[i].attrs[1] =
-+				&entries[i].macro_attr->dev_attr.attr;
-+			entries[i].attrs[2] = NULL;
-+		}
-+
-+		entries[i].group.name = ally_button_names[i];
-+		entries[i].group.attrs = entries[i].attrs;
-+
-+		ret = sysfs_create_group(&hdev->dev.kobj, &entries[i].group);
-+		if (ret < 0) {
-+			hid_err(hdev,
-+				"Failed to create sysfs group for %s: %d\n",
-+				ally_button_names[i], ret);
-+			goto err_cleanup;
-+		}
-+	}
-+
-+	return 0;
-+
-+err_cleanup:
-+	while (--i >= 0) {
-+		sysfs_remove_group(&hdev->dev.kobj, &entries[i].group);
-+		if (entries[i].turbo_attr)
-+			kfree(entries[i].turbo_attr);
-+		if (entries[i].remap_attr)
-+			kfree(entries[i].remap_attr);
-+		if (entries[i].macro_attr)
-+			kfree(entries[i].macro_attr);
-+	}
-+
-+err_free_entries:
-+	if (mappings)
-+		devm_kfree(&hdev->dev, mappings);
-+	devm_kfree(&hdev->dev, entries);
-+	return ret;
-+}
-+
-+/**
-+ * ally_remove_button_attributes - Remove button attributes
-+ * @hdev: HID device
-+ * @cfg: Ally config structure
-+ */
-+static void ally_remove_button_attributes(struct hid_device *hdev,
-+					  struct ally_config *cfg)
-+{
-+	struct button_sysfs_entry *entries;
-+	int i;
-+
-+	if (!cfg || !cfg->button_entries)
-+		return;
-+
-+	entries = cfg->button_entries;
-+
-+	/* Remove all attribute groups */
-+	for (i = 0; i < ALLY_BTN_MAX; i++) {
-+		sysfs_remove_group(&hdev->dev.kobj, &entries[i].group);
-+		if (entries[i].turbo_attr)
-+			kfree(entries[i].turbo_attr);
-+		if (entries[i].remap_attr)
-+			kfree(entries[i].remap_attr);
-+		if (entries[i].macro_attr)
-+			kfree(entries[i].macro_attr);
-+	}
-+
-+	if (cfg->button_mappings)
-+		devm_kfree(&hdev->dev, cfg->button_mappings);
-+	devm_kfree(&hdev->dev, entries);
-+}
-+
-+/**
-+ * ally_config_create - Initialize configuration and create sysfs entries
-+ * @hdev: HID device
-+ * @ally: Ally device data
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+int ally_config_create(struct hid_device *hdev, struct ally_handheld *ally)
-+{
-+	struct ally_config *cfg;
-+	int ret, i;
-+
-+	if (!hdev || !ally)
-+		return -EINVAL;
-+
-+	if (get_endpoint_address(hdev) != HID_ALLY_INTF_CFG_IN)
-+		return 0;
-+
-+	cfg = devm_kzalloc(&hdev->dev, sizeof(*cfg), GFP_KERNEL);
-+	if (!cfg)
-+		return -ENOMEM;
-+
-+	cfg->hdev = hdev;
-+
-+	ally->config = cfg;
-+
-+	ret = ally_detect_capabilities(hdev, cfg);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to detect Ally capabilities: %d\n", ret);
-+		goto err_free;
-+	}
-+
-+	/* Create all attribute groups */
-+	for (i = 0; i < ARRAY_SIZE(ally_attr_groups); i++) {
-+		ret = sysfs_create_group(&hdev->dev.kobj, &ally_attr_groups[i]);
-+		if (ret < 0) {
-+			hid_err(hdev, "Failed to create sysfs group '%s': %d\n",
-+				ally_attr_groups[i].name, ret);
-+			/* Remove any groups already created */
-+			while (--i >= 0)
-+				sysfs_remove_group(&hdev->dev.kobj,
-+						   &ally_attr_groups[i]);
-+			goto err_free;
-+		}
-+	}
-+
-+	if (cfg->turbo_support) {
-+		ret = ally_create_button_attributes(hdev, cfg);
-+		if (ret < 0) {
-+			hid_err(hdev, "Failed to create button attributes: %d\n", ret);
-+			for (i = 0; i < ARRAY_SIZE(ally_attr_groups); i++)
-+				sysfs_remove_group(&hdev->dev.kobj, &ally_attr_groups[i]);
-+			goto err_free;
-+		}
-+	}
-+
-+	ret = ally_set_default_gamepad_mode(hdev, cfg);
-+		if (ret < 0)
-+			hid_warn(hdev, "Failed to set default gamepad mode: %d\n", ret);
-+
-+	cfg->gamepad_mode = 0x01;
-+	cfg->left_deadzone = 10;
-+	cfg->left_outer_threshold = 90;
-+	cfg->right_deadzone = 10;
-+	cfg->right_outer_threshold = 90;
-+
-+	cfg->vibration_intensity_left = 100;
-+	cfg->vibration_intensity_right = 100;
-+	cfg->vibration_active = false;
-+
-+	/* Initialize default response curve values (linear) */
-+	cfg->left_curve.entry_1.move = 0;
-+	cfg->left_curve.entry_1.resp = 0;
-+	cfg->left_curve.entry_2.move = 33;
-+	cfg->left_curve.entry_2.resp = 33;
-+	cfg->left_curve.entry_3.move = 66;
-+	cfg->left_curve.entry_3.resp = 66;
-+	cfg->left_curve.entry_4.move = 100;
-+	cfg->left_curve.entry_4.resp = 100;
-+
-+	cfg->right_curve.entry_1.move = 0;
-+	cfg->right_curve.entry_1.resp = 0;
-+	cfg->right_curve.entry_2.move = 33;
-+	cfg->right_curve.entry_2.resp = 33;
-+	cfg->right_curve.entry_3.move = 66;
-+	cfg->right_curve.entry_3.resp = 66;
-+	cfg->right_curve.entry_4.move = 100;
-+	cfg->right_curve.entry_4.resp = 100;
-+
-+	// ONLY FOR ALLY 1
-+	if (cfg->xbox_controller_support) {
-+		ret = ally_set_xbox_controller(hdev, cfg, true);
-+		if (ret < 0)
-+			hid_warn(
-+				hdev,
-+				"Failed to set default Xbox controller mode: %d\n",
-+				ret);
-+	}
-+
-+	cfg->initialized = true;
-+	hid_info(hdev, "Ally configuration system initialized successfully\n");
-+
-+	return 0;
-+
-+err_free:
-+	ally->config = NULL;
-+	devm_kfree(&hdev->dev, cfg);
-+	return ret;
-+}
-+
-+/**
-+ * ally_config_remove - Clean up configuration resources
-+ * @hdev: HID device
-+ * @ally: Ally device data
-+ */
-+void ally_config_remove(struct hid_device *hdev, struct ally_handheld *ally)
-+{
-+	struct ally_config *cfg;
-+	int i;
-+
-+	if (!ally)
-+		return;
-+
-+	cfg = ally->config;
-+	if (!cfg || !cfg->initialized)
-+		return;
-+
-+	if (get_endpoint_address(hdev) != HID_ALLY_INTF_CFG_IN)
-+		return;
-+
-+	if (cfg->turbo_support && cfg->button_entries)
-+			ally_remove_button_attributes(hdev, cfg);
-+
-+	/* Remove all attribute groups in reverse order */
-+	for (i = ARRAY_SIZE(ally_attr_groups) - 1; i >= 0; i--)
-+		sysfs_remove_group(&hdev->dev.kobj, &ally_attr_groups[i]);
-+
-+	ally->config = NULL;
-+
-+	hid_info(hdev, "Ally configuration system removed\n");
-+}
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-hid-core.c b/drivers/hid/asus-ally-hid/asus-ally-hid-core.c
-new file mode 100644
-index 000000000000..1e8f98b69332
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-hid-core.c
-@@ -0,0 +1,600 @@
-+// SPDX-License-Identifier: GPL-2.0-or-later
-+/*
-+ *  HID driver for Asus ROG laptops and Ally
-+ *
-+ *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
-+ */
-+
-+#include "linux/mutex.h"
-+#include "linux/stddef.h"
-+#include "linux/types.h"
 +#include <linux/usb.h>
++#include <linux/leds.h>
++#include <linux/led-class-multicolor.h>
 +
-+#include "../hid-ids.h"
-+#include "asus-ally.h"
++#include "hid-ids.h"
++#include "hid-asus.h"
++#include "hid-asus-ally.h"
++
++#define DEBUG
 +
 +#define READY_MAX_TRIES 3
++#define FEATURE_REPORT_ID 0x0d
++#define FEATURE_ROG_ALLY_REPORT_ID 0x5a
++#define FEATURE_ROG_ALLY_CODE_PAGE 0xD1
++#define FEATURE_ROG_ALLY_REPORT_SIZE 64
++#define ALLY_X_INPUT_REPORT_USB 0x0B
++#define ALLY_X_INPUT_REPORT_USB_SIZE 16
++
++#define ROG_ALLY_REPORT_SIZE 64
++#define ROG_ALLY_X_MIN_MCU 313
++#define ROG_ALLY_MIN_MCU 319
++
++#define FEATURE_KBD_LED_REPORT_ID1 0x5d
++#define FEATURE_KBD_LED_REPORT_ID2 0x5e
++
++#define BTN_DATA_LEN 11;
++#define BTN_CODE_BYTES_LEN 8
 +
 +static const u8 EC_INIT_STRING[] = { 0x5A, 'A', 'S', 'U', 'S', ' ', 'T', 'e','c', 'h', '.', 'I', 'n', 'c', '.', '\0' };
++static const u8 EC_MODE_LED_APPLY[] = { 0x5A, 0xB4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
++static const u8 EC_MODE_LED_SET[] = { 0x5A, 0xB5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 +static const u8 FORCE_FEEDBACK_OFF[] = { 0x0D, 0x0F, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0xEB };
 +
 +static const struct hid_device_id rog_ally_devices[] = {
@@ -2611,18 +269,384 @@ index 000000000000..1e8f98b69332
 +	{}
 +};
 +
-+const char * ally_keyboard_name = "ROG Ally Keyboard";
-+const char * ally_mouse_name = "ROG Ally Mouse";
-+
-+/* Changes to ally_drvdata must lock */
-+static DEFINE_MUTEX(ally_data_mutex);
-+static struct ally_handheld ally_drvdata = {
-+    .cfg_hdev = NULL,
-+    .led_rgb_dev = NULL,
-+    .ally_x_input = NULL,
++struct btn_code_map {
++	u64 code;
++	const char *name;
 +};
 +
-+static inline int asus_dev_set_report(struct hid_device *hdev, const u8 *buf, size_t len)
++static const struct btn_code_map ally_btn_codes[] = {
++	{ 0, "NONE" },
++	/* Gamepad button codes */
++	{ BTN_PAD_A, "PAD_A" },
++	{ BTN_PAD_B, "PAD_B" },
++	{ BTN_PAD_X, "PAD_X" },
++	{ BTN_PAD_Y, "PAD_Y" },
++	{ BTN_PAD_LB, "PAD_LB" },
++	{ BTN_PAD_RB, "PAD_RB" },
++	{ BTN_PAD_LS, "PAD_LS" },
++	{ BTN_PAD_RS, "PAD_RS" },
++	{ BTN_PAD_DPAD_UP, "PAD_DPAD_UP" },
++	{ BTN_PAD_DPAD_DOWN, "PAD_DPAD_DOWN" },
++	{ BTN_PAD_DPAD_LEFT, "PAD_DPAD_LEFT" },
++	{ BTN_PAD_DPAD_RIGHT, "PAD_DPAD_RIGHT" },
++	{ BTN_PAD_VIEW, "PAD_VIEW" },
++	{ BTN_PAD_MENU, "PAD_MENU" },
++	{ BTN_PAD_XBOX, "PAD_XBOX" },
++
++	/* Triggers mapped to keyboard codes */
++	{ BTN_KB_M2, "KB_M2" },
++	{ BTN_KB_M1, "KB_M1" },
++	{ BTN_KB_ESC, "KB_ESC" },
++	{ BTN_KB_F1, "KB_F1" },
++	{ BTN_KB_F2, "KB_F2" },
++	{ BTN_KB_F3, "KB_F3" },
++	{ BTN_KB_F4, "KB_F4" },
++	{ BTN_KB_F5, "KB_F5" },
++	{ BTN_KB_F6, "KB_F6" },
++	{ BTN_KB_F7, "KB_F7" },
++	{ BTN_KB_F8, "KB_F8" },
++	{ BTN_KB_F9, "KB_F9" },
++	{ BTN_KB_F10, "KB_F10" },
++	{ BTN_KB_F11, "KB_F11" },
++	{ BTN_KB_F12, "KB_F12" },
++	{ BTN_KB_F14, "KB_F14" },
++	{ BTN_KB_F15, "KB_F15" },
++	{ BTN_KB_BACKTICK, "KB_BACKTICK" },
++	{ BTN_KB_1, "KB_1" },
++	{ BTN_KB_2, "KB_2" },
++	{ BTN_KB_3, "KB_3" },
++	{ BTN_KB_4, "KB_4" },
++	{ BTN_KB_5, "KB_5" },
++	{ BTN_KB_6, "KB_6" },
++	{ BTN_KB_7, "KB_7" },
++	{ BTN_KB_8, "KB_8" },
++	{ BTN_KB_9, "KB_9" },
++	{ BTN_KB_0, "KB_0" },
++	{ BTN_KB_HYPHEN, "KB_HYPHEN" },
++	{ BTN_KB_EQUALS, "KB_EQUALS" },
++	{ BTN_KB_BACKSPACE, "KB_BACKSPACE" },
++	{ BTN_KB_TAB, "KB_TAB" },
++	{ BTN_KB_Q, "KB_Q" },
++	{ BTN_KB_W, "KB_W" },
++	{ BTN_KB_E, "KB_E" },
++	{ BTN_KB_R, "KB_R" },
++	{ BTN_KB_T, "KB_T" },
++	{ BTN_KB_Y, "KB_Y" },
++	{ BTN_KB_U, "KB_U" },
++	{ BTN_KB_O, "KB_O" },
++	{ BTN_KB_P, "KB_P" },
++	{ BTN_KB_LBRACKET, "KB_LBRACKET" },
++	{ BTN_KB_RBRACKET, "KB_RBRACKET" },
++	{ BTN_KB_BACKSLASH, "KB_BACKSLASH" },
++	{ BTN_KB_CAPS, "KB_CAPS" },
++	{ BTN_KB_A, "KB_A" },
++	{ BTN_KB_S, "KB_S" },
++	{ BTN_KB_D, "KB_D" },
++	{ BTN_KB_F, "KB_F" },
++	{ BTN_KB_G, "KB_G" },
++	{ BTN_KB_H, "KB_H" },
++	{ BTN_KB_J, "KB_J" },
++	{ BTN_KB_K, "KB_K" },
++	{ BTN_KB_L, "KB_L" },
++	{ BTN_KB_SEMI, "KB_SEMI" },
++	{ BTN_KB_QUOTE, "KB_QUOTE" },
++	{ BTN_KB_RET, "KB_RET" },
++	{ BTN_KB_LSHIFT, "KB_LSHIFT" },
++	{ BTN_KB_Z, "KB_Z" },
++	{ BTN_KB_X, "KB_X" },
++	{ BTN_KB_C, "KB_C" },
++	{ BTN_KB_V, "KB_V" },
++	{ BTN_KB_B, "KB_B" },
++	{ BTN_KB_N, "KB_N" },
++	{ BTN_KB_M, "KB_M" },
++	{ BTN_KB_COMMA, "KB_COMMA" },
++	{ BTN_KB_PERIOD, "KB_PERIOD" },
++	{ BTN_KB_RSHIFT, "KB_RSHIFT" },
++	{ BTN_KB_LCTL, "KB_LCTL" },
++	{ BTN_KB_META, "KB_META" },
++	{ BTN_KB_LALT, "KB_LALT" },
++	{ BTN_KB_SPACE, "KB_SPACE" },
++	{ BTN_KB_RALT, "KB_RALT" },
++	{ BTN_KB_MENU, "KB_MENU" },
++	{ BTN_KB_RCTL, "KB_RCTL" },
++	{ BTN_KB_PRNTSCN, "KB_PRNTSCN" },
++	{ BTN_KB_SCRLCK, "KB_SCRLCK" },
++	{ BTN_KB_PAUSE, "KB_PAUSE" },
++	{ BTN_KB_INS, "KB_INS" },
++	{ BTN_KB_HOME, "KB_HOME" },
++	{ BTN_KB_PGUP, "KB_PGUP" },
++	{ BTN_KB_DEL, "KB_DEL" },
++	{ BTN_KB_END, "KB_END" },
++	{ BTN_KB_PGDWN, "KB_PGDWN" },
++	{ BTN_KB_UP_ARROW, "KB_UP_ARROW" },
++	{ BTN_KB_DOWN_ARROW, "KB_DOWN_ARROW" },
++	{ BTN_KB_LEFT_ARROW, "KB_LEFT_ARROW" },
++	{ BTN_KB_RIGHT_ARROW, "KB_RIGHT_ARROW" },
++
++	/* Numpad mappings */
++	{ BTN_NUMPAD_LOCK, "NUMPAD_LOCK" },
++	{ BTN_NUMPAD_FWDSLASH, "NUMPAD_FWDSLASH" },
++	{ BTN_NUMPAD_ASTERISK, "NUMPAD_ASTERISK" },
++	{ BTN_NUMPAD_HYPHEN, "NUMPAD_HYPHEN" },
++	{ BTN_NUMPAD_0, "NUMPAD_0" },
++	{ BTN_NUMPAD_1, "NUMPAD_1" },
++	{ BTN_NUMPAD_2, "NUMPAD_2" },
++	{ BTN_NUMPAD_3, "NUMPAD_3" },
++	{ BTN_NUMPAD_4, "NUMPAD_4" },
++	{ BTN_NUMPAD_5, "NUMPAD_5" },
++	{ BTN_NUMPAD_6, "NUMPAD_6" },
++	{ BTN_NUMPAD_7, "NUMPAD_7" },
++	{ BTN_NUMPAD_8, "NUMPAD_8" },
++	{ BTN_NUMPAD_9, "NUMPAD_9" },
++	{ BTN_NUMPAD_PLUS, "NUMPAD_PLUS" },
++	{ BTN_NUMPAD_ENTER, "NUMPAD_ENTER" },
++	{ BTN_NUMPAD_PERIOD, "NUMPAD_PERIOD" },
++
++	/* Mouse mappings */
++	{ BTN_MOUSE_LCLICK, "MOUSE_LCLICK" },
++	{ BTN_MOUSE_RCLICK, "MOUSE_RCLICK" },
++	{ BTN_MOUSE_MCLICK, "MOUSE_MCLICK" },
++	{ BTN_MOUSE_WHEEL_UP, "MOUSE_WHEEL_UP" },
++	{ BTN_MOUSE_WHEEL_DOWN, "MOUSE_WHEEL_DOWN" },
++
++	/* Media mappings */
++	{ BTN_MEDIA_SCREENSHOT, "MEDIA_SCREENSHOT" },
++	{ BTN_MEDIA_SHOW_KEYBOARD, "MEDIA_SHOW_KEYBOARD" },
++	{ BTN_MEDIA_SHOW_DESKTOP, "MEDIA_SHOW_DESKTOP" },
++	{ BTN_MEDIA_START_RECORDING, "MEDIA_START_RECORDING" },
++	{ BTN_MEDIA_MIC_OFF, "MEDIA_MIC_OFF" },
++	{ BTN_MEDIA_VOL_DOWN, "MEDIA_VOL_DOWN" },
++	{ BTN_MEDIA_VOL_UP, "MEDIA_VOL_UP" },
++};
++static const size_t keymap_len = ARRAY_SIZE(ally_btn_codes);
++
++/* byte_array must be >= 8 in length */
++static void btn_code_to_byte_array(u64 keycode, u8 *byte_array)
++{
++	/* Convert the u64 to bytes[8] */
++	for (int i = 0; i < 8; ++i) {
++		byte_array[i] = (keycode >> (56 - 8 * i)) & 0xFF;
++	}
++}
++
++static u64 name_to_btn(const char *name)
++{
++	int len = strcspn(name, "\n");
++	for (size_t i = 0; i < keymap_len; ++i) {
++		if (strncmp(ally_btn_codes[i].name, name, len) == 0) {
++			return ally_btn_codes[i].code;
++		}
++	}
++	return -EINVAL;
++}
++
++static const char* btn_to_name(u64 key)
++{
++	for (size_t i = 0; i < keymap_len; ++i) {
++		if (ally_btn_codes[i].code == key) {
++			return ally_btn_codes[i].name;
++		}
++	}
++	return NULL;
++}
++
++struct btn_data {
++	u64 button;
++	u64 macro;
++	bool turbo;
++};
++
++struct btn_mapping {
++	struct btn_data btn_a;
++	struct btn_data btn_b;
++	struct btn_data btn_x;
++	struct btn_data btn_y;
++	struct btn_data btn_lb;
++	struct btn_data btn_rb;
++	struct btn_data btn_ls;
++	struct btn_data btn_rs;
++	struct btn_data btn_lt;
++	struct btn_data btn_rt;
++	struct btn_data dpad_up;
++	struct btn_data dpad_down;
++	struct btn_data dpad_left;
++	struct btn_data dpad_right;
++	struct btn_data btn_view;
++	struct btn_data btn_menu;
++	struct btn_data btn_m1;
++	struct btn_data btn_m2;
++};
++
++struct deadzone {
++	u8 inner;
++	u8 outer;
++};
++
++struct response_curve {
++	uint8_t move_pct_1;
++	uint8_t response_pct_1;
++	uint8_t move_pct_2;
++	uint8_t response_pct_2;
++	uint8_t move_pct_3;
++	uint8_t response_pct_3;
++	uint8_t move_pct_4;
++	uint8_t response_pct_4;
++} __packed;
++
++struct js_axis_calibrations {
++	uint16_t left_y_stable;
++	uint16_t left_y_min;
++	uint16_t left_y_max;
++	uint16_t left_x_stable;
++	uint16_t left_x_min;
++	uint16_t left_x_max;
++	uint16_t right_y_stable;
++	uint16_t right_y_min;
++	uint16_t right_y_max;
++	uint16_t right_x_stable;
++	uint16_t right_x_min;
++	uint16_t right_x_max;
++} __packed;
++
++struct tr_axis_calibrations {
++	uint16_t left_stable;
++	uint16_t left_max;
++	uint16_t right_stable;
++	uint16_t right_max;
++} __packed;
++
++/* ROG Ally has many settings related to the gamepad, all using the same n-key endpoint */
++struct ally_gamepad_cfg {
++	struct hid_device *hdev;
++	struct input_dev *input;
++
++	enum xpad_mode mode;
++	/*
++	 * index: [mode]
++	 */
++	struct btn_mapping key_mapping[xpad_mode_mouse];
++	/*
++	 * index: left, right
++	 * max: 64
++	 */
++	u8 vibration_intensity[2];
++
++	/* deadzones */
++	struct deadzone ls_dz; // left stick
++	struct deadzone rs_dz; // right stick
++	struct deadzone lt_dz; // left trigger
++	struct deadzone rt_dz; // right trigger
++	/* anti-deadzones */
++	u8 ls_adz; // left stick
++	u8 rs_adz; // right stick
++	/* joystick response curves */
++	struct response_curve ls_rc;
++	struct response_curve rs_rc;
++
++	struct js_axis_calibrations js_cal;
++	struct tr_axis_calibrations tr_cal;
++};
++
++/* The hatswitch outputs integers, we use them to index this X|Y pair */
++static const int hat_values[][2] = {
++	{ 0, 0 }, { 0, -1 }, { 1, -1 }, { 1, 0 },   { 1, 1 },
++	{ 0, 1 }, { -1, 1 }, { -1, 0 }, { -1, -1 },
++};
++
++/* rumble packet structure */
++struct ff_data {
++	u8 enable;
++	u8 magnitude_left;
++	u8 magnitude_right;
++	u8 magnitude_strong;
++	u8 magnitude_weak;
++	u8 pulse_sustain_10ms;
++	u8 pulse_release_10ms;
++	u8 loop_count;
++} __packed;
++
++struct ff_report {
++	u8 report_id;
++	struct ff_data ff;
++} __packed;
++
++struct ally_x_input_report {
++	uint16_t x, y;
++	uint16_t rx, ry;
++	uint16_t z, rz;
++	uint8_t buttons[4];
++} __packed;
++
++struct ally_x_device {
++	struct input_dev *input;
++	struct hid_device *hdev;
++	spinlock_t lock;
++
++	struct ff_report *ff_packet;
++	struct work_struct output_worker;
++	bool output_worker_initialized;
++	/* Prevent multiple queued event due to the enforced delay in worker */
++	bool update_qam_btn;
++	/* Set if the QAM and AC buttons emit Xbox and Xbox+A */
++	bool qam_btns_steam_mode;
++	bool update_ff;
++};
++
++struct ally_rgb_dev {
++	struct hid_device *hdev;
++	struct led_classdev_mc led_rgb_dev;
++	struct work_struct work;
++	bool output_worker_initialized;
++	spinlock_t lock;
++
++	bool removed;
++	bool update_rgb;
++	uint8_t red[4];
++	uint8_t green[4];
++	uint8_t blue[4];
++};
++
++struct ally_rgb_data {
++	uint8_t brightness;
++	uint8_t red[4];
++	uint8_t green[4];
++	uint8_t blue[4];
++	bool initialized;
++};
++
++static struct ally_drvdata {
++	struct hid_device *hdev;
++	struct ally_x_device *ally_x;
++	struct ally_gamepad_cfg *gamepad_cfg;
++	struct ally_rgb_dev *led_rgb_dev;
++	struct ally_rgb_data led_rgb_data;
++	uint mcu_version;
++} drvdata;
++
++static void reverse_bytes_in_pairs(u8 *buf, size_t size) {
++	uint16_t *word_ptr;
++	size_t i;
++
++	for (i = 0; i < size; i += 2) {
++		if (i + 1 < size) {
++			word_ptr = (uint16_t *)&buf[i];
++			*word_ptr = cpu_to_be16(*word_ptr);
++		}
++	}
++}
++
++/**
++ * asus_dev_set_report - send set report request to device.
++ *
++ * @hdev: hid device
++ * @buf: in/out data to transfer
++ * @len: length of buf
++ *
++ * Return: count of data transferred, negative if error
++ *
++ * Same behavior as hid_hw_raw_request. Note that the input buffer is duplicated.
++ */
++static int asus_dev_set_report(struct hid_device *hdev, const u8 *buf, size_t len)
 +{
 +	unsigned char *dmabuf;
 +	int ret;
@@ -2632,167 +656,81 @@ index 000000000000..1e8f98b69332
 +		return -ENOMEM;
 +
 +	ret = hid_hw_raw_request(hdev, buf[0], dmabuf, len, HID_FEATURE_REPORT,
-+					HID_REQ_SET_REPORT);
++				 HID_REQ_SET_REPORT);
 +	kfree(dmabuf);
 +
 +	return ret;
 +}
 +
-+static inline int asus_dev_get_report(struct hid_device *hdev, u8 *out, size_t len)
++/**
++ * asus_dev_get_report - send get report request to device.
++ *
++ * @hdev: hid device
++ * @out: buffer to write output data in to
++ * @len: length the output buffer provided
++ *
++ * Return: count of data transferred, negative if error
++ *
++ * Same behavior as hid_hw_raw_request.
++ */
++static int asus_dev_get_report(struct hid_device *hdev, u8 *out, size_t len)
 +{
-+	return hid_hw_raw_request(hdev, HID_ALLY_GET_REPORT_ID, out, len,
++	return hid_hw_raw_request(hdev, FEATURE_REPORT_ID, out, len,
 +		HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
 +}
 +
-+/**
-+ * ally_gamepad_send_packet - Send a raw packet to the gamepad device.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @buf: Buffer containing the packet data
-+ * @len: Length of data to send
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_packet(struct ally_handheld *ally,
-+			     struct hid_device *hdev, const u8 *buf, size_t len)
++static u8 get_endpoint_address(struct hid_device *hdev)
 +{
-+	int ret;
++	struct usb_interface *intf;
++	struct usb_host_endpoint *ep;
 +
-+	mutex_lock(&ally->intf_mutex);
-+	ret = asus_dev_set_report(hdev, buf, len);
-+	mutex_unlock(&ally->intf_mutex);
++	intf = to_usb_interface(hdev->dev.parent);
 +
-+	return ret;
-+}
-+
-+/**
-+ * ally_gamepad_send_receive_packet - Send packet and receive response.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @buf: Buffer containing the packet data to send and receive response in
-+ * @len: Length of buffer
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_receive_packet(struct ally_handheld *ally,
-+				     struct hid_device *hdev, u8 *buf,
-+				     size_t len)
-+{
-+	int ret;
-+
-+	mutex_lock(&ally->intf_mutex);
-+	ret = asus_dev_set_report(hdev, buf, len);
-+	if (ret >= 0) {
-+		memset(buf, 0, len);
-+		ret = asus_dev_get_report(hdev, buf, len);
++	if (intf) {
++		ep = intf->cur_altsetting->endpoint;
++		if (ep) {
++			return ep->desc.bEndpointAddress;
++		}
 +	}
-+	mutex_unlock(&ally->intf_mutex);
 +
-+	return ret;
++	return -ENODEV;
 +}
 +
-+/**
-+ * ally_gamepad_send_one_byte_packet - Send a one-byte payload packet.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @command: Command code
-+ * @param: Parameter byte
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_one_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command, u8 param)
-+{
-+	u8 *packet;
-+	int ret;
++/**************************************************************************************************/
++/* ROG Ally gamepad configuration                                                                 */
++/**************************************************************************************************/
 +
-+	packet = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
-+	if (!packet)
-+		return -ENOMEM;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = command;
-+	packet[3] = 0x01; /* Length */
-+	packet[4] = param;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	kfree(packet);
-+	return ret;
-+}
-+
-+/**
-+ * ally_gamepad_send_two_byte_packet - Send a two-byte payload packet.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @command: Command code
-+ * @param1: First parameter byte
-+ * @param2: Second parameter byte
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_two_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command,
-+				      u8 param1, u8 param2)
-+{
-+	u8 *packet;
-+	int ret;
-+
-+	packet = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
-+	if (!packet)
-+		return -ENOMEM;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = command;
-+	packet[3] = 0x02; /* Length */
-+	packet[4] = param1;
-+	packet[5] = param2;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	kfree(packet);
-+	return ret;
-+}
-+
-+/*
-+ * This should be called before any remapping attempts, and on driver init/resume.
-+ */
-+int ally_gamepad_check_ready(struct hid_device *hdev)
++/* This should be called before any attempts to set device functions */
++static int ally_gamepad_check_ready(struct hid_device *hdev)
 +{
 +	int ret, count;
 +	u8 *hidbuf;
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
 +
-+	hidbuf = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
 +	if (!hidbuf)
 +		return -ENOMEM;
 +
 +	ret = 0;
 +	for (count = 0; count < READY_MAX_TRIES; count++) {
-+		hidbuf[0] = HID_ALLY_SET_REPORT_ID;
-+		hidbuf[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+		hidbuf[2] = CMD_CHECK_READY;
++		hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++		hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++		hidbuf[2] = xpad_cmd_check_ready;
 +		hidbuf[3] = 01;
++		ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0)
++			hid_dbg(hdev, "ROG Ally check failed set report: %d\n", ret);
 +
-+		ret = ally_gamepad_send_receive_packet(ally, hdev, hidbuf,
-+						       HID_ALLY_REPORT_SIZE);
-+		if (ret < 0) {
-+			hid_err(hdev, "ROG Ally check failed: %d\n", ret);
-+			continue;
-+		}
++		hidbuf[0] = hidbuf[1] = hidbuf[2] = hidbuf[3] = 0;
++		ret = asus_dev_get_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0)
++			hid_dbg(hdev, "ROG Ally check failed get report: %d\n", ret);
 +
-+		ret = hidbuf[2] == CMD_CHECK_READY;
++		ret = hidbuf[2] == xpad_cmd_check_ready;
 +		if (ret)
 +			break;
-+		usleep_range(1000, 2000);
++		usleep_range(
++			1000,
++			2000); /* don't spam the entire loop in less than USB response time */
 +	}
 +
 +	if (count == READY_MAX_TRIES)
@@ -2802,492 +740,899 @@ index 000000000000..1e8f98b69332
 +	return ret;
 +}
 +
-+u8 get_endpoint_address(struct hid_device *hdev)
++/* VIBRATION INTENSITY ****************************************************************************/
++static ssize_t gamepad_vibration_intensity_index_show(struct device *dev,
++						      struct device_attribute *attr, char *buf)
 +{
-+	struct usb_host_endpoint *ep;
-+	struct usb_interface *intf;
-+
-+	intf = to_usb_interface(hdev->dev.parent);
-+	if (!intf || !intf->cur_altsetting)
-+		return -ENODEV;
-+
-+	ep = intf->cur_altsetting->endpoint;
-+	if (!ep)
-+		return -ENODEV;
-+
-+	return ep->desc.bEndpointAddress;
++	return sysfs_emit(buf, "left right\n");
 +}
 +
-+/**************************************************************************************************/
-+/* ROG Ally driver init                                                                           */
-+/**************************************************************************************************/
++ALLY_DEVICE_ATTR_RO(gamepad_vibration_intensity_index, vibration_intensity_index);
 +
-+static int cad_sequence_state = 0;
-+static unsigned long cad_last_event_time = 0;
-+
-+/* Ally left buton emits a sequence of events: ctrl+alt+del. Capture this and emit only a single code */
-+static bool handle_ctrl_alt_del(struct hid_device *hdev, u8 *data, int size)
++static ssize_t _gamepad_apply_intensity(struct hid_device *hdev,
++					struct ally_gamepad_cfg *ally_cfg)
 +{
-+	if (size < 16 || data[0] != 0x01)
-+		return false;
-+
-+	if (cad_sequence_state > 0 && time_after(jiffies, cad_last_event_time + msecs_to_jiffies(100)))
-+		cad_sequence_state = 0;
-+
-+	cad_last_event_time = jiffies;
-+
-+	switch (cad_sequence_state) {
-+	case 0:
-+		if (data[1] == 0x01 && data[2] == 0x00 && data[3] == 0x00) {
-+			cad_sequence_state = 1;
-+			data[1] = 0x00;
-+			return true;
-+		}
-+		break;
-+	case 1:
-+		if (data[1] == 0x05 && data[2] == 0x00 && data[3] == 0x00) {
-+			cad_sequence_state = 2;
-+			data[1] = 0x00;
-+			return true;
-+		}
-+		break;
-+	case 2:
-+		if (data[1] == 0x05 && data[2] == 0x00 && data[3] == 0x4c) {
-+			cad_sequence_state = 3;
-+			data[1] = 0x00;
-+			data[3] = 0x6F; // F20;
-+			return true;
-+		}
-+		break;
-+	case 3:
-+		if (data[1] == 0x04 && data[2] == 0x00 && data[3] == 0x4c) {
-+			cad_sequence_state = 4;
-+			data[1] = 0x00;
-+			data[1] = data[3] = 0x00;
-+			return true;
-+		}
-+		break;
-+	case 4:
-+		if (data[1] == 0x00 && data[2] == 0x00 && data[3] == 0x4c) {
-+			cad_sequence_state = 5;
-+			data[3] = 0x00;
-+			return true;
-+		}
-+		break;
-+	}
-+	cad_sequence_state = 0;
-+	return false;
-+}
-+
-+static bool handle_ally_event(struct hid_device *hdev, u8 *data, int size)
-+{
-+	struct input_dev *keyboard_input;
-+	int keycode = 0;
-+
-+	if (data[0] == 0x5A) {
-+		switch (data[1]) {
-+		case 0x38:
-+			keycode = KEY_F19;
-+			break;
-+		case 0xA6:
-+			keycode = KEY_F16;
-+			break;
-+		case 0xA7:
-+			keycode = KEY_F17;
-+			break;
-+		case 0xA8:
-+			keycode = KEY_F18;
-+			break;
-+		default:
-+			return false;
-+		}
-+
-+		keyboard_input = ally_drvdata.keyboard_input;
-+		if (keyboard_input) {
-+			input_report_key(keyboard_input, keycode, 1);
-+			input_sync(keyboard_input);
-+			input_report_key(keyboard_input, keycode, 0);
-+			input_sync(keyboard_input);
-+			return true;
-+		}
-+
-+		memset(data, 0, size);
-+	}
-+	return false;
-+}
-+
-+static int ally_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data,
-+					int size)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x;
-+	int ep;
-+
-+	if (!ally)
-+		return -ENODEV;
-+
-+	ep = get_endpoint_address(hdev);
-+	if (ep != HID_ALLY_INTF_CFG_IN && ep != HID_ALLY_X_INTF_IN && ep != HID_ALLY_KEYBOARD_INTF_IN)
-+		return 0;
-+
-+	ally_x = ally->ally_x_input;
-+	if (ally_x) {
-+		if ((hdev->bus == BUS_USB && report->id == HID_ALLY_X_INPUT_REPORT &&
-+		   size == HID_ALLY_X_INPUT_REPORT_SIZE) ||
-+		   (data[0] == 0x5A)) {
-+			if (ally_x_raw_event(ally_x, report, data, size))
-+				return 0;
-+		}
-+	}
-+
-+	switch (ep) {
-+	case HID_ALLY_INTF_CFG_IN:
-+		if (handle_ally_event(hdev, data, size))
-+			return 0;
-+		break;
-+	case HID_ALLY_KEYBOARD_INTF_IN:
-+		if (handle_ctrl_alt_del(hdev, data, size))
-+			return 0;
-+		break;
-+	}
-+
-+	return 0;
-+}
-+
-+static int ally_hid_init(struct hid_device *hdev)
-+{
++	u8 *hidbuf;
 +	int ret;
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, EC_INIT_STRING, sizeof(EC_INIT_STRING));
-+	if (ret < 0) {
-+		hid_err(hdev, "Ally failed to send init command: %d\n", ret);
-+		goto cleanup;
-+	}
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
 +
-+	/* All gamepad configuration commands must go after the ally_gamepad_check_ready() */
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_vibe_intensity;
++	hidbuf[3] = xpad_cmd_len_vibe_intensity;
++	hidbuf[4] = ally_cfg->vibration_intensity[0];
++	hidbuf[5] = ally_cfg->vibration_intensity[1];
++
 +	ret = ally_gamepad_check_ready(hdev);
 +	if (ret < 0)
-+		goto cleanup;
++		goto report_fail;
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, FORCE_FEEDBACK_OFF, sizeof(FORCE_FEEDBACK_OFF));
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
 +	if (ret < 0)
-+		hid_err(hdev, "Ally failed to init force-feedback off: %d\n", ret);
++		goto report_fail;
 +
-+cleanup:
++report_fail:
++	kfree(hidbuf);
 +	return ret;
 +}
 +
-+static int ally_input_configured(struct hid_device *hdev, struct hid_input *hi)
++static ssize_t gamepad_vibration_intensity_show(struct device *dev,
++						struct device_attribute *attr, char *buf)
 +{
-+	int ep = get_endpoint_address(hdev);
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
 +
-+	hid_info(hdev, "Input configured: endpoint 0x%02x, name: %s\n", ep, hi->input->name);
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
 +
-+	if (ep == HID_ALLY_KEYBOARD_INTF_IN)
-+		hi->input->name = ally_keyboard_name;
-+
-+	if (ep == HID_ALLY_MOUSE_INTF_IN)
-+		hi->input->name = ally_mouse_name;
-+
-+	return 0;
++	return sysfs_emit(
++		buf, "%d %d\n",
++		ally_cfg->vibration_intensity[0],
++		ally_cfg->vibration_intensity[1]);
 +}
 +
-+static int ally_hid_probe(struct hid_device *hdev, const struct hid_device_id *_id)
++static ssize_t gamepad_vibration_intensity_store(struct device *dev,
++						 struct device_attribute *attr, const char *buf,
++						 size_t count)
 +{
-+	int ret, ep;
-+
-+	ep = get_endpoint_address(hdev);
-+	if (ep < 0)
-+		return ep;
-+
-+	/*** CRITICAL START ***/
-+	mutex_lock(&ally_data_mutex);
-+	if (ep == HID_ALLY_INTF_CFG_IN)
-+		ally_drvdata.cfg_hdev = hdev;
-+	if (ep == HID_ALLY_KEYBOARD_INTF_IN)
-+		ally_drvdata.keyboard_hdev = hdev;
-+	mutex_unlock(&ally_data_mutex);
-+	/*** CRITICAL END ***/
-+
-+	hid_set_drvdata(hdev, &ally_drvdata);
-+
-+	ret = hid_parse(hdev);
-+	if (ret) {
-+		hid_err(hdev, "Parse failed\n");
-+		return ret;
-+	}
-+
-+	if (ep == HID_ALLY_INTF_CFG_IN || ep == HID_ALLY_X_INTF_IN) {
-+		ret = hid_hw_start(hdev, HID_CONNECT_HIDRAW);
-+	} else if (ep == HID_ALLY_KEYBOARD_INTF_IN) {
-+		ret = hid_hw_start(hdev, HID_CONNECT_HIDINPUT | HID_CONNECT_HIDRAW);
-+		if (!list_empty(&hdev->inputs)) {
-+			struct hid_input *hidinput = list_first_entry(&hdev->inputs, struct hid_input, list);
-+			ally_drvdata.keyboard_input = hidinput->input;
-+		}
-+		hid_info(hdev, "Connected keyboard interface with input events\n");
-+	} else {
-+		ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
-+		hid_info(hdev, "Passing through HID events for endpoint: 0x%02x\n", ep);
-+		return 0;
-+	}
-+
-+	ret = hid_hw_open(hdev);
-+	if (ret) {
-+		hid_err(hdev, "Failed to open HID device\n");
-+		goto err_stop;
-+	}
-+
-+	/* Initialize MCU even before alloc */
-+	ret = ally_hid_init(hdev);
-+	if (ret < 0)
-+		goto err_close;
-+
-+	if (ep == HID_ALLY_INTF_CFG_IN) {
-+		ret = ally_config_create(hdev, &ally_drvdata);
-+		if (ret < 0)
-+			hid_err(hdev, "Failed to create Ally configuration interface.\n");
-+		else
-+			hid_info(hdev, "Created Ally configuration interface.\n");
-+
-+		ret = ally_rgb_create(hdev, &ally_drvdata);
-+		if (ret < 0)
-+			hid_err(hdev, "Failed to create Ally gamepad LEDs.\n");
-+		else
-+			hid_info(hdev, "Created Ally RGB LED controls.\n");
-+	}
-+
-+	if (ep == HID_ALLY_X_INTF_IN) {
-+		ret = ally_x_create(hdev, &ally_drvdata);
-+		if (ret < 0) {
-+			hid_err(hdev, "Failed to create Ally X gamepad device.\n");
-+			ally_drvdata.ally_x_input = NULL;
-+			goto err_close;
-+		} else {
-+			hid_info(hdev, "Created Ally X gamepad device.\n");
-+		}
-+		// Not required since we send this inputs ep through the gamepad input dev
-+		// if (drvdata.gamepad_cfg && drvdata.gamepad_cfg->input) {
-+		// 	input_unregister_device(drvdata.gamepad_cfg->input);
-+		// 	hid_info(hdev, "Ally X removed unrequired input dev.\n");
-+		// }
-+	}
-+
-+	return 0;
-+
-+err_close:
-+	hid_hw_close(hdev);
-+err_stop:
-+	hid_hw_stop(hdev);
-+	return ret;
-+}
-+
-+static void ally_hid_remove(struct hid_device *hdev)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	if (!ally)
-+		goto out;
-+
-+	if (ally->led_rgb_dev)
-+		ally_rgb_remove(hdev, ally);
-+
-+	if (ally->config)
-+		ally_config_remove(hdev, ally);
-+
-+	if (ally->ally_x_input)
-+		ally_x_remove(hdev, ally);
-+
-+out:
-+	hid_hw_close(hdev);
-+	hid_hw_stop(hdev);
-+}
-+
-+static int ally_hid_reset_resume(struct hid_device *hdev)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
++	struct hid_device *hdev = to_hid_device(dev);
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	u32 left, right;
 +	int ret;
 +
-+	if (!ally)
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	if (sscanf(buf, "%d %d", &left, &right) != 2)
 +		return -EINVAL;
 +
-+	int ep = get_endpoint_address(hdev);
-+	if (ep != HID_ALLY_INTF_CFG_IN)
-+		return 0;
++	if (left > 64 || right > 64)
++		return -EINVAL;
 +
-+	ret = ally_hid_init(hdev);
++	ally_cfg->vibration_intensity[0] = left;
++	ally_cfg->vibration_intensity[1] = right;
++
++	ret = _gamepad_apply_intensity(hdev, ally_cfg);
 +	if (ret < 0)
 +		return ret;
 +
-+	ally_rgb_resume(ally);
-+
-+	return 0;
++	return count;
 +}
 +
-+static int ally_pm_thaw(struct device *dev)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
++ALLY_DEVICE_ATTR_RW(gamepad_vibration_intensity, vibration_intensity);
 +
-+	if (!hdev)
++/* ANALOGUE DEADZONES *****************************************************************************/
++static ssize_t _gamepad_apply_deadzones(struct hid_device *hdev,
++				       struct ally_gamepad_cfg *ally_cfg)
++{
++	u8 *hidbuf;
++	int ret;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		return ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_js_dz;
++	hidbuf[3] = xpad_cmd_len_deadzone;
++	hidbuf[4] = ally_cfg->ls_dz.inner;
++	hidbuf[5] = ally_cfg->ls_dz.outer;
++	hidbuf[6] = ally_cfg->rs_dz.inner;
++	hidbuf[7] = ally_cfg->rs_dz.outer;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto end;
++
++	hidbuf[2] = xpad_cmd_set_tr_dz;
++	hidbuf[4] = ally_cfg->lt_dz.inner;
++	hidbuf[5] = ally_cfg->lt_dz.outer;
++	hidbuf[6] = ally_cfg->rt_dz.inner;
++	hidbuf[7] = ally_cfg->rt_dz.outer;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto end;
++
++end:
++	kfree(hidbuf);
++	return ret;
++}
++
++static void _gamepad_set_deadzones_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	ally_cfg->ls_dz.inner = 0x00;
++	ally_cfg->ls_dz.outer = 0x64;
++	ally_cfg->rs_dz.inner = 0x00;
++	ally_cfg->rs_dz.outer = 0x64;
++	ally_cfg->lt_dz.inner = 0x00;
++	ally_cfg->lt_dz.outer = 0x64;
++	ally_cfg->rt_dz.inner = 0x00;
++	ally_cfg->rt_dz.outer = 0x64;
++}
++
++static ssize_t axis_xyz_deadzone_index_show(struct device *dev, struct device_attribute *attr,
++					    char *buf)
++{
++	return sysfs_emit(buf, "inner outer\n");
++}
++
++ALLY_DEVICE_ATTR_RO(axis_xyz_deadzone_index, deadzone_index);
++
++ALLY_DEADZONES(axis_xy_left, ls_dz);
++ALLY_DEADZONES(axis_xy_right, rs_dz);
++ALLY_DEADZONES(axis_z_left, lt_dz);
++ALLY_DEADZONES(axis_z_right, rt_dz);
++
++/* ANTI-DEADZONES *********************************************************************************/
++static ssize_t _gamepad_apply_js_ADZ(struct hid_device *hdev,
++					     struct ally_gamepad_cfg *ally_cfg)
++{
++	u8 *hidbuf;
++	int ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_adz;
++	hidbuf[3] = xpad_cmd_len_adz;
++	hidbuf[4] = ally_cfg->ls_adz;
++	hidbuf[5] = ally_cfg->rs_adz;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto report_fail;
++
++report_fail:
++	kfree(hidbuf);
++	return ret;
++}
++
++static void _gamepad_set_anti_deadzones_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	ally_cfg->ls_adz = 0x00;
++	ally_cfg->rs_adz = 0x00;
++}
++
++static ssize_t _gamepad_js_ADZ_store(struct device *dev, const char *buf, u8 *adz)
++{
++	int ret, val;
++
++	ret = kstrtoint(buf, 0, &val);
++	if (ret)
++		return ret;
++
++	if (val < 0 || val > 32)
 +		return -EINVAL;
 +
-+	return ally_hid_reset_resume(hdev);
++	*adz = val;
++
++	return ret;
 +}
 +
-+static int ally_pm_prepare(struct device *dev)
++static ssize_t axis_xy_left_anti_deadzone_show(struct device *dev,
++						struct device_attribute *attr,
++						char *buf)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	return sysfs_emit(buf, "%d\n", ally_cfg->ls_adz);
++}
++
++static ssize_t axis_xy_left_anti_deadzone_store(struct device *dev,
++						struct device_attribute *attr,
++						const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int ret;
++
++	ret = _gamepad_js_ADZ_store(dev, buf, &ally_cfg->ls_adz);
++	if (ret)
++		return ret;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_RW(axis_xy_left_anti_deadzone, anti_deadzone);
++
++static ssize_t axis_xy_right_anti_deadzone_show(struct device *dev,
++						struct device_attribute *attr,
++						char *buf)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	return sysfs_emit(buf, "%d\n", ally_cfg->rs_adz);
++}
++
++static ssize_t axis_xy_right_anti_deadzone_store(struct device *dev,
++						struct device_attribute *attr,
++						const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int ret;
++
++	ret = _gamepad_js_ADZ_store(dev, buf, &ally_cfg->rs_adz);
++	if (ret)
++		return ret;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_RW(axis_xy_right_anti_deadzone, anti_deadzone);
++
++/* JS RESPONSE CURVES *****************************************************************************/
++static void _gamepad_set_js_response_curves_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	struct response_curve *js1_rc = &ally_cfg->ls_rc;
++	struct response_curve *js2_rc = &ally_cfg->rs_rc;
++	js1_rc->move_pct_1 = js2_rc->move_pct_1 = 0x16; // 25%
++	js1_rc->move_pct_2 = js2_rc->move_pct_2 = 0x32; // 50%
++	js1_rc->move_pct_3 = js2_rc->move_pct_3 = 0x48; // 75%
++	js1_rc->move_pct_4 = js2_rc->move_pct_4 = 0x64; // 100%
++	js1_rc->response_pct_1 = js2_rc->response_pct_1 = 0x16;
++	js1_rc->response_pct_2 = js2_rc->response_pct_2 = 0x32;
++	js1_rc->response_pct_3 = js2_rc->response_pct_3 = 0x48;
++	js1_rc->response_pct_4 = js2_rc->response_pct_4 = 0x64;
++}
++
++static ssize_t _gamepad_apply_response_curves(struct hid_device *hdev,
++					      struct ally_gamepad_cfg *ally_cfg)
++{
++	u8 *hidbuf;
++	int ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	memcpy(&hidbuf[2], &ally_cfg->ls_rc, sizeof(ally_cfg->ls_rc));
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	hidbuf[4] = 0x02;
++	memcpy(&hidbuf[5], &ally_cfg->rs_rc, sizeof(ally_cfg->rs_rc));
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto report_fail;
++
++report_fail:
++	kfree(hidbuf);
++	return ret;
++}
++
++ALLY_JS_RC_POINT(axis_xy_left, move, 1);
++ALLY_JS_RC_POINT(axis_xy_left, move, 2);
++ALLY_JS_RC_POINT(axis_xy_left, move, 3);
++ALLY_JS_RC_POINT(axis_xy_left, move, 4);
++ALLY_JS_RC_POINT(axis_xy_left, response, 1);
++ALLY_JS_RC_POINT(axis_xy_left, response, 2);
++ALLY_JS_RC_POINT(axis_xy_left, response, 3);
++ALLY_JS_RC_POINT(axis_xy_left, response, 4);
++
++ALLY_JS_RC_POINT(axis_xy_right, move, 1);
++ALLY_JS_RC_POINT(axis_xy_right, move, 2);
++ALLY_JS_RC_POINT(axis_xy_right, move, 3);
++ALLY_JS_RC_POINT(axis_xy_right, move, 4);
++ALLY_JS_RC_POINT(axis_xy_right, response, 1);
++ALLY_JS_RC_POINT(axis_xy_right, response, 2);
++ALLY_JS_RC_POINT(axis_xy_right, response, 3);
++ALLY_JS_RC_POINT(axis_xy_right, response, 4);
++
++/* CALIBRATIONS ***********************************************************************************/
++static int gamepad_get_calibration(struct hid_device *hdev)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	u8 *hidbuf;
++	int ret, i;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	for (i = 0; i < 2; i++) {
++		hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++		hidbuf[1] = 0xD0;
++		hidbuf[2] = 0x03;
++		hidbuf[3] = i + 1; // 0x01 JS, 0x02 TR
++		hidbuf[4] = 0x20;
++
++		ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0) {
++			hid_warn(hdev, "ROG Ally check failed set report: %d\n", ret);
++			goto cleanup;
++		}
++
++		memset(hidbuf, 0, FEATURE_ROG_ALLY_REPORT_SIZE);
++		ret = asus_dev_get_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0 || hidbuf[5] != 1) {
++			hid_warn(hdev, "ROG Ally check failed get report: %d\n", ret);
++			goto cleanup;
++		}
++
++		if (i == 0) {
++			/* Joystick calibration */
++			reverse_bytes_in_pairs(&hidbuf[6], sizeof(struct js_axis_calibrations));
++			ally_cfg->js_cal = *(struct js_axis_calibrations *)&hidbuf[6];
++			print_hex_dump(KERN_INFO, "HID Buffer JS: ", DUMP_PREFIX_OFFSET, 16, 1, hidbuf, 32, true);
++			struct js_axis_calibrations *cal = &drvdata.gamepad_cfg->js_cal;
++			pr_err("LS_CAL: X: %d, Min: %d, Max: %d", cal->left_x_stable, cal->left_x_min, cal->left_x_max);
++			pr_err("LS_CAL: Y: %d, Min: %d, Max: %d", cal->left_y_stable, cal->left_y_min, cal->left_y_max);
++			pr_err("RS_CAL: X: %d, Min: %d, Max: %d", cal->right_x_stable, cal->right_x_min, cal->right_x_max);
++			pr_err("RS_CAL: Y: %d, Min: %d, Max: %d", cal->right_y_stable, cal->right_y_min, cal->right_y_max);
++		} else {
++			/* Trigger calibration */
++			reverse_bytes_in_pairs(&hidbuf[6], sizeof(struct tr_axis_calibrations));
++			ally_cfg->tr_cal = *(struct tr_axis_calibrations *)&hidbuf[6];
++			print_hex_dump(KERN_INFO, "HID Buffer TR: ", DUMP_PREFIX_OFFSET, 16, 1, hidbuf, 32, true);
++		}
++	}
++
++cleanup:
++	kfree(hidbuf);
++	return ret;
++}
++
++static struct attribute *axis_xy_left_attrs[] = {
++	&dev_attr_axis_xy_left_anti_deadzone.attr,
++	&dev_attr_axis_xy_left_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	&dev_attr_axis_xy_left_move_1.attr,
++	&dev_attr_axis_xy_left_move_2.attr,
++	&dev_attr_axis_xy_left_move_3.attr,
++	&dev_attr_axis_xy_left_move_4.attr,
++	&dev_attr_axis_xy_left_response_1.attr,
++	&dev_attr_axis_xy_left_response_2.attr,
++	&dev_attr_axis_xy_left_response_3.attr,
++	&dev_attr_axis_xy_left_response_4.attr,
++	NULL
++};
++static const struct attribute_group axis_xy_left_attr_group = {
++	.name = "axis_xy_left",
++	.attrs = axis_xy_left_attrs,
++};
++
++static struct attribute *axis_xy_right_attrs[] = {
++	&dev_attr_axis_xy_right_anti_deadzone.attr,
++	&dev_attr_axis_xy_right_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	&dev_attr_axis_xy_right_move_1.attr,
++	&dev_attr_axis_xy_right_move_2.attr,
++	&dev_attr_axis_xy_right_move_3.attr,
++	&dev_attr_axis_xy_right_move_4.attr,
++	&dev_attr_axis_xy_right_response_1.attr,
++	&dev_attr_axis_xy_right_response_2.attr,
++	&dev_attr_axis_xy_right_response_3.attr,
++	&dev_attr_axis_xy_right_response_4.attr,
++	NULL
++};
++static const struct attribute_group axis_xy_right_attr_group = {
++	.name = "axis_xy_right",
++	.attrs = axis_xy_right_attrs,
++};
++
++static struct attribute *axis_z_left_attrs[] = {
++	&dev_attr_axis_z_left_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	NULL,
++};
++static const struct attribute_group axis_z_left_attr_group = {
++	.name = "axis_z_left",
++	.attrs = axis_z_left_attrs,
++};
++
++static struct attribute *axis_z_right_attrs[] = {
++	&dev_attr_axis_z_right_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	NULL,
++};
++static const struct attribute_group axis_z_right_attr_group = {
++	.name = "axis_z_right",
++	.attrs = axis_z_right_attrs,
++};
++
++/* A HID packet conatins mappings for two buttons: btn1, btn1_macro, btn2, btn2_macro */
++static void _btn_pair_to_hid_pkt(struct ally_gamepad_cfg *ally_cfg,
++				enum btn_pair_index pair,
++				struct btn_data *btn1, struct btn_data *btn2,
++				u8 *out, int out_len)
++{
++	int start = 5;
++
++	out[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	out[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	out[2] = xpad_cmd_set_mapping;
++	out[3] = pair;
++	out[4] = xpad_cmd_len_mapping;
++
++	btn_code_to_byte_array(btn1->button, &out[start]);
++	start += BTN_DATA_LEN;
++	btn_code_to_byte_array(btn1->macro, &out[start]);
++	start += BTN_DATA_LEN;
++	btn_code_to_byte_array(btn2->button, &out[start]);
++	start += BTN_DATA_LEN;
++	btn_code_to_byte_array(btn2->macro, &out[start]);
++	//print_hex_dump(KERN_DEBUG, "byte_array: ", DUMP_PREFIX_OFFSET, 64, 1, out, 64, false);
++}
++
++/* Apply the mapping pair to the device */
++static int _gamepad_apply_btn_pair(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg,
++				 enum btn_pair_index btn_pair)
++{
++	u8 mode = ally_cfg->mode - 1;
++	struct btn_data *btn1, *btn2;
++	u8 *hidbuf;
++	int ret;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		return ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	switch (btn_pair) {
++	case btn_pair_dpad_u_d:
++		btn1 = &ally_cfg->key_mapping[mode].dpad_up;
++		btn2 = &ally_cfg->key_mapping[mode].dpad_down;
++		break;
++	case btn_pair_dpad_l_r:
++		btn1 = &ally_cfg->key_mapping[mode].dpad_left;
++		btn2 = &ally_cfg->key_mapping[mode].dpad_right;
++		break;
++	case btn_pair_ls_rs:
++		btn1 = &ally_cfg->key_mapping[mode].btn_ls;
++		btn2 = &ally_cfg->key_mapping[mode].btn_rs;
++		break;
++	case btn_pair_lb_rb:
++		btn1 = &ally_cfg->key_mapping[mode].btn_lb;
++		btn2 = &ally_cfg->key_mapping[mode].btn_rb;
++		break;
++	case btn_pair_lt_rt:
++		btn1 = &ally_cfg->key_mapping[mode].btn_lt;
++		btn2 = &ally_cfg->key_mapping[mode].btn_rt;
++		break;
++	case btn_pair_a_b:
++		btn1 = &ally_cfg->key_mapping[mode].btn_a;
++		btn2 = &ally_cfg->key_mapping[mode].btn_b;
++		break;
++	case btn_pair_x_y:
++		btn1 = &ally_cfg->key_mapping[mode].btn_x;
++		btn2 = &ally_cfg->key_mapping[mode].btn_y;
++		break;
++	case btn_pair_view_menu:
++		btn1 = &ally_cfg->key_mapping[mode].btn_view;
++		btn2 = &ally_cfg->key_mapping[mode].btn_menu;
++		break;
++	case btn_pair_m1_m2:
++		btn1 = &ally_cfg->key_mapping[mode].btn_m1;
++		btn2 = &ally_cfg->key_mapping[mode].btn_m2;
++		break;
++	default:
++		break;
++	}
++
++	_btn_pair_to_hid_pkt(ally_cfg, btn_pair, btn1, btn2, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++
++	kfree(hidbuf);
++
++	return ret;
++}
++
++static int _gamepad_apply_turbo(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg)
++{
++	struct btn_mapping *map = &ally_cfg->key_mapping[ally_cfg->mode - 1];
++	u8 *hidbuf;
++	int ret;
++
++	/* set turbo */
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_turbo;
++	hidbuf[3] = xpad_cmd_len_turbo;
++
++	hidbuf[4] = map->dpad_up.turbo;
++	hidbuf[6] = map->dpad_down.turbo;
++	hidbuf[8] = map->dpad_left.turbo;
++	hidbuf[10] = map->dpad_right.turbo;
++
++	hidbuf[12] = map->btn_ls.turbo;
++	hidbuf[14] = map->btn_rs.turbo;
++	hidbuf[16] = map->btn_lb.turbo;
++	hidbuf[18] = map->btn_rb.turbo;
++
++	hidbuf[20] = map->btn_a.turbo;
++	hidbuf[22] = map->btn_b.turbo;
++	hidbuf[24] = map->btn_x.turbo;
++	hidbuf[26] = map->btn_y.turbo;
++
++	hidbuf[28] = map->btn_lt.turbo;
++	hidbuf[30] = map->btn_rt.turbo;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++
++	kfree(hidbuf);
++
++	return ret;
++}
++
++static ssize_t _gamepad_apply_all(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg)
++{
++	int ret;
++
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_dpad_u_d);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_dpad_l_r);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_ls_rs);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_lb_rb);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_a_b);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_x_y);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_view_menu);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_m1_m2);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_lt_rt);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_turbo(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_deadzones(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_js_ADZ(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++	ret =_gamepad_apply_response_curves(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++
++	return 0;
++}
++
++static ssize_t gamepad_apply_all_store(struct device *dev, struct device_attribute *attr,
++				       const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	struct hid_device *hdev = to_hid_device(dev);
++	int ret;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	ret = _gamepad_apply_all(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_WO(gamepad_apply_all, apply_all);
++
++/* button map attributes, regular and macro*/
++ALLY_BTN_MAPPING(m1, btn_m1);
++ALLY_BTN_MAPPING(m2, btn_m2);
++ALLY_BTN_MAPPING(view, btn_view);
++ALLY_BTN_MAPPING(menu, btn_menu);
++ALLY_TURBO_BTN_MAPPING(a, btn_a);
++ALLY_TURBO_BTN_MAPPING(b, btn_b);
++ALLY_TURBO_BTN_MAPPING(x, btn_x);
++ALLY_TURBO_BTN_MAPPING(y, btn_y);
++ALLY_TURBO_BTN_MAPPING(lb, btn_lb);
++ALLY_TURBO_BTN_MAPPING(rb, btn_rb);
++ALLY_TURBO_BTN_MAPPING(ls, btn_ls);
++ALLY_TURBO_BTN_MAPPING(rs, btn_rs);
++ALLY_TURBO_BTN_MAPPING(lt, btn_lt);
++ALLY_TURBO_BTN_MAPPING(rt, btn_rt);
++ALLY_TURBO_BTN_MAPPING(dpad_u, dpad_up);
++ALLY_TURBO_BTN_MAPPING(dpad_d, dpad_down);
++ALLY_TURBO_BTN_MAPPING(dpad_l, dpad_left);
++ALLY_TURBO_BTN_MAPPING(dpad_r, dpad_right);
++
++static void _gamepad_set_xpad_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	struct btn_mapping *map = &ally_cfg->key_mapping[ally_cfg->mode - 1];
++	map->btn_m1.button = BTN_KB_M1;
++	map->btn_m2.button = BTN_KB_M2;
++	map->btn_a.button = BTN_PAD_A;
++	map->btn_b.button = BTN_PAD_B;
++	map->btn_x.button = BTN_PAD_X;
++	map->btn_y.button = BTN_PAD_Y;
++	map->btn_lb.button = BTN_PAD_LB;
++	map->btn_rb.button = BTN_PAD_RB;
++	map->btn_lt.button = BTN_PAD_LT;
++	map->btn_rt.button = BTN_PAD_RT;
++	map->btn_ls.button = BTN_PAD_LS;
++	map->btn_rs.button = BTN_PAD_RS;
++	map->dpad_up.button = BTN_PAD_DPAD_UP;
++	map->dpad_down.button = BTN_PAD_DPAD_DOWN;
++	map->dpad_left.button = BTN_PAD_DPAD_LEFT;
++	map->dpad_right.button = BTN_PAD_DPAD_RIGHT;
++	map->btn_view.button = BTN_PAD_VIEW;
++	map->btn_menu.button = BTN_PAD_MENU;
++}
++
++static ssize_t btn_mapping_reset_store(struct device *dev, struct device_attribute *attr,
++				       const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	switch (ally_cfg->mode) {
++	case xpad_mode_game:
++		_gamepad_set_xpad_default(ally_cfg);
++		break;
++	default:
++		_gamepad_set_xpad_default(ally_cfg);
++		break;
++	}
++
++	return count;
++}
++ALLY_DEVICE_ATTR_WO(btn_mapping_reset, reset_btn_mapping);
++
++/* GAMEPAD MODE */
++static ssize_t _gamepad_set_mode(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg,
++				  int val)
++{
++	u8 *hidbuf;
++	int ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_mode;
++	hidbuf[3] = xpad_cmd_len_mode;
++	hidbuf[4] = val;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = _gamepad_apply_all(hdev, ally_cfg);
++	if (ret < 0)
++		goto report_fail;
++
++report_fail:
++	kfree(hidbuf);
++	return ret;
++}
++
++static ssize_t gamepad_mode_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	return sysfs_emit(buf, "%d\n", ally_cfg->mode);
++}
++
++static ssize_t gamepad_mode_store(struct device *dev, struct device_attribute *attr,
++				  const char *buf, size_t count)
 +{
 +	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int ret, val;
 +
-+	if (ally->led_rgb_dev) {
-+		ally_rgb_store_settings(ally);
-+	}
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
 +
-+	return 0;
++	ret = kstrtoint(buf, 0, &val);
++	if (ret)
++		return ret;
++
++	if (val < xpad_mode_game || val > xpad_mode_mouse)
++		return -EINVAL;
++
++	ally_cfg->mode = val;
++
++	ret = _gamepad_set_mode(hdev, ally_cfg, val);
++	if (ret < 0)
++		return ret;
++
++	return count;
 +}
 +
-+static const struct dev_pm_ops ally_pm_ops = {
-+	.thaw = ally_pm_thaw,
-+	.prepare = ally_pm_prepare,
++DEVICE_ATTR_RW(gamepad_mode);
++
++static ssize_t mcu_version_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	return sysfs_emit(buf, "%d\n", drvdata.mcu_version);
++}
++
++DEVICE_ATTR_RO(mcu_version);
++
++/* ROOT LEVEL ATTRS *******************************************************************************/
++static struct attribute *gamepad_device_attrs[] = {
++	&dev_attr_btn_mapping_reset.attr,
++	&dev_attr_gamepad_mode.attr,
++	&dev_attr_gamepad_apply_all.attr,
++	&dev_attr_gamepad_vibration_intensity.attr,
++	&dev_attr_gamepad_vibration_intensity_index.attr,
++	&dev_attr_mcu_version.attr,
++	NULL
 +};
 +
-+MODULE_DEVICE_TABLE(hid, rog_ally_devices);
-+
-+static struct hid_driver rog_ally_cfg = { .name = "asus_rog_ally",
-+		.id_table = rog_ally_devices,
-+		.probe = ally_hid_probe,
-+		.remove = ally_hid_remove,
-+		.raw_event = ally_raw_event,
-+		.input_configured = ally_input_configured,
-+		/* ALLy 1 requires this to reset device state correctly */
-+		.reset_resume = ally_hid_reset_resume,
-+		.driver = {
-+			.pm = &ally_pm_ops,
-+		}
++static const struct attribute_group ally_controller_attr_group = {
++	.attrs = gamepad_device_attrs,
 +};
 +
-+static int __init rog_ally_init(void)
-+{
-+	mutex_init(&ally_drvdata.intf_mutex);
-+	return hid_register_driver(&rog_ally_cfg);
-+}
-+
-+static void __exit rog_ally_exit(void)
-+{
-+	mutex_destroy(&ally_drvdata.intf_mutex);
-+	hid_unregister_driver(&rog_ally_cfg);
-+}
-+
-+module_init(rog_ally_init);
-+module_exit(rog_ally_exit);
-+
-+MODULE_AUTHOR("Luke D. Jones");
-+MODULE_DESCRIPTION("HID Driver for ASUS ROG Ally handeheld.");
-+MODULE_LICENSE("GPL");
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-hid-input.c b/drivers/hid/asus-ally-hid/asus-ally-hid-input.c
-new file mode 100644
-index 000000000000..4fc848d67c23
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-hid-input.c
-@@ -0,0 +1,345 @@
-+// SPDX-License-Identifier: GPL-2.0-or-later
-+/*
-+ *  HID driver for Asus ROG laptops and Ally
-+ *
-+ *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
-+ */
-+
-+#include "linux/delay.h"
-+#include "linux/input-event-codes.h"
-+#include <linux/hid.h>
-+#include <linux/types.h>
-+
-+#include "asus-ally.h"
-+
-+struct ally_x_input_report {
-+	uint16_t x, y;
-+	uint16_t rx, ry;
-+	uint16_t z, rz;
-+	uint8_t buttons[4];
-+} __packed;
-+
-+/* The hatswitch outputs integers, we use them to index this X|Y pair */
-+static const int hat_values[][2] = {
-+	{ 0, 0 }, { 0, -1 }, { 1, -1 }, { 1, 0 },   { 1, 1 },
-+	{ 0, 1 }, { -1, 1 }, { -1, 0 }, { -1, -1 },
++static const struct attribute_group *gamepad_device_attr_groups[] = {
++	&ally_controller_attr_group,
++	&axis_xy_left_attr_group,
++	&axis_xy_right_attr_group,
++	&axis_z_left_attr_group,
++	&axis_z_right_attr_group,
++	&btn_mapping_m1_attr_group,
++	&btn_mapping_m2_attr_group,
++	&btn_mapping_a_attr_group,
++	&btn_mapping_b_attr_group,
++	&btn_mapping_x_attr_group,
++	&btn_mapping_y_attr_group,
++	&btn_mapping_lb_attr_group,
++	&btn_mapping_rb_attr_group,
++	&btn_mapping_ls_attr_group,
++	&btn_mapping_rs_attr_group,
++	&btn_mapping_lt_attr_group,
++	&btn_mapping_rt_attr_group,
++	&btn_mapping_dpad_u_attr_group,
++	&btn_mapping_dpad_d_attr_group,
++	&btn_mapping_dpad_l_attr_group,
++	&btn_mapping_dpad_r_attr_group,
++	&btn_mapping_view_attr_group,
++	&btn_mapping_menu_attr_group,
++	NULL,
 +};
 +
-+static void ally_x_work(struct work_struct *work)
++static struct ally_gamepad_cfg *ally_gamepad_cfg_create(struct hid_device *hdev)
 +{
-+	struct ally_x_input *ally_x = container_of(work, struct ally_x_input, output_worker);
-+	struct ff_report *ff_report = NULL;
-+	bool update_qam_chord = false;
-+	bool update_ff = false;
-+	unsigned long flags;
++	struct ally_gamepad_cfg *ally_cfg;
++	struct input_dev *input_dev;
++	int err;
 +
-+	spin_lock_irqsave(&ally_x->lock, flags);
-+	update_qam_chord = ally_x->update_qam_chord;
++	ally_cfg = devm_kzalloc(&hdev->dev, sizeof(*ally_cfg), GFP_KERNEL);
++	if (!ally_cfg)
++		return ERR_PTR(-ENOMEM);
++	ally_cfg->hdev = hdev;
++	// Allocate memory for each mode's `btn_mapping`
++	ally_cfg->mode = xpad_mode_game;
 +
-+	update_ff = ally_x->update_ff;
-+	if (ally_x->update_ff) {
-+		ff_report = kmemdup(ally_x->ff_packet, sizeof(*ally_x->ff_packet), GFP_KERNEL);
-+		ally_x->update_ff = false;
++	input_dev = devm_input_allocate_device(&hdev->dev);
++	if (!input_dev) {
++		err = -ENOMEM;
++		goto free_ally_cfg;
 +	}
-+	spin_unlock_irqrestore(&ally_x->lock, flags);
 +
-+	if (update_ff && ff_report) {
-+		ff_report->ff.magnitude_left = ff_report->ff.magnitude_strong;
-+		ff_report->ff.magnitude_right = ff_report->ff.magnitude_weak;
-+		ally_gamepad_send_packet(ally_x->ally, ally_x->hdev,
-+					 (u8 *)ff_report, sizeof(*ff_report));
++	input_dev->id.bustype = hdev->bus;
++	input_dev->id.vendor = hdev->vendor;
++	input_dev->id.product = hdev->product;
++	input_dev->id.version = hdev->version;
++	input_dev->uniq = hdev->uniq;
++	input_dev->name = "ASUS ROG Ally Config";
++	input_set_capability(input_dev, EV_KEY, KEY_PROG1);
++	input_set_capability(input_dev, EV_KEY, KEY_F16);
++	input_set_capability(input_dev, EV_KEY, KEY_F17);
++	input_set_capability(input_dev, EV_KEY, KEY_F18);
++	input_set_drvdata(input_dev, hdev);
++
++	err = input_register_device(input_dev);
++	if (err)
++		goto free_input_dev;
++	ally_cfg->input = input_dev;
++
++	/* ignore all errors for this as they are related to USB HID I/O */
++	_gamepad_set_xpad_default(ally_cfg);
++	ally_cfg->key_mapping[ally_cfg->mode - 1].btn_m1.button = BTN_KB_M1;
++	ally_cfg->key_mapping[ally_cfg->mode - 1].btn_m2.button = BTN_KB_M2;
++	_gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_m1_m2);
++	gamepad_get_calibration(hdev);
++
++	ally_cfg->vibration_intensity[0] = 0x64;
++	ally_cfg->vibration_intensity[1] = 0x64;
++	_gamepad_set_deadzones_default(ally_cfg);
++	_gamepad_set_anti_deadzones_default(ally_cfg);
++	_gamepad_set_js_response_curves_default(ally_cfg);
++
++	drvdata.gamepad_cfg = ally_cfg; // Must asign before attr group setup
++	if (sysfs_create_groups(&hdev->dev.kobj, gamepad_device_attr_groups)) {
++		err = -ENODEV;
++		goto unregister_input_dev;
 +	}
-+	kfree(ff_report);
 +
-+	if (update_qam_chord) {
-+		/*
-+		 * The sleeps here are required to allow steam to register the button combo.
-+		 */
-+		input_report_key(ally_x->input, BTN_MODE, 1);
-+		input_sync(ally_x->input);
-+		msleep(150);
-+		input_report_key(ally_x->input, BTN_A, 1);
-+		input_sync(ally_x->input);
-+		input_report_key(ally_x->input, BTN_A, 0);
-+		input_sync(ally_x->input);
-+		input_report_key(ally_x->input, BTN_MODE, 0);
-+		input_sync(ally_x->input);
++	return ally_cfg;
 +
-+		spin_lock_irqsave(&ally_x->lock, flags);
-+		ally_x->update_qam_chord = false;
-+		spin_unlock_irqrestore(&ally_x->lock, flags);
-+	}
++unregister_input_dev:
++	input_unregister_device(input_dev);
++	ally_cfg->input = NULL; // Prevent double free when kfree(ally_cfg) happens
++
++free_input_dev:
++	devm_kfree(&hdev->dev, input_dev);
++
++free_ally_cfg:
++	devm_kfree(&hdev->dev, ally_cfg);
++	return ERR_PTR(err);
 +}
 +
-+static int ally_x_play_effect(struct input_dev *idev, void *data, struct ff_effect *effect)
++static void ally_cfg_remove(struct hid_device *hdev)
 +{
-+	struct hid_device *hdev = input_get_drvdata(idev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x = ally->ally_x_input;
-+	unsigned long flags;
-+
-+	if (effect->type != FF_RUMBLE)
-+		return 0;
-+
-+	spin_lock_irqsave(&ally_x->lock, flags);
-+	ally_x->ff_packet->ff.magnitude_strong = effect->u.rumble.strong_magnitude / 512;
-+	ally_x->ff_packet->ff.magnitude_weak = effect->u.rumble.weak_magnitude / 512;
-+	ally_x->update_ff = true;
-+	spin_unlock_irqrestore(&ally_x->lock, flags);
-+
-+	if (ally_x->output_worker_initialized)
-+		schedule_work(&ally_x->output_worker);
-+
-+	return 0;
++	// __gamepad_set_mode(hdev, drvdata.gamepad_cfg, xpad_mode_mouse);
++	sysfs_remove_groups(&hdev->dev.kobj, gamepad_device_attr_groups);
 +}
 +
-+/* Return true if event was handled, otherwise false */
-+bool ally_x_raw_event(struct ally_x_input *ally_x, struct hid_report *report, u8 *data,
++/**************************************************************************************************/
++/* ROG Ally gamepad i/o and force-feedback                                                        */
++/**************************************************************************************************/
++static int ally_x_raw_event(struct ally_x_device *ally_x, struct hid_report *report, u8 *data,
 +			    int size)
 +{
 +	struct ally_x_input_report *in_report;
@@ -3297,10 +1642,10 @@ index 000000000000..4fc848d67c23
 +	if (data[0] == 0x0B) {
 +		in_report = (struct ally_x_input_report *)&data[1];
 +
-+		input_report_abs(ally_x->input, ABS_X, in_report->x - 32768);
-+		input_report_abs(ally_x->input, ABS_Y, in_report->y - 32768);
-+		input_report_abs(ally_x->input, ABS_RX, in_report->rx - 32768);
-+		input_report_abs(ally_x->input, ABS_RY, in_report->ry - 32768);
++		input_report_abs(ally_x->input, ABS_X, in_report->x);
++		input_report_abs(ally_x->input, ABS_Y, in_report->y);
++		input_report_abs(ally_x->input, ABS_RX, in_report->rx);
++		input_report_abs(ally_x->input, ABS_RY, in_report->ry);
 +		input_report_abs(ally_x->input, ABS_Z, in_report->z);
 +		input_report_abs(ally_x->input, ABS_RZ, in_report->rz);
 +
@@ -3322,9 +1667,6 @@ index 000000000000..4fc848d67c23
 +		byte = in_report->buttons[2];
 +		input_report_abs(ally_x->input, ABS_HAT0X, hat_values[byte][0]);
 +		input_report_abs(ally_x->input, ABS_HAT0Y, hat_values[byte][1]);
-+		input_sync(ally_x->input);
-+
-+		return true;
 +	}
 +	/*
 +	 * The MCU used on Ally provides many devices: gamepad, keyboord, mouse, other.
@@ -3332,33 +1674,29 @@ index 000000000000..4fc848d67c23
 +	 * use the events unless we grab those and use them here. Only works for Ally X.
 +	 */
 +	else if (data[0] == 0x5A) {
-+		if (ally_x->qam_mode) {
++		if (ally_x->qam_btns_steam_mode) {
 +			spin_lock_irqsave(&ally_x->lock, flags);
-+			/* Right Armoury Crate button */
-+			if (data[1] == 0x38 && !ally_x->update_qam_chord) {
-+				ally_x->update_qam_chord = true;
++			if (data[1] == 0x38 && !ally_x->update_qam_btn) {
++				ally_x->update_qam_btn = true;
 +				if (ally_x->output_worker_initialized)
 +					schedule_work(&ally_x->output_worker);
 +			}
 +			spin_unlock_irqrestore(&ally_x->lock, flags);
-+			/* Left/XBox button */
++			/* Left/XBox button. Long press does ctrl+alt+del which we can't catch */
 +			input_report_key(ally_x->input, BTN_MODE, data[1] == 0xA6);
 +		} else {
-+			/* Right Armoury Crate button */
-+			input_report_key(ally_x->input, KEY_PROG1, data[1] == 0x38);
-+			/* Left/XBox button */
 +			input_report_key(ally_x->input, KEY_F16, data[1] == 0xA6);
++			input_report_key(ally_x->input, KEY_PROG1, data[1] == 0x38);
 +		}
 +		/* QAM long press */
 +		input_report_key(ally_x->input, KEY_F17, data[1] == 0xA7);
 +		/* QAM long press released */
 +		input_report_key(ally_x->input, KEY_F18, data[1] == 0xA8);
-+		input_sync(ally_x->input);
-+
-+		return data[1] == 0xA6 || data[1] == 0xA7 || data[1] == 0xA8 || data[1] == 0x38;
 +	}
 +
-+	return false;
++	input_sync(ally_x->input);
++
++	return 0;
 +}
 +
 +static struct input_dev *ally_x_alloc_input_dev(struct hid_device *hdev,
@@ -3382,56 +1720,91 @@ index 000000000000..4fc848d67c23
 +	return input_dev;
 +}
 +
-+static ssize_t ally_x_qam_mode_show(struct device *dev, struct device_attribute *attr,
-+								char *buf)
++static int ally_x_play_effect(struct input_dev *idev, void *data, struct ff_effect *effect)
 +{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x = ally->ally_x_input;
++	struct ally_x_device *ally_x = drvdata.ally_x;
++	unsigned long flags;
 +
-+	if (!ally_x)
-+		return -ENODEV;
++	if (effect->type != FF_RUMBLE)
++		return 0;
 +
-+	return sysfs_emit(buf, "%d\n", ally_x->qam_mode);
++	spin_lock_irqsave(&ally_x->lock, flags);
++	ally_x->ff_packet->ff.magnitude_strong = effect->u.rumble.strong_magnitude / 512;
++	ally_x->ff_packet->ff.magnitude_weak = effect->u.rumble.weak_magnitude / 512;
++	ally_x->update_ff = true;
++	spin_unlock_irqrestore(&ally_x->lock, flags);
++
++	if (ally_x->output_worker_initialized)
++		schedule_work(&ally_x->output_worker);
++
++	return 0;
 +}
 +
-+static ssize_t ally_x_qam_mode_store(struct device *dev, struct device_attribute *attr,
-+				     const char *buf, size_t count)
++static void ally_x_work(struct work_struct *work)
 +{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x = ally->ally_x_input;
-+	bool val;
-+	int ret;
++	struct ally_x_device *ally_x = container_of(work, struct ally_x_device, output_worker);
++	struct ff_report *ff_report = NULL;
++	bool update_qam = false;
++	bool update_ff = false;
++	unsigned long flags;
 +
-+	if (!ally_x)
-+		return -ENODEV;
++	spin_lock_irqsave(&ally_x->lock, flags);
++	update_ff = ally_x->update_ff;
++	if (ally_x->update_ff) {
++		ff_report = kmemdup(ally_x->ff_packet, sizeof(*ally_x->ff_packet), GFP_KERNEL);
++		ally_x->update_ff = false;
++	}
++	update_qam = ally_x->update_qam_btn;
++	spin_unlock_irqrestore(&ally_x->lock, flags);
 +
-+	ret = kstrtobool(buf, &val);
-+	if (ret < 0)
-+		return ret;
++	if (update_ff && ff_report) {
++		ff_report->ff.magnitude_left = ff_report->ff.magnitude_strong;
++		ff_report->ff.magnitude_right = ff_report->ff.magnitude_weak;
++		asus_dev_set_report(ally_x->hdev, (u8 *)ff_report, sizeof(*ff_report));
++	}
++	kfree(ff_report);
 +
-+	ally_x->qam_mode = val;
++	if (update_qam) {
++		/*
++		 * The sleeps here are required to allow steam to register the button combo.
++		 */
++		usleep_range(1000, 2000);
++		input_report_key(ally_x->input, BTN_MODE, 1);
++		input_sync(ally_x->input);
 +
-+	return count;
++		msleep(80);
++		input_report_key(ally_x->input, BTN_A, 1);
++		input_sync(ally_x->input);
++
++		msleep(80);
++		input_report_key(ally_x->input, BTN_A, 0);
++		input_sync(ally_x->input);
++
++		msleep(80);
++		input_report_key(ally_x->input, BTN_MODE, 0);
++		input_sync(ally_x->input);
++
++		spin_lock_irqsave(&ally_x->lock, flags);
++		ally_x->update_qam_btn = false;
++		spin_unlock_irqrestore(&ally_x->lock, flags);
++	}
 +}
-+ALLY_DEVICE_ATTR_RW(ally_x_qam_mode, qam_mode);
 +
-+static int ally_x_setup_input(struct hid_device *hdev, struct ally_x_input *ally_x)
++static struct input_dev *ally_x_setup_input(struct hid_device *hdev)
 +{
++	int ret, abs_min = 0, js_abs_max = 65535, tr_abs_max = 1023;
 +	struct input_dev *input;
-+	int ret;
 +
 +	input = ally_x_alloc_input_dev(hdev, NULL);
 +	if (IS_ERR(input))
-+		return PTR_ERR(input);
++		return ERR_CAST(input);
 +
-+	input_set_abs_params(input, ABS_X, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_Y, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_RX, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_RY, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_Z, 0, 1023, 0, 0);
-+	input_set_abs_params(input, ABS_RZ, 0, 1023, 0, 0);
++	input_set_abs_params(input, ABS_X, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_Y, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_RX, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_RY, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_Z, abs_min, tr_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_RZ, abs_min, tr_abs_max, 0, 0);
 +	input_set_abs_params(input, ABS_HAT0X, -1, 1, 0, 0);
 +	input_set_abs_params(input, ABS_HAT0Y, -1, 1, 0, 0);
 +	input_set_capability(input, EV_KEY, BTN_A);
@@ -3450,121 +1823,121 @@ index 000000000000..4fc848d67c23
 +	input_set_capability(input, EV_KEY, KEY_F16);
 +	input_set_capability(input, EV_KEY, KEY_F17);
 +	input_set_capability(input, EV_KEY, KEY_F18);
-+	input_set_capability(input, EV_KEY, BTN_TRIGGER_HAPPY);
-+	input_set_capability(input, EV_KEY, BTN_TRIGGER_HAPPY1);
 +
 +	input_set_capability(input, EV_FF, FF_RUMBLE);
 +	input_ff_create_memless(input, NULL, ally_x_play_effect);
 +
 +	ret = input_register_device(input);
-+	if (ret) {
-+		input_unregister_device(input);
-+		return ret;
-+	}
++	if (ret)
++		return ERR_PTR(ret);
 +
-+	ally_x->input = input;
-+
-+	return 0;
++	return input;
 +}
 +
-+int ally_x_create(struct hid_device *hdev, struct ally_handheld *ally)
++static ssize_t ally_x_qam_mode_show(struct device *dev, struct device_attribute *attr,
++				    char *buf)
++{
++	struct ally_x_device *ally_x = drvdata.ally_x;
++
++	return sysfs_emit(buf, "%d\n", ally_x->qam_btns_steam_mode);
++}
++
++static ssize_t ally_x_qam_mode_store(struct device *dev, struct device_attribute *attr,
++				     const char *buf, size_t count)
++{
++	struct ally_x_device *ally_x = drvdata.ally_x;
++	bool val;
++	int ret;
++
++	ret = kstrtobool(buf, &val);
++	if (ret < 0)
++		return ret;
++
++	ally_x->qam_btns_steam_mode = val;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_RW(ally_x_qam_mode, qam_mode);
++
++static struct ally_x_device *ally_x_create(struct hid_device *hdev)
 +{
 +	uint8_t max_output_report_size;
-+	struct ally_x_input *ally_x;
-+	struct ff_report *ff_report;
++	struct ally_x_device *ally_x;
++	struct ff_report *report;
 +	int ret;
 +
 +	ally_x = devm_kzalloc(&hdev->dev, sizeof(*ally_x), GFP_KERNEL);
 +	if (!ally_x)
-+		return -ENOMEM;
++		return ERR_PTR(-ENOMEM);
 +
 +	ally_x->hdev = hdev;
-+	ally_x->ally = ally;
-+	ally->ally_x_input = ally_x;
-+
-+	max_output_report_size = sizeof(struct ally_x_input_report);
-+
-+	ret = ally_x_setup_input(hdev, ally_x);
-+	if (ret)
-+		goto free_ally_x;
-+
 +	INIT_WORK(&ally_x->output_worker, ally_x_work);
 +	spin_lock_init(&ally_x->lock);
 +	ally_x->output_worker_initialized = true;
-+	ally_x->qam_mode =
-+		true;
++	ally_x->qam_btns_steam_mode =
++		true; /* Always default to steam mode, it can be changed by userspace attr */
 +
-+	ff_report = devm_kzalloc(&hdev->dev, sizeof(*ff_report), GFP_KERNEL);
-+	if (!ff_report) {
++	max_output_report_size = sizeof(struct ally_x_input_report);
++	report = devm_kzalloc(&hdev->dev, sizeof(*report), GFP_KERNEL);
++	if (!report) {
 +		ret = -ENOMEM;
 +		goto free_ally_x;
 +	}
 +
 +	/* None of these bytes will change for the FF command for now */
-+	ff_report->report_id = 0x0D;
-+	ff_report->ff.enable = 0x0F; /* Enable all by default */
-+	ff_report->ff.pulse_sustain_10ms = 0xFF; /* Duration */
-+	ff_report->ff.pulse_release_10ms = 0x00; /* Start Delay */
-+	ff_report->ff.loop_count = 0xEB; /* Loop Count */
-+	ally_x->ff_packet = ff_report;
++	report->report_id = 0x0D;
++	report->ff.enable = 0x0F; /* Enable all by default */
++	report->ff.pulse_sustain_10ms = 0xFF; /* Duration */
++	report->ff.pulse_release_10ms = 0x00; /* Start Delay */
++	report->ff.loop_count = 0xEB; /* Loop Count */
++	ally_x->ff_packet = report;
++
++	ally_x->input = ally_x_setup_input(hdev);
++	if (IS_ERR(ally_x->input)) {
++		ret = PTR_ERR(ally_x->input);
++		goto free_ff_packet;
++	}
 +
 +	if (sysfs_create_file(&hdev->dev.kobj, &dev_attr_ally_x_qam_mode.attr)) {
 +		ret = -ENODEV;
 +		goto unregister_input;
 +	}
 +
-+	hid_info(hdev, "Registered Ally X controller using %s\n",
-+			dev_name(&ally_x->input->dev));
++	ally_x->update_ff = true;
++	if (ally_x->output_worker_initialized)
++		schedule_work(&ally_x->output_worker);
 +
-+	return 0;
++	hid_info(hdev, "Registered Ally X controller using %s\n",
++		 dev_name(&ally_x->input->dev));
++	return ally_x;
 +
 +unregister_input:
 +	input_unregister_device(ally_x->input);
++free_ff_packet:
++	kfree(ally_x->ff_packet);
 +free_ally_x:
-+	devm_kfree(&hdev->dev, ally_x);
-+	return ret;
++	kfree(ally_x);
++	return ERR_PTR(ret);
 +}
 +
-+void ally_x_remove(struct hid_device *hdev, struct ally_handheld *ally)
++static void ally_x_remove(struct hid_device *hdev)
 +{
-+	if (ally->ally_x_input) {
-+		sysfs_remove_file(&hdev->dev.kobj, &dev_attr_ally_x_qam_mode.attr);
++	struct ally_x_device *ally_x = drvdata.ally_x;
++	unsigned long flags;
 +
-+		if (ally->ally_x_input->output_worker_initialized)
-+			cancel_work_sync(&ally->ally_x_input->output_worker);
-+
-+		ally->ally_x_input = NULL;
-+	}
++	spin_lock_irqsave(&ally_x->lock, flags);
++	ally_x->output_worker_initialized = false;
++	spin_unlock_irqrestore(&ally_x->lock, flags);
++	cancel_work_sync(&ally_x->output_worker);
++	sysfs_remove_file(&hdev->dev.kobj, &dev_attr_ally_x_qam_mode.attr);
 +}
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-rgb.c b/drivers/hid/asus-ally-hid/asus-ally-rgb.c
-new file mode 100644
-index 000000000000..22aec39a7634
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-rgb.c
-@@ -0,0 +1,356 @@
-+// SPDX-License-Identifier: GPL-2.0-or-later
-+/*
-+ *  HID driver for Asus ROG laptops and Ally
-+ *
-+ *  Copyright (c) 2025 Luke Jones <luke@ljones.dev>
-+ */
 +
-+#include "asus-ally.h"
-+#include "linux/delay.h"
-+
-+static const u8 EC_MODE_LED_APPLY[] = { 0x5A, 0xB4, 0, 0, 0, 0, 0, 0, 0,
-+					0,    0,    0, 0, 0, 0, 0, 0 };
-+static const u8 EC_MODE_LED_SET[] = { 0x5A, 0xB5, 0, 0, 0, 0, 0, 0, 0,
-+				      0,    0,	  0, 0, 0, 0, 0, 0 };
-+
-+static struct ally_rgb_resume_data resume_data;
-+
++/**************************************************************************************************/
++/* ROG Ally LED control                                                                           */
++/**************************************************************************************************/
 +static void ally_rgb_schedule_work(struct ally_rgb_dev *led)
 +{
 +	unsigned long flags;
-+
-+	if (!led)
-+		return;
 +
 +	spin_lock_irqsave(&led->lock, flags);
 +	if (!led->removed)
@@ -3576,231 +1949,160 @@ index 000000000000..22aec39a7634
 + * The RGB still has the basic 0-3 level brightness. Since the multicolour
 + * brightness is being used in place, set this to max
 + */
-+static int ally_rgb_set_bright_base_max(struct hid_device *hdev, struct ally_handheld *ally)
++static int ally_rgb_set_bright_base_max(struct hid_device *hdev)
 +{
-+	u8 buf[] = { HID_ALLY_SET_RGB_REPORT_ID, 0xba, 0xc5, 0xc4, 0x02 };
++	u8 buf[] = { FEATURE_KBD_LED_REPORT_ID1, 0xba, 0xc5, 0xc4, 0x02 };
 +
-+	return ally_gamepad_send_packet(ally, hdev, buf, sizeof(buf));
++	return asus_dev_set_report(hdev, buf, sizeof(buf));
 +}
 +
 +static void ally_rgb_do_work(struct work_struct *work)
 +{
 +	struct ally_rgb_dev *led = container_of(work, struct ally_rgb_dev, work);
-+	unsigned long flags;
 +	int ret;
++	unsigned long flags;
 +
-+	bool update_needed = false;
-+	u8 red[4], green[4], blue[4];
-+	const int data_size = 12; /* 4 RGB zones × 3 colors */
-+
-+	u8 buf[16] = { [0] = HID_ALLY_SET_REPORT_ID,
-+		       [1] = HID_ALLY_FEATURE_CODE_PAGE,
-+		       [2] = CMD_LED_CONTROL,
-+		       [3] = data_size };
-+
-+	if (!led || !led->hdev)
-+		return;
++	u8 buf[16] = { [0] = FEATURE_ROG_ALLY_REPORT_ID,
++		       [1] = FEATURE_ROG_ALLY_CODE_PAGE,
++		       [2] = xpad_cmd_set_leds,
++		       [3] = xpad_cmd_len_leds };
 +
 +	spin_lock_irqsave(&led->lock, flags);
-+	if (led->removed) {
++	if (!led->update_rgb) {
 +		spin_unlock_irqrestore(&led->lock, flags);
 +		return;
 +	}
 +
-+	if (led->update_rgb) {
-+		memcpy(red, led->red, sizeof(red));
-+		memcpy(green, led->green, sizeof(green));
-+		memcpy(blue, led->blue, sizeof(blue));
-+		led->update_rgb = false;
-+		update_needed = true;
++	for (int i = 0; i < 4; i++) {
++		buf[5 + i * 3] = drvdata.led_rgb_dev->green[i];
++		buf[6 + i * 3] = drvdata.led_rgb_dev->blue[i];
++		buf[4 + i * 3] = drvdata.led_rgb_dev->red[i];
 +	}
++	led->update_rgb = false;
++
 +	spin_unlock_irqrestore(&led->lock, flags);
 +
-+	if (!update_needed)
-+		return;
-+
-+	for (int i = 0; i < 4; i++) {
-+		buf[5 + i * 3] = green[i];
-+		buf[6 + i * 3] = blue[i];
-+		buf[4 + i * 3] = red[i];
-+	}
-+
-+	ret = ally_gamepad_send_packet(led->ally, led->hdev, buf, sizeof(buf));
++	ret = asus_dev_set_report(led->hdev, buf, sizeof(buf));
 +	if (ret < 0)
-+		hid_err(led->hdev, "Ally failed to set gamepad backlight: %d\n",
-+			ret);
++		hid_err(led->hdev, "Ally failed to set gamepad backlight: %d\n", ret);
 +}
 +
-+static void ally_rgb_set(struct led_classdev *cdev,
-+			 enum led_brightness brightness)
++static void ally_rgb_set(struct led_classdev *cdev, enum led_brightness brightness)
 +{
-+	struct led_classdev_mc *mc_cdev;
-+	struct ally_rgb_dev *led;
++	struct led_classdev_mc *mc_cdev = lcdev_to_mccdev(cdev);
++	struct ally_rgb_dev *led = container_of(mc_cdev, struct ally_rgb_dev, led_rgb_dev);
 +	int intensity, bright;
 +	unsigned long flags;
 +
-+	mc_cdev = lcdev_to_mccdev(cdev);
-+	if (!mc_cdev)
-+		return;
-+
-+	led = container_of(mc_cdev, struct ally_rgb_dev, led_rgb_dev);
-+	if (!led)
-+		return;
-+
 +	led_mc_calc_color_components(mc_cdev, brightness);
-+
 +	spin_lock_irqsave(&led->lock, flags);
-+
 +	led->update_rgb = true;
 +	bright = mc_cdev->led_cdev.brightness;
-+
 +	for (int i = 0; i < 4; i++) {
 +		intensity = mc_cdev->subled_info[i].intensity;
-+		led->red[i] = (((intensity >> 16) & 0xFF) * bright) / 255;
-+		led->green[i] = (((intensity >> 8) & 0xFF) * bright) / 255;
-+		led->blue[i] = ((intensity & 0xFF) * bright) / 255;
++		drvdata.led_rgb_dev->red[i] = (((intensity >> 16) & 0xFF) * bright) / 255;
++		drvdata.led_rgb_dev->green[i] = (((intensity >> 8) & 0xFF) * bright) / 255;
++		drvdata.led_rgb_dev->blue[i] = ((intensity & 0xFF) * bright) / 255;
 +	}
-+
-+	resume_data.initialized = true;
-+
 +	spin_unlock_irqrestore(&led->lock, flags);
++	drvdata.led_rgb_data.initialized = true;
 +
 +	ally_rgb_schedule_work(led);
 +}
 +
-+static int ally_rgb_set_static_from_multi(struct hid_device *hdev,
-+					  struct ally_handheld *ally, u8 r,
-+					  u8 g, u8 b)
++static int ally_rgb_set_static_from_multi(struct hid_device *hdev)
 +{
-+	u8 buf[17] = { HID_ALLY_SET_RGB_REPORT_ID, 0xb3 };
++	u8 buf[17] = {FEATURE_KBD_LED_REPORT_ID1, 0xb3};
 +	int ret;
 +
 +	/*
 +	 * Set single zone single colour based on the first LED of EC software mode.
 +	 * buf[2] = zone, buf[3] = mode
 +	 */
-+	buf[4] = r;
-+	buf[5] = g;
-+	buf[6] = b;
++	buf[4] = drvdata.led_rgb_data.red[0];
++	buf[5] = drvdata.led_rgb_data.green[0];
++	buf[6] = drvdata.led_rgb_data.blue[0];
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, buf, sizeof(buf));
++	ret = asus_dev_set_report(hdev, buf, sizeof(buf));
 +	if (ret < 0)
 +		return ret;
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, EC_MODE_LED_APPLY,
-+				       sizeof(EC_MODE_LED_APPLY));
++	ret = asus_dev_set_report(hdev, EC_MODE_LED_APPLY, sizeof(EC_MODE_LED_APPLY));
 +	if (ret < 0)
 +		return ret;
 +
-+	return ally_gamepad_send_packet(ally, hdev, EC_MODE_LED_SET,
-+					sizeof(EC_MODE_LED_SET));
++	return asus_dev_set_report(hdev, EC_MODE_LED_SET, sizeof(EC_MODE_LED_SET));
 +}
 +
 +/*
 + * Store the RGB values for restoring on resume, and set the static mode to the first LED colour
 +*/
-+void ally_rgb_store_settings(struct ally_handheld *ally)
++static void ally_rgb_store_settings(void)
 +{
-+	struct ally_rgb_dev *led_rgb;
-+	int arr_size;
-+	u8 r = 0, g = 0, b = 0;
++	int arr_size = sizeof(drvdata.led_rgb_data.red);
 +
-+	led_rgb = ally->led_rgb_dev;
-+	if (!led_rgb || !led_rgb->hdev)
-+		return;
++	struct ally_rgb_dev *led_rgb = drvdata.led_rgb_dev;
 +
-+	arr_size = sizeof(resume_data.red);
++	drvdata.led_rgb_data.brightness = led_rgb->led_rgb_dev.led_cdev.brightness;
 +
-+	/* Take a snapshot of current settings with locking */
-+	spin_lock_irq(&led_rgb->lock);
-+	resume_data.brightness = led_rgb->led_rgb_dev.led_cdev.brightness;
-+	memcpy(resume_data.red, led_rgb->red, arr_size);
-+	memcpy(resume_data.green, led_rgb->green, arr_size);
-+	memcpy(resume_data.blue, led_rgb->blue, arr_size);
-+	r = resume_data.red[0];
-+	g = resume_data.green[0];
-+	b = resume_data.blue[0];
-+	spin_unlock_irq(&led_rgb->lock);
++	memcpy(drvdata.led_rgb_data.red, led_rgb->red, arr_size);
++	memcpy(drvdata.led_rgb_data.green, led_rgb->green, arr_size);
++	memcpy(drvdata.led_rgb_data.blue, led_rgb->blue, arr_size);
 +
-+	ally_rgb_set_static_from_multi(led_rgb->hdev, ally, r, g, b);
++	ally_rgb_set_static_from_multi(led_rgb->hdev);
 +}
 +
-+static void ally_rgb_restore_settings(struct ally_handheld *ally,
-+				      struct led_classdev *led_cdev,
++static void ally_rgb_restore_settings(struct ally_rgb_dev *led_rgb, struct led_classdev *led_cdev,
 +				      struct mc_subled *mc_led_info)
 +{
-+	struct ally_rgb_dev *led_rgb_dev;
-+	unsigned long flags;
-+	int arr_size;
++	int arr_size = sizeof(drvdata.led_rgb_data.red);
 +
-+	led_rgb_dev = ally->led_rgb_dev;
-+	if (!led_rgb_dev)
-+		return;
-+
-+	arr_size = sizeof(resume_data.red);
-+
-+	spin_lock_irqsave(&led_rgb_dev->lock, flags);
-+
-+	memcpy(led_rgb_dev->red, resume_data.red, arr_size);
-+	memcpy(led_rgb_dev->green, resume_data.green, arr_size);
-+	memcpy(led_rgb_dev->blue, resume_data.blue, arr_size);
-+
++	memcpy(led_rgb->red, drvdata.led_rgb_data.red, arr_size);
++	memcpy(led_rgb->green, drvdata.led_rgb_data.green, arr_size);
++	memcpy(led_rgb->blue, drvdata.led_rgb_data.blue, arr_size);
 +	for (int i = 0; i < 4; i++) {
-+		mc_led_info[i].intensity = (resume_data.red[i] << 16) |
-+					   (resume_data.green[i] << 8) |
-+					   resume_data.blue[i];
++		mc_led_info[i].intensity = (drvdata.led_rgb_data.red[i] << 16) |
++					   (drvdata.led_rgb_data.green[i] << 8) |
++					   drvdata.led_rgb_data.blue[i];
 +	}
-+	led_cdev->brightness = resume_data.brightness;
-+
-+	spin_unlock_irqrestore(&led_rgb_dev->lock, flags);
++	led_cdev->brightness = drvdata.led_rgb_data.brightness;
 +}
 +
 +/* Set LEDs. Call after any setup. */
-+void ally_rgb_resume(struct ally_handheld *ally)
++static void ally_rgb_resume(void)
 +{
-+	struct ally_rgb_dev *led_rgb;
++	struct ally_rgb_dev *led_rgb = drvdata.led_rgb_dev;
 +	struct led_classdev *led_cdev;
 +	struct mc_subled *mc_led_info;
 +
-+	led_rgb = ally->led_rgb_dev;
 +	if (!led_rgb)
 +		return;
 +
 +	led_cdev = &led_rgb->led_rgb_dev.led_cdev;
 +	mc_led_info = led_rgb->led_rgb_dev.subled_info;
-+	if (!led_cdev || !mc_led_info)
-+		return;
 +
-+	if (resume_data.initialized) {
-+		ally_rgb_restore_settings(ally, led_cdev, mc_led_info);
-+
-+		spin_lock_irq(&led_rgb->lock);
++	if (drvdata.led_rgb_data.initialized) {
++		ally_rgb_restore_settings(led_rgb, led_cdev, mc_led_info);
 +		led_rgb->update_rgb = true;
-+		spin_unlock_irq(&led_rgb->lock);
-+
 +		ally_rgb_schedule_work(led_rgb);
-+		ally_rgb_set_bright_base_max(led_rgb->hdev, ally);
++		ally_rgb_set_bright_base_max(led_rgb->hdev);
 +	}
 +}
 +
-+static int ally_rgb_register(struct hid_device *hdev,
-+			     struct ally_rgb_dev *led_rgb)
++static int ally_rgb_register(struct hid_device *hdev, struct ally_rgb_dev *led_rgb)
 +{
 +	struct mc_subled *mc_led_info;
 +	struct led_classdev *led_cdev;
-+	int ret;
 +
-+	if (!hdev || !led_rgb)
-+		return -EINVAL;
-+
-+	mc_led_info = devm_kmalloc_array(&hdev->dev, 4, sizeof(*mc_led_info),
-+					 GFP_KERNEL | __GFP_ZERO);
++	mc_led_info =
++		devm_kmalloc_array(&hdev->dev, 12, sizeof(*mc_led_info), GFP_KERNEL | __GFP_ZERO);
 +	if (!mc_led_info)
 +		return -ENOMEM;
 +
-+	for (int i = 0; i < 4; i++) {
-+		mc_led_info[i].color_index = LED_COLOR_ID_RGB;
-+	}
++	mc_led_info[0].color_index = LED_COLOR_ID_RGB;
++	mc_led_info[1].color_index = LED_COLOR_ID_RGB;
++	mc_led_info[2].color_index = LED_COLOR_ID_RGB;
++	mc_led_info[3].color_index = LED_COLOR_ID_RGB;
 +
 +	led_rgb->led_rgb_dev.subled_info = mc_led_info;
 +	led_rgb->led_rgb_dev.num_colors = 4;
@@ -3811,99 +2113,310 @@ index 000000000000..22aec39a7634
 +	led_cdev->max_brightness = 255;
 +	led_cdev->brightness_set = ally_rgb_set;
 +
-+	ret = devm_led_classdev_multicolor_register(&hdev->dev,
-+						    &led_rgb->led_rgb_dev);
-+	if (ret < 0)
-+		hid_err(hdev, "Failed to register RGB LED device: %d\n", ret);
++	if (drvdata.led_rgb_data.initialized) {
++		ally_rgb_restore_settings(led_rgb, led_cdev, mc_led_info);
++	}
 +
-+	return ret;
++	return devm_led_classdev_multicolor_register(&hdev->dev, &led_rgb->led_rgb_dev);
 +}
 +
-+int ally_rgb_create(struct hid_device *hdev, struct ally_handheld *ally)
++static struct ally_rgb_dev *ally_rgb_create(struct hid_device *hdev)
 +{
 +	struct ally_rgb_dev *led_rgb;
 +	int ret;
 +
-+	led_rgb = devm_kzalloc(&hdev->dev, sizeof(struct ally_rgb_dev),
-+			       GFP_KERNEL);
++	led_rgb = devm_kzalloc(&hdev->dev, sizeof(struct ally_rgb_dev), GFP_KERNEL);
 +	if (!led_rgb)
-+		return -ENOMEM;
-+
-+	led_rgb->ally = ally;
-+	led_rgb->hdev = hdev;
-+	led_rgb->removed = false;
-+	INIT_WORK(&led_rgb->work, ally_rgb_do_work);
-+	spin_lock_init(&led_rgb->lock);
-+
-+	/* Set the pointer in ally structure BEFORE doing any operations that might use it */
-+	ally->led_rgb_dev = led_rgb;
++		return ERR_PTR(-ENOMEM);
 +
 +	ret = ally_rgb_register(hdev, led_rgb);
 +	if (ret < 0) {
-+		hid_err(hdev, "Failed to register RGB LED device: %d\n", ret);
 +		cancel_work_sync(&led_rgb->work);
-+		ally->led_rgb_dev = NULL; /* Reset pointer on failure */
 +		devm_kfree(&hdev->dev, led_rgb);
-+		return ret;
++		return ERR_PTR(ret);
 +	}
 +
++	led_rgb->hdev = hdev;
++	led_rgb->removed = false;
++
++	INIT_WORK(&led_rgb->work, ally_rgb_do_work);
 +	led_rgb->output_worker_initialized = true;
++	spin_lock_init(&led_rgb->lock);
 +
-+	ret = ally_rgb_set_bright_base_max(hdev, ally);
-+	if (ret < 0)
-+		hid_warn(hdev, "Failed to set maximum base brightness: %d\n",
-+			 ret);
++	ally_rgb_set_bright_base_max(hdev);
 +
-+	if (resume_data.initialized) {
++	/* Not marked as initialized unless ally_rgb_set() is called */
++	if (drvdata.led_rgb_data.initialized) {
 +		msleep(1500);
-+		spin_lock_irq(&led_rgb->lock);
 +		led_rgb->update_rgb = true;
-+		spin_unlock_irq(&led_rgb->lock);
 +		ally_rgb_schedule_work(led_rgb);
++	}
++
++	return led_rgb;
++}
++
++static void ally_rgb_remove(struct hid_device *hdev)
++{
++	struct ally_rgb_dev *led_rgb = drvdata.led_rgb_dev;
++	unsigned long flags;
++	int ep;
++
++	ep = get_endpoint_address(hdev);
++	if (ep != ROG_ALLY_CFG_INTF_IN)
++		return;
++
++	if (!drvdata.led_rgb_dev || led_rgb->removed)
++		return;
++
++	spin_lock_irqsave(&led_rgb->lock, flags);
++	led_rgb->removed = true;
++	led_rgb->output_worker_initialized = false;
++	spin_unlock_irqrestore(&led_rgb->lock, flags);
++	cancel_work_sync(&led_rgb->work);
++	devm_led_classdev_multicolor_unregister(&hdev->dev, &led_rgb->led_rgb_dev);
++
++	hid_info(hdev, "Removed Ally RGB interface");
++}
++
++/**************************************************************************************************/
++/* ROG Ally driver init                                                                           */
++/**************************************************************************************************/
++
++static int ally_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data,
++			  int size)
++{
++	struct ally_gamepad_cfg *cfg = drvdata.gamepad_cfg;
++	struct ally_x_device *ally_x = drvdata.ally_x;
++
++	if (ally_x) {
++		if ((hdev->bus == BUS_USB && report->id == ALLY_X_INPUT_REPORT_USB &&
++		     size == ALLY_X_INPUT_REPORT_USB_SIZE) ||
++		    (data[0] == 0x5A)) {
++			ally_x_raw_event(ally_x, report, data, size);
++		} else {
++			return -1;
++		}
++	}
++
++	if (cfg && !ally_x) {
++		input_report_key(cfg->input, KEY_PROG1, data[1] == 0x38);
++		input_report_key(cfg->input, KEY_F16, data[1] == 0xA6);
++		input_report_key(cfg->input, KEY_F17, data[1] == 0xA7);
++		input_report_key(cfg->input, KEY_F18, data[1] == 0xA8);
++		input_sync(cfg->input);
 +	}
 +
 +	return 0;
 +}
 +
-+void ally_rgb_remove(struct hid_device *hdev, struct ally_handheld *ally)
++static int ally_hid_init(struct hid_device *hdev)
 +{
-+	struct ally_rgb_dev *led_rgb;
-+	unsigned long flags;
-+	int ep;
++	int ret;
++
++	ret = asus_dev_set_report(hdev, EC_INIT_STRING, sizeof(EC_INIT_STRING));
++	if (ret < 0) {
++		hid_err(hdev, "Ally failed to send init command: %d\n", ret);
++		return ret;
++	}
++
++	ret = asus_dev_set_report(hdev, FORCE_FEEDBACK_OFF, sizeof(FORCE_FEEDBACK_OFF));
++	if (ret < 0)
++		hid_err(hdev, "Ally failed to send init command: %d\n", ret);
++
++	return ret;
++}
++
++static int ally_hid_probe(struct hid_device *hdev, const struct hid_device_id *_id)
++{
++	struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
++	struct usb_device *udev = interface_to_usbdev(intf);
++	u16 idProduct = le16_to_cpu(udev->descriptor.idProduct);
++	int ret, ep;
 +
 +	ep = get_endpoint_address(hdev);
-+	if (ep != HID_ALLY_INTF_CFG_IN)
-+		return;
++	if (ep < 0)
++		return ep;
 +
-+	led_rgb = ally->led_rgb_dev;
-+	if (!led_rgb)
-+		return;
++	if (ep != ROG_ALLY_CFG_INTF_IN &&
++	    ep != ROG_ALLY_X_INTF_IN)
++		return -ENODEV;
 +
-+	/* Mark as removed to prevent new work from being scheduled */
-+	spin_lock_irqsave(&led_rgb->lock, flags);
-+	if (led_rgb->removed) {
-+		spin_unlock_irqrestore(&led_rgb->lock, flags);
-+		return;
++	ret = hid_parse(hdev);
++	if (ret) {
++		hid_err(hdev, "Parse failed\n");
++		return ret;
 +	}
-+	led_rgb->removed = true;
-+	led_rgb->output_worker_initialized = false;
-+	spin_unlock_irqrestore(&led_rgb->lock, flags);
 +
-+	cancel_work_sync(&led_rgb->work);
++	ret = hid_hw_start(hdev, HID_CONNECT_HIDRAW);
++	if (ret) {
++		hid_err(hdev, "Failed to start HID device\n");
++		return ret;
++	}
 +
-+	devm_led_classdev_multicolor_unregister(&hdev->dev,
-+						&led_rgb->led_rgb_dev);
++	ret = hid_hw_open(hdev);
++	if (ret) {
++		hid_err(hdev, "Failed to open HID device\n");
++		goto err_stop;
++	}
 +
-+	ally->led_rgb_dev = NULL;
++	/* Initialize MCU even before alloc */
++	ret = ally_hid_init(hdev);
++	if (ret < 0)
++		return ret;
 +
-+	hid_info(hdev, "Removed Ally RGB interface");
++	drvdata.hdev = hdev;
++	hid_set_drvdata(hdev, &drvdata);
++
++	/* This should almost always exist */
++	if (ep == ROG_ALLY_CFG_INTF_IN) {
++		validate_mcu_fw_version(hdev, idProduct);
++
++		drvdata.led_rgb_dev = ally_rgb_create(hdev);
++		if (IS_ERR(drvdata.led_rgb_dev))
++			hid_err(hdev, "Failed to create Ally gamepad LEDs.\n");
++		else
++			hid_info(hdev, "Created Ally RGB LED controls.\n");
++
++		drvdata.gamepad_cfg = ally_gamepad_cfg_create(hdev);
++		if (IS_ERR(drvdata.gamepad_cfg))
++			hid_err(hdev, "Failed to create Ally gamepad attributes.\n");
++		else
++			hid_info(hdev, "Created Ally gamepad attributes.\n");
++
++		if (IS_ERR(drvdata.led_rgb_dev) && IS_ERR(drvdata.gamepad_cfg))
++			goto err_close;
++	}
++
++	/* May or may not exist */
++	if (ep == ROG_ALLY_X_INTF_IN) {
++		drvdata.ally_x = ally_x_create(hdev);
++		if (IS_ERR(drvdata.ally_x)) {
++			hid_err(hdev, "Failed to create Ally X gamepad.\n");
++			drvdata.ally_x = NULL;
++			goto err_close;
++		}
++		hid_info(hdev, "Created Ally X controller.\n");
++
++		// Not required since we send this inputs ep through the gamepad input dev
++		if (drvdata.gamepad_cfg && drvdata.gamepad_cfg->input) {
++			input_unregister_device(drvdata.gamepad_cfg->input);
++			hid_info(hdev, "Ally X removed unrequired input dev.\n");
++		}
++	}
++
++	return 0;
++
++err_close:
++	hid_hw_close(hdev);
++err_stop:
++	hid_hw_stop(hdev);
++	return ret;
 +}
-diff --git a/drivers/hid/asus-ally-hid/asus-ally.h b/drivers/hid/asus-ally-hid/asus-ally.h
++
++static void ally_hid_remove(struct hid_device *hdev)
++{
++	if (drvdata.led_rgb_dev)
++		ally_rgb_remove(hdev);
++
++	if (drvdata.ally_x)
++		ally_x_remove(hdev);
++
++	if (drvdata.gamepad_cfg)
++		ally_cfg_remove(hdev);
++
++	hid_hw_close(hdev);
++	hid_hw_stop(hdev);
++}
++
++static int ally_hid_resume(struct hid_device *hdev)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int err;
++
++	if (!ally_cfg)
++		return 0;
++
++	err = _gamepad_apply_all(hdev, ally_cfg);
++	if (err)
++		return err;
++
++	return 0;
++}
++
++static int ally_hid_reset_resume(struct hid_device *hdev)
++{
++	int ep = get_endpoint_address(hdev);
++	if (ep != ROG_ALLY_CFG_INTF_IN)
++		return 0;
++
++	ally_hid_init(hdev);
++	ally_rgb_resume();
++
++	return ally_hid_resume(hdev);
++}
++
++static int ally_pm_thaw(struct device *dev)
++{
++	struct hid_device *hdev = to_hid_device(dev);
++
++	return ally_hid_reset_resume(hdev);
++}
++
++static int ally_pm_suspend(struct device *dev)
++{
++	if (drvdata.led_rgb_dev) {
++		ally_rgb_store_settings();
++	}
++
++	return 0;
++}
++
++static const struct dev_pm_ops ally_pm_ops = {
++	.thaw = ally_pm_thaw,
++	.suspend = ally_pm_suspend,
++	.poweroff = ally_pm_suspend,
++};
++
++MODULE_DEVICE_TABLE(hid, rog_ally_devices);
++
++static struct hid_driver rog_ally_cfg = { .name = "asus_rog_ally",
++		.id_table = rog_ally_devices,
++		.probe = ally_hid_probe,
++		.remove = ally_hid_remove,
++		.raw_event = ally_raw_event,
++		/* HID is the better place for resume functions, not pm_ops */
++		.resume = ally_hid_resume,
++		/* ALLy 1 requires this to reset device state correctly */
++		.reset_resume = ally_hid_reset_resume,
++		.driver = {
++			.pm = &ally_pm_ops,
++		}
++};
++
++static int __init rog_ally_init(void)
++{
++	return hid_register_driver(&rog_ally_cfg);
++}
++
++static void __exit rog_ally_exit(void)
++{
++	hid_unregister_driver(&rog_ally_cfg);
++}
++
++module_init(rog_ally_init);
++module_exit(rog_ally_exit);
++
++MODULE_IMPORT_NS("ASUS_WMI");
++MODULE_IMPORT_NS("HID_ASUS");
++MODULE_AUTHOR("Luke D. Jones");
++MODULE_DESCRIPTION("HID Driver for ASUS ROG Ally gamepad configuration.");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/hid/hid-asus-ally.h b/drivers/hid/hid-asus-ally.h
 new file mode 100644
-index 000000000000..fd9c788a4a42
+index 000000000..c83817589
 --- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally.h
-@@ -0,0 +1,314 @@
++++ b/drivers/hid/hid-asus-ally.h
+@@ -0,0 +1,398 @@
 +/* SPDX-License-Identifier: GPL-2.0-or-later
 + *
 + *  HID driver for Asus ROG laptops and Ally
@@ -3911,291 +2424,202 @@ index 000000000000..fd9c788a4a42
 + *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
 + */
 +
-+ #ifndef __ASUS_ALLY_H
-+ #define __ASUS_ALLY_H
-+
 +#include <linux/hid.h>
-+#include <linux/led-class-multicolor.h>
 +#include <linux/types.h>
 +
-+#define HID_ALLY_KEYBOARD_INTF_IN 0x81
-+#define HID_ALLY_MOUSE_INTF_IN 0x82
-+#define HID_ALLY_INTF_CFG_IN 0x83
-+#define HID_ALLY_X_INTF_IN 0x87
-+
-+#define HID_ALLY_REPORT_SIZE 64
-+#define HID_ALLY_GET_REPORT_ID 0x0D
-+#define HID_ALLY_SET_REPORT_ID 0x5A
-+#define HID_ALLY_SET_RGB_REPORT_ID 0x5D
-+#define HID_ALLY_FEATURE_CODE_PAGE 0xD1
-+
-+#define HID_ALLY_X_INPUT_REPORT 0x0B
-+#define HID_ALLY_X_INPUT_REPORT_SIZE 16
-+
-+enum ally_command_codes {
-+    CMD_SET_GAMEPAD_MODE            = 0x01,
-+    CMD_SET_MAPPING                 = 0x02,
-+    CMD_SET_JOYSTICK_MAPPING        = 0x03,
-+    CMD_SET_JOYSTICK_DEADZONE       = 0x04,
-+    CMD_SET_TRIGGER_RANGE           = 0x05,
-+    CMD_SET_VIBRATION_INTENSITY     = 0x06,
-+    CMD_LED_CONTROL                 = 0x08,
-+    CMD_CHECK_READY                 = 0x0A,
-+    CMD_SET_XBOX_CONTROLLER         = 0x0B,
-+    CMD_CHECK_XBOX_SUPPORT          = 0x0C,
-+    CMD_USER_CAL_DATA               = 0x0D,
-+    CMD_CHECK_USER_CAL_SUPPORT      = 0x0E,
-+    CMD_SET_TURBO_PARAMS            = 0x0F,
-+    CMD_CHECK_TURBO_SUPPORT         = 0x10,
-+    CMD_CHECK_RESP_CURVE_SUPPORT    = 0x12,
-+    CMD_SET_RESP_CURVE              = 0x13,
-+    CMD_CHECK_DIR_TO_BTN_SUPPORT    = 0x14,
-+    CMD_SET_GYRO_PARAMS             = 0x15,
-+    CMD_CHECK_GYRO_TO_JOYSTICK      = 0x16,
-+    CMD_CHECK_ANTI_DEADZONE         = 0x17,
-+    CMD_SET_ANTI_DEADZONE           = 0x18,
-+};
-+
-+enum ally_gamepad_mode {
-+	ALLY_GAMEPAD_MODE_GAMEPAD = 0x01,
-+	ALLY_GAMEPAD_MODE_KEYBOARD = 0x02,
-+};
-+
-+static const char *const gamepad_mode_names[] = {
-+	[ALLY_GAMEPAD_MODE_GAMEPAD] = "gamepad",
-+	[ALLY_GAMEPAD_MODE_KEYBOARD] = "keyboard"
-+};
-+
-+/* Button identifiers for the attribute system */
-+enum ally_button_id {
-+	ALLY_BTN_A,
-+	ALLY_BTN_B,
-+	ALLY_BTN_X,
-+	ALLY_BTN_Y,
-+	ALLY_BTN_LB,
-+	ALLY_BTN_RB,
-+	ALLY_BTN_DU,
-+	ALLY_BTN_DD,
-+	ALLY_BTN_DL,
-+	ALLY_BTN_DR,
-+	ALLY_BTN_J0B,
-+	ALLY_BTN_J1B,
-+	ALLY_BTN_MENU,
-+	ALLY_BTN_VIEW,
-+	ALLY_BTN_M1,
-+	ALLY_BTN_M2,
-+	ALLY_BTN_MAX
-+};
-+
-+/* Names for the button directories in sysfs */
-+static const char *const ally_button_names[ALLY_BTN_MAX] = {
-+	[ALLY_BTN_A] = "btn_a",
-+	[ALLY_BTN_B] = "btn_b",
-+	[ALLY_BTN_X] = "btn_x",
-+	[ALLY_BTN_Y] = "btn_y",
-+	[ALLY_BTN_LB] = "btn_lb",
-+	[ALLY_BTN_RB] = "btn_rb",
-+	[ALLY_BTN_DU] = "dpad_up",
-+	[ALLY_BTN_DD] = "dpad_down",
-+	[ALLY_BTN_DL] = "dpad_left",
-+	[ALLY_BTN_DR] = "dpad_right",
-+	[ALLY_BTN_J0B] = "btn_l3",
-+	[ALLY_BTN_J1B] = "btn_r3",
-+	[ALLY_BTN_MENU] = "btn_menu",
-+	[ALLY_BTN_VIEW] = "btn_view",
-+	[ALLY_BTN_M1] = "btn_m1",
-+	[ALLY_BTN_M2] = "btn_m2",
-+};
-+
-+struct ally_rgb_resume_data {
-+	uint8_t brightness;
-+	uint8_t red[4];
-+	uint8_t green[4];
-+	uint8_t blue[4];
-+	bool initialized;
-+};
-+
-+struct ally_rgb_dev {
-+	struct ally_handheld *ally;
-+	struct hid_device *hdev;
-+	struct led_classdev_mc led_rgb_dev;
-+	struct work_struct work;
-+	bool output_worker_initialized;
-+	spinlock_t lock;
-+
-+	bool removed;
-+	bool update_rgb;
-+	uint8_t red[4];
-+	uint8_t green[4];
-+	uint8_t blue[4];
-+};
-+
-+/* rumble packet structure */
-+struct ff_data {
-+	u8 enable;
-+	u8 magnitude_left;
-+	u8 magnitude_right;
-+	u8 magnitude_strong;
-+	u8 magnitude_weak;
-+	u8 pulse_sustain_10ms;
-+	u8 pulse_release_10ms;
-+	u8 loop_count;
-+} __packed;
-+
-+struct ff_report {
-+	u8 report_id;
-+	struct ff_data ff;
-+} __packed;
-+
-+struct ally_x_input {
-+	struct ally_handheld *ally;
-+	struct input_dev *input;
-+	struct hid_device *hdev;
-+	spinlock_t lock;
-+
-+	struct work_struct output_worker;
-+	bool output_worker_initialized;
-+
-+	/* Set if the left QAM emits Guide/Mode and right QAM emits Home + A chord */
-+	bool qam_mode;
-+	/* Prevent multiple queued event due to the enforced delay in worker */
-+	bool update_qam_chord;
-+
-+	struct ff_report *ff_packet;
-+	bool update_ff;
-+};
-+
-+struct resp_curve_param {
-+	u8 move;
-+	u8 resp;
-+} __packed;
-+
-+struct joystick_resp_curve {
-+	struct resp_curve_param entry_1;
-+	struct resp_curve_param entry_2;
-+	struct resp_curve_param entry_3;
-+	struct resp_curve_param entry_4;
-+} __packed;
-+
 +/*
-+ * Button turbo parameters structure
-+ * Each button can have:
-+ * - turbo: Turbo press interval in multiple of 50ms (0 = disabled, 1-20 = 50ms-1000ms)
-+ * - toggle: Toggle interval (0 = disabled)
++ * the xpad_mode is used inside the mode setting packet and is used
++ * for indexing (xpad_mode - 1)
 + */
-+struct button_turbo_params {
-+	u8 turbo;
-+	u8 toggle;
-+} __packed;
-+
-+/* Collection of all button turbo settings */
-+struct turbo_config {
-+	struct button_turbo_params btn_du;   /* D-pad Up */
-+	struct button_turbo_params btn_dd;   /* D-pad Down */
-+	struct button_turbo_params btn_dl;   /* D-pad Left */
-+	struct button_turbo_params btn_dr;   /* D-pad Right */
-+	struct button_turbo_params btn_j0b;  /* Left joystick button */
-+	struct button_turbo_params btn_j1b;  /* Right joystick button */
-+	struct button_turbo_params btn_lb;   /* Left bumper */
-+	struct button_turbo_params btn_rb;   /* Right bumper */
-+	struct button_turbo_params btn_a;    /* A button */
-+	struct button_turbo_params btn_b;    /* B button */
-+	struct button_turbo_params btn_x;    /* X button */
-+	struct button_turbo_params btn_y;    /* Y button */
-+	struct button_turbo_params btn_view; /* View button */
-+	struct button_turbo_params btn_menu; /* Menu button */
-+	struct button_turbo_params btn_m2;   /* M2 button */
-+	struct button_turbo_params btn_m1;   /* M1 button */
++enum xpad_mode {
++	xpad_mode_game = 0x01,
++	xpad_mode_wasd = 0x02,
++	xpad_mode_mouse = 0x03,
 +};
 +
-+struct ally_config {
-+	struct hid_device *hdev;
-+	/* Must be locked if the data is being changed */
-+	struct mutex config_mutex;
-+	bool initialized;
-+
-+	/* Device capabilities flags */
-+	bool is_ally_x;
-+	bool xbox_controller_support;
-+	bool user_cal_support;
-+	bool turbo_support;
-+	bool resp_curve_support;
-+	bool dir_to_btn_support;
-+	bool gyro_support;
-+	bool anti_deadzone_support;
-+
-+	/* Current settings */
-+	bool xbox_controller_enabled;
-+	u8 gamepad_mode;
-+	u8 left_deadzone;
-+	u8 left_outer_threshold;
-+	u8 right_deadzone;
-+	u8 right_outer_threshold;
-+	u8 left_anti_deadzone;
-+	u8 right_anti_deadzone;
-+	u8 left_trigger_min;
-+	u8 left_trigger_max;
-+	u8 right_trigger_min;
-+	u8 right_trigger_max;
-+
-+	/* Vibration settings */
-+	u8 vibration_intensity_left;
-+	u8 vibration_intensity_right;
-+	bool vibration_active;
-+
-+	struct turbo_config turbo;
-+	struct button_sysfs_entry *button_entries;
-+	void *button_mappings; /* ally_button_mapping array indexed by gamepad_mode */
-+
-+	struct joystick_resp_curve left_curve;
-+	struct joystick_resp_curve right_curve;
++/* the xpad_cmd determines which feature is set or queried */
++enum xpad_cmd {
++	xpad_cmd_set_mode = 0x01,
++	xpad_cmd_set_mapping = 0x02,
++	xpad_cmd_set_js_dz = 0x04, /* deadzones */
++	xpad_cmd_set_tr_dz = 0x05, /* deadzones */
++	xpad_cmd_set_vibe_intensity = 0x06,
++	xpad_cmd_set_leds = 0x08,
++	xpad_cmd_check_ready = 0x0A,
++	xpad_cmd_set_turbo = 0x0F,
++	xpad_cmd_set_response_curve = 0x13,
++	xpad_cmd_set_adz = 0x18,
 +};
 +
-+struct ally_handheld {
-+	/* All read/write to IN interfaces must lock */
-+	struct mutex intf_mutex;
-+	struct hid_device *cfg_hdev;
-+
-+	struct ally_rgb_dev *led_rgb_dev;
-+
-+	struct ally_x_input *ally_x_input;
-+
-+	struct hid_device *keyboard_hdev;
-+	struct input_dev *keyboard_input;
-+
-+	struct ally_config *config;
++/* the xpad_cmd determines which feature is set or queried */
++enum xpad_cmd_len {
++	xpad_cmd_len_mode = 0x01,
++	xpad_cmd_len_mapping = 0x2c,
++	xpad_cmd_len_deadzone = 0x04,
++	xpad_cmd_len_vibe_intensity = 0x02,
++	xpad_cmd_len_leds = 0x0C,
++	xpad_cmd_len_turbo = 0x20,
++	xpad_cmd_len_response_curve = 0x09,
++	xpad_cmd_len_adz = 0x02,
 +};
 +
-+int ally_gamepad_send_packet(struct ally_handheld *ally,
-+			     struct hid_device *hdev, const u8 *buf,
-+			     size_t len);
-+int ally_gamepad_send_receive_packet(struct ally_handheld *ally,
-+				     struct hid_device *hdev, u8 *buf,
-+				     size_t len);
-+int ally_gamepad_send_one_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command,
-+				      u8 param);
-+int ally_gamepad_send_two_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command,
-+				      u8 param1, u8 param2);
-+int ally_gamepad_check_ready(struct hid_device *hdev);
-+u8 get_endpoint_address(struct hid_device *hdev);
++/* Values correspond to the actual HID byte value required */
++enum btn_pair_index {
++	btn_pair_dpad_u_d = 0x01,
++	btn_pair_dpad_l_r = 0x02,
++	btn_pair_ls_rs = 0x03,
++	btn_pair_lb_rb = 0x04,
++	btn_pair_a_b = 0x05,
++	btn_pair_x_y = 0x06,
++	btn_pair_view_menu = 0x07,
++	btn_pair_m1_m2 = 0x08,
++	btn_pair_lt_rt = 0x09,
++};
 +
-+int ally_rgb_create(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_rgb_remove(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_rgb_store_settings(struct ally_handheld *ally);
-+void ally_rgb_resume(struct ally_handheld *ally);
++#define BTN_PAD_A             0x0101000000000000
++#define BTN_PAD_B             0x0102000000000000
++#define BTN_PAD_X             0x0103000000000000
++#define BTN_PAD_Y             0x0104000000000000
++#define BTN_PAD_LB            0x0105000000000000
++#define BTN_PAD_RB            0x0106000000000000
++#define BTN_PAD_LS            0x0107000000000000
++#define BTN_PAD_RS            0x0108000000000000
++#define BTN_PAD_DPAD_UP       0x0109000000000000
++#define BTN_PAD_DPAD_DOWN     0x010A000000000000
++#define BTN_PAD_DPAD_LEFT     0x010B000000000000
++#define BTN_PAD_DPAD_RIGHT    0x010C000000000000
++#define BTN_PAD_LT            0x010D000000000000
++#define BTN_PAD_RT            0x010E000000000000
++#define BTN_PAD_VIEW          0x0111000000000000
++#define BTN_PAD_MENU          0x0112000000000000
++#define BTN_PAD_XBOX          0x0113000000000000
 +
-+int ally_x_create(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_x_remove(struct hid_device *hdev, struct ally_handheld *ally);
-+bool ally_x_raw_event(struct ally_x_input *ally_x, struct hid_report *report, u8 *data,
-+			    int size);
++#define BTN_KB_M2             0x02008E0000000000
++#define BTN_KB_M1             0x02008F0000000000
++#define BTN_KB_ESC            0x0200760000000000
++#define BTN_KB_F1             0x0200500000000000
++#define BTN_KB_F2             0x0200600000000000
++#define BTN_KB_F3             0x0200400000000000
++#define BTN_KB_F4             0x02000C0000000000
++#define BTN_KB_F5             0x0200030000000000
++#define BTN_KB_F6             0x02000B0000000000
++#define BTN_KB_F7             0x0200800000000000
++#define BTN_KB_F8             0x02000A0000000000
++#define BTN_KB_F9             0x0200010000000000
++#define BTN_KB_F10            0x0200090000000000
++#define BTN_KB_F11            0x0200780000000000
++#define BTN_KB_F12            0x0200070000000000
++#define BTN_KB_F14            0x0200180000000000
++#define BTN_KB_F15            0x0200100000000000
++#define BTN_KB_BACKTICK       0x02000E0000000000
++#define BTN_KB_1              0x0200160000000000
++#define BTN_KB_2              0x02001E0000000000
++#define BTN_KB_3              0x0200260000000000
++#define BTN_KB_4              0x0200250000000000
++#define BTN_KB_5              0x02002E0000000000
++#define BTN_KB_6              0x0200360000000000
++#define BTN_KB_7              0x02003D0000000000
++#define BTN_KB_8              0x02003E0000000000
++#define BTN_KB_9              0x0200460000000000
++#define BTN_KB_0              0x0200450000000000
++#define BTN_KB_HYPHEN         0x02004E0000000000
++#define BTN_KB_EQUALS         0x0200550000000000
++#define BTN_KB_BACKSPACE      0x0200660000000000
++#define BTN_KB_TAB            0x02000D0000000000
++#define BTN_KB_Q              0x0200150000000000
++#define BTN_KB_W              0x02001D0000000000
++#define BTN_KB_E              0x0200240000000000
++#define BTN_KB_R              0x02002D0000000000
++#define BTN_KB_T              0x02002C0000000000
++#define BTN_KB_Y              0x0200350000000000
++#define BTN_KB_U              0x02003C0000000000
++#define BTN_KB_O              0x0200440000000000
++#define BTN_KB_P              0x02004D0000000000
++#define BTN_KB_LBRACKET       0x0200540000000000
++#define BTN_KB_RBRACKET       0x02005B0000000000
++#define BTN_KB_BACKSLASH      0x02005D0000000000
++#define BTN_KB_CAPS           0x0200580000000000
++#define BTN_KB_A              0x02001C0000000000
++#define BTN_KB_S              0x02001B0000000000
++#define BTN_KB_D              0x0200230000000000
++#define BTN_KB_F              0x02002B0000000000
++#define BTN_KB_G              0x0200340000000000
++#define BTN_KB_H              0x0200330000000000
++#define BTN_KB_J              0x02003B0000000000
++#define BTN_KB_K              0x0200420000000000
++#define BTN_KB_L              0x02004B0000000000
++#define BTN_KB_SEMI           0x02004C0000000000
++#define BTN_KB_QUOTE          0x0200520000000000
++#define BTN_KB_RET            0x02005A0000000000
++#define BTN_KB_LSHIFT         0x0200880000000000
++#define BTN_KB_Z              0x02001A0000000000
++#define BTN_KB_X              0x0200220000000000
++#define BTN_KB_C              0x0200210000000000
++#define BTN_KB_V              0x02002A0000000000
++#define BTN_KB_B              0x0200320000000000
++#define BTN_KB_N              0x0200310000000000
++#define BTN_KB_M              0x02003A0000000000
++#define BTN_KB_COMMA          0x0200410000000000
++#define BTN_KB_PERIOD         0x0200490000000000
++#define BTN_KB_RSHIFT         0x0200890000000000
++#define BTN_KB_LCTL           0x02008C0000000000
++#define BTN_KB_META           0x0200820000000000
++#define BTN_KB_LALT           0x02008A0000000000
++#define BTN_KB_SPACE          0x0200290000000000
++#define BTN_KB_RALT           0x02008B0000000000
++#define BTN_KB_MENU           0x0200840000000000
++#define BTN_KB_RCTL           0x02008D0000000000
++#define BTN_KB_PRNTSCN        0x0200C30000000000
++#define BTN_KB_SCRLCK         0x02007E0000000000
++#define BTN_KB_PAUSE          0x0200910000000000
++#define BTN_KB_INS            0x0200C20000000000
++#define BTN_KB_HOME           0x0200940000000000
++#define BTN_KB_PGUP           0x0200960000000000
++#define BTN_KB_DEL            0x0200C00000000000
++#define BTN_KB_END            0x0200950000000000
++#define BTN_KB_PGDWN          0x0200970000000000
++#define BTN_KB_UP_ARROW       0x0200980000000000
++#define BTN_KB_DOWN_ARROW     0x0200990000000000
++#define BTN_KB_LEFT_ARROW     0x0200910000000000
++#define BTN_KB_RIGHT_ARROW    0x02009B0000000000
 +
-+int ally_config_create(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_config_remove(struct hid_device *hdev, struct ally_handheld *ally);
++#define BTN_NUMPAD_LOCK       0x0200770000000000
++#define BTN_NUMPAD_FWDSLASH   0x0200900000000000
++#define BTN_NUMPAD_ASTERISK   0x02007C0000000000
++#define BTN_NUMPAD_HYPHEN     0x02007B0000000000
++#define BTN_NUMPAD_0          0x0200700000000000
++#define BTN_NUMPAD_1          0x0200690000000000
++#define BTN_NUMPAD_2          0x0200720000000000
++#define BTN_NUMPAD_3          0x02007A0000000000
++#define BTN_NUMPAD_4          0x02006B0000000000
++#define BTN_NUMPAD_5          0x0200730000000000
++#define BTN_NUMPAD_6          0x0200740000000000
++#define BTN_NUMPAD_7          0x02006C0000000000
++#define BTN_NUMPAD_8          0x0200750000000000
++#define BTN_NUMPAD_9          0x02007D0000000000
++#define BTN_NUMPAD_PLUS       0x0200790000000000
++#define BTN_NUMPAD_ENTER      0x0200810000000000
++#define BTN_NUMPAD_PERIOD     0x0200710000000000
 +
++#define BTN_MOUSE_LCLICK      0x0300000001000000
++#define BTN_MOUSE_RCLICK      0x0300000002000000
++#define BTN_MOUSE_MCLICK      0x0300000003000000
++#define BTN_MOUSE_WHEEL_UP    0x0300000004000000
++#define BTN_MOUSE_WHEEL_DOWN  0x0300000005000000
++
++#define BTN_MEDIA_SCREENSHOT      0x0500001600000000
++#define BTN_MEDIA_SHOW_KEYBOARD   0x0500001900000000
++#define BTN_MEDIA_SHOW_DESKTOP    0x0500001C00000000
++#define BTN_MEDIA_START_RECORDING 0x0500001E00000000
++#define BTN_MEDIA_MIC_OFF         0x0500000100000000
++#define BTN_MEDIA_VOL_DOWN        0x0500000200000000
++#define BTN_MEDIA_VOL_UP          0x0500000300000000
++
++#define ALLY_DEVICE_ATTR_WO(_name, _sysfs_name)    \
++	struct device_attribute dev_attr_##_name = \
++		__ATTR(_sysfs_name, 0200, NULL, _name##_store)
++
++/* required so we can have nested attributes with same name but different functions */
 +#define ALLY_DEVICE_ATTR_RW(_name, _sysfs_name)    \
 +	struct device_attribute dev_attr_##_name = \
 +		__ATTR(_sysfs_name, 0644, _name##_show, _name##_store)
@@ -4204,72 +2628,913 @@ index 000000000000..fd9c788a4a42
 +	struct device_attribute dev_attr_##_name = \
 +		__ATTR(_sysfs_name, 0444, _name##_show, NULL)
 +
-+#define ALLY_DEVICE_ATTR_WO(_name, _sysfs_name)    \
-+	struct device_attribute dev_attr_##_name = \
-+		__ATTR(_sysfs_name, 0200, NULL, _name##_store)
++/* button specific macros */
++#define ALLY_BTN_SHOW(_fname, _btn_name, _secondary)                           \
++	static ssize_t _fname##_show(struct device *dev,                       \
++				     struct device_attribute *attr, char *buf) \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		const char* name;                                              \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		name = btn_to_name(_secondary ? btn->macro : btn->button);     \
++		return sysfs_emit(buf, "%s\n", name);                          \
++	}
 +
-+#define ALLY_DEVICE_CONST_ATTR_RO(fname, sysfs_name, value)			\
-+	static ssize_t fname##_show(struct device *dev,				\
-+				   struct device_attribute *attr, char *buf)	\
-+	{									\
-+		return sprintf(buf, value);					\
-+	}									\
-+	struct device_attribute dev_attr_##fname =				\
-+		__ATTR(sysfs_name, 0444, fname##_show, NULL)
++#define ALLY_BTN_STORE(_fname, _btn_name, _secondary)                          \
++	static ssize_t _fname##_store(struct device *dev,                      \
++				      struct device_attribute *attr,           \
++				      const char *buf, size_t count)           \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		u64 code;                                                      \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		code = name_to_btn(buf);                                       \
++		if (_secondary)                                                \
++			btn->macro = code;                                     \
++		else                                                           \
++			btn->button = code;                                    \
++		return count;                                                  \
++	}
 +
-+#endif /* __ASUS_ALLY_H */
++#define ALLY_TURBO_SHOW(_fname, _btn_name)                                     \
++	static ssize_t _fname##_show(struct device *dev,                       \
++				     struct device_attribute *attr, char *buf) \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		return sysfs_emit(buf, "%d\n", btn->turbo);                    \
++	}
++
++#define ALLY_TURBO_STORE(_fname, _btn_name)                                    \
++	static ssize_t _fname##_store(struct device *dev,                      \
++				      struct device_attribute *attr,           \
++				      const char *buf, size_t count)           \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		bool turbo;                                                    \
++		int ret; \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		ret = kstrtobool(buf, &turbo);                                 \
++		if (ret)                                                       \
++			return ret;                                            \
++		btn->turbo = turbo;                                            \
++		return count;                                                  \
++	}
++
++#define ALLY_DEADZONE_SHOW(_fname, _axis_name)                                 \
++	static ssize_t _fname##_show(struct device *dev,                       \
++				     struct device_attribute *attr, char *buf) \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct deadzone *dz;                                           \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		dz = &ally_cfg->_axis_name;                                    \
++		return sysfs_emit(buf, "%d %d\n", dz->inner, dz->outer);       \
++	}
++
++#define ALLY_DEADZONE_STORE(_fname, _axis_name)                                \
++	static ssize_t _fname##_store(struct device *dev,                      \
++				      struct device_attribute *attr,           \
++				      const char *buf, size_t count)           \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct hid_device *hdev = to_hid_device(dev);                  \
++		u32 inner, outer;                                              \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		if (sscanf(buf, "%d %d", &inner, &outer) != 2)                 \
++			return -EINVAL;                                        \
++		if (inner > 64 || outer > 64 || inner > outer)                 \
++			return -EINVAL;                                        \
++		ally_cfg->_axis_name.inner = inner;                            \
++		ally_cfg->_axis_name.outer = outer;                            \
++		_gamepad_apply_deadzones(hdev, ally_cfg);                      \
++		return count;                                                  \
++	}
++
++#define ALLY_DEADZONES(_fname, _mname)                                    \
++	ALLY_DEADZONE_SHOW(_fname##_deadzone, _mname);                    \
++	ALLY_DEADZONE_STORE(_fname##_deadzone, _mname);                   \
++	ALLY_DEVICE_ATTR_RW(_fname##_deadzone, deadzone)
++
++/* response curve macros */
++#define ALLY_RESP_CURVE_SHOW(_fname, _mname)                             \
++static ssize_t _fname##_show(struct device *dev,                         \
++			struct device_attribute *attr,                   \
++			char *buf)                                       \
++	{                                                                \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg; \
++		if (!drvdata.gamepad_cfg)                                \
++			return -ENODEV;                                  \
++		return sysfs_emit(buf, "%d\n", ally_cfg->ls_rc._mname);  \
++	}
++
++#define ALLY_RESP_CURVE_STORE(_fname, _mname)                            \
++static ssize_t _fname##_store(struct device *dev,                        \
++			struct device_attribute *attr,                   \
++			const char *buf, size_t count)                   \
++	{                                                                \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg; \
++		int ret, val;                                            \
++		if (!drvdata.gamepad_cfg)                                \
++			return -ENODEV;                                  \
++		ret = kstrtoint(buf, 0, &val);                           \
++		if (ret)                                                 \
++			return ret;                                      \
++		if (val < 0 || val > 100)                                \
++			return -EINVAL;                                  \
++		ally_cfg->ls_rc._mname = val;                            \
++		return count;                                            \
++	}
++
++/* _point_n must start at 1 */
++#define ALLY_JS_RC_POINT(_fname, _mname, _num)                                 \
++	ALLY_RESP_CURVE_SHOW(_fname##_##_mname##_##_num, _mname##_pct_##_num); \
++	ALLY_RESP_CURVE_STORE(_fname##_##_mname##_##_num, _mname##_pct_##_num); \
++	ALLY_DEVICE_ATTR_RW(_fname##_##_mname##_##_num, curve_##_mname##_pct_##_num)
++
++#define ALLY_BTN_ATTRS_GROUP(_name, _fname)                               \
++	static struct attribute *_fname##_attrs[] = {                     \
++		&dev_attr_##_fname.attr,                                  \
++		&dev_attr_##_fname##_macro.attr,                          \
++	};                                                                \
++	static const struct attribute_group _fname##_attr_group = {       \
++		.name = __stringify(_name),                               \
++		.attrs = _fname##_attrs,                                  \
++	}
++
++#define _ALLY_BTN_REMAP(_fname, _btn_name)                              \
++	ALLY_BTN_SHOW(btn_mapping_##_fname##_remap, _btn_name, false);  \
++	ALLY_BTN_STORE(btn_mapping_##_fname##_remap, _btn_name, false); \
++	ALLY_DEVICE_ATTR_RW(btn_mapping_##_fname##_remap, remap);
++
++#define _ALLY_BTN_MACRO(_fname, _btn_name)                             \
++	ALLY_BTN_SHOW(btn_mapping_##_fname##_macro, _btn_name, true);  \
++	ALLY_BTN_STORE(btn_mapping_##_fname##_macro, _btn_name, true); \
++	ALLY_DEVICE_ATTR_RW(btn_mapping_##_fname##_macro, macro_remap);
++
++#define ALLY_BTN_MAPPING(_fname, _btn_name)                                       \
++	_ALLY_BTN_REMAP(_fname, _btn_name)                                        \
++	_ALLY_BTN_MACRO(_fname, _btn_name)                                        \
++	static struct attribute *_fname##_attrs[] = {                             \
++		&dev_attr_btn_mapping_##_fname##_remap.attr,                      \
++		&dev_attr_btn_mapping_##_fname##_macro.attr,                      \
++		NULL,                                                             \
++	};                                                                        \
++	static const struct attribute_group btn_mapping_##_fname##_attr_group = { \
++		.name = __stringify(btn_##_fname),                                \
++		.attrs = _fname##_attrs,                                          \
++	}
++
++#define ALLY_TURBO_BTN_MAPPING(_fname, _btn_name)                                 \
++	_ALLY_BTN_REMAP(_fname, _btn_name)                                        \
++	_ALLY_BTN_MACRO(_fname, _btn_name)                                        \
++	ALLY_TURBO_SHOW(btn_mapping_##_fname##_turbo, _btn_name);                 \
++	ALLY_TURBO_STORE(btn_mapping_##_fname##_turbo, _btn_name);                \
++	ALLY_DEVICE_ATTR_RW(btn_mapping_##_fname##_turbo, turbo);                 \
++	static struct attribute *_fname##_turbo_attrs[] = {                       \
++		&dev_attr_btn_mapping_##_fname##_remap.attr,                      \
++		&dev_attr_btn_mapping_##_fname##_macro.attr,                      \
++		&dev_attr_btn_mapping_##_fname##_turbo.attr,                      \
++		NULL,                                                             \
++	};                                                                        \
++	static const struct attribute_group btn_mapping_##_fname##_attr_group = { \
++		.name = __stringify(btn_##_fname),                                \
++		.attrs = _fname##_turbo_attrs,                                    \
++	}
 diff --git a/drivers/hid/hid-asus.c b/drivers/hid/hid-asus.c
-index 599c836507ff..52882d6589e1 100644
+index 599c83650..4805d1505 100644
 --- a/drivers/hid/hid-asus.c
 +++ b/drivers/hid/hid-asus.c
-@@ -624,6 +624,9 @@ static void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
- 		hid_warn(hdev,
- 			"The MCU firmware version must be %d or greater to avoid issues with suspend.\n",
- 			min_version);
-+	} else {
-+		set_ally_mcu_hack(ASUS_WMI_ALLY_MCU_HACK_DISABLED);
-+		set_ally_mcu_powersave(true);
+@@ -23,6 +23,8 @@
+ /*
+  */
+ 
++#include <linux/array_size.h>
++#include "linux/export.h"
+ #include <linux/dmi.h>
+ #include <linux/hid.h>
+ #include <linux/module.h>
+@@ -30,9 +32,11 @@
+ #include <linux/input/mt.h>
+ #include <linux/usb.h> /* For to_usb_interface for T100 touchpad intf check */
+ #include <linux/power_supply.h>
++#include <linux/led-class-multicolor.h>
+ #include <linux/leds.h>
+ 
+ #include "hid-ids.h"
++#include "hid-asus.h"
+ 
+ MODULE_AUTHOR("Yusuke Fujimaki <usk.fujimaki@gmail.com>");
+ MODULE_AUTHOR("Brendan McGrath <redmcg@redmandi.dyndns.org>");
+@@ -47,10 +51,12 @@ MODULE_DESCRIPTION("Asus HID Keyboard and TouchPad");
+ #define T100CHI_MOUSE_REPORT_ID 0x06
+ #define FEATURE_REPORT_ID 0x0d
+ #define INPUT_REPORT_ID 0x5d
++#define HID_USAGE_PAGE_VENDOR 0xff310000
+ #define FEATURE_KBD_REPORT_ID 0x5a
+-#define FEATURE_KBD_REPORT_SIZE 16
++#define FEATURE_KBD_REPORT_SIZE 64
+ #define FEATURE_KBD_LED_REPORT_ID1 0x5d
+ #define FEATURE_KBD_LED_REPORT_ID2 0x5e
++#define FEATURE_KBD_LED_REPORT_SIZE 7
+ 
+ #define ROG_ALLY_REPORT_SIZE 64
+ #define ROG_ALLY_X_MIN_MCU 313
+@@ -89,6 +95,9 @@ MODULE_DESCRIPTION("Asus HID Keyboard and TouchPad");
+ #define QUIRK_ROG_NKEY_KEYBOARD		BIT(11)
+ #define QUIRK_ROG_CLAYMORE_II_KEYBOARD BIT(12)
+ #define QUIRK_ROG_ALLY_XPAD		BIT(13)
++#define QUIRK_HANDLE_GENERIC		BIT(14)
++#define QUIRK_ROG_NKEY_RGB		BIT(15)
++#define QUIRK_ROG_NKEY_LEGACY		BIT(16)
+ 
+ #define I2C_KEYBOARD_QUIRKS			(QUIRK_FIX_NOTEBOOK_REPORT | \
+ 						 QUIRK_NO_INIT_REPORTS | \
+@@ -100,10 +109,16 @@ MODULE_DESCRIPTION("Asus HID Keyboard and TouchPad");
+ #define TRKID_SGN       ((TRKID_MAX + 1) >> 1)
+ 
+ struct asus_kbd_leds {
+-	struct led_classdev cdev;
++	struct asus_hid_listener listener;
++	struct led_classdev_mc mc_led;
++	struct mc_subled subled_info[3];
+ 	struct hid_device *hdev;
+ 	struct work_struct work;
+ 	unsigned int brightness;
++	u8 rgb_colors[3];
++	bool rgb_init;
++	bool rgb_set;
++	bool rgb_registered;
+ 	spinlock_t lock;
+ 	bool removed;
+ };
+@@ -125,7 +140,6 @@ struct asus_drvdata {
+ 	struct input_dev *tp_kbd_input;
+ 	struct asus_kbd_leds *kbd_backlight;
+ 	const struct asus_touchpad_info *tp;
+-	bool enable_backlight;
+ 	struct power_supply *battery;
+ 	struct power_supply_desc battery_desc;
+ 	int battery_capacity;
+@@ -316,13 +330,24 @@ static int asus_e1239t_event(struct asus_drvdata *drvdat, u8 *data, int size)
+ static int asus_event(struct hid_device *hdev, struct hid_field *field,
+ 		      struct hid_usage *usage, __s32 value)
+ {
+-	if ((usage->hid & HID_USAGE_PAGE) == 0xff310000 &&
++	if ((usage->hid & HID_USAGE_PAGE) == HID_USAGE_PAGE_VENDOR &&
+ 	    (usage->hid & HID_USAGE) != 0x00 &&
+ 	    (usage->hid & HID_USAGE) != 0xff && !usage->type) {
+ 		hid_warn(hdev, "Unmapped Asus vendor usagepage code 0x%02x\n",
+ 			 usage->hid & HID_USAGE);
  	}
+ 
++	if (usage->type == EV_KEY && value) {
++		switch (usage->code) {
++		case KEY_KBDILLUMUP:
++			return !asus_hid_event(ASUS_EV_BRTUP);
++		case KEY_KBDILLUMDOWN:
++			return !asus_hid_event(ASUS_EV_BRTDOWN);
++		case KEY_KBDILLUMTOGGLE:
++			return !asus_hid_event(ASUS_EV_BRTTOGGLE);
++		}
++	}
++
+ 	return 0;
  }
  
-@@ -1381,12 +1384,17 @@ static const struct hid_device_id asus_devices[] = {
+@@ -331,6 +356,10 @@ static int asus_raw_event(struct hid_device *hdev,
+ {
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return 0;
++
+ 	if (drvdata->battery && data[0] == BATTERY_REPORT_ID)
+ 		return asus_report_battery(drvdata, data, size);
+ 
+@@ -393,14 +422,37 @@ static int asus_kbd_set_report(struct hid_device *hdev, const u8 *buf, size_t bu
+ 
+ static int asus_kbd_init(struct hid_device *hdev, u8 report_id)
+ {
+-	const u8 buf[] = { report_id, 0x41, 0x53, 0x55, 0x53, 0x20, 0x54,
+-		     0x65, 0x63, 0x68, 0x2e, 0x49, 0x6e, 0x63, 0x2e, 0x00 };
++	/*
++	 * The handshake is first sent as a set_report, then retrieved
++	 * from a get_report. They should be equal.
++	 */
++	const u8 buf[] = { report_id, 0x41, 0x53, 0x55, 0x53, 0x20,
++		0x54, 0x65, 0x63, 0x68, 0x2e, 0x49, 0x6e, 0x63, 0x2e, 0x00 };
++	u8 *readbuf;
+ 	int ret;
+ 
+ 	ret = asus_kbd_set_report(hdev, buf, sizeof(buf));
+-	if (ret < 0)
+-		hid_err(hdev, "Asus failed to send init command: %d\n", ret);
++	if (ret < 0) {
++		hid_err(hdev, "Asus failed to send handshake: %d\n", ret);
++		return ret;
++	}
++
++	readbuf = kzalloc(FEATURE_KBD_REPORT_SIZE, GFP_KERNEL);
++	if (!readbuf)
++		return -ENOMEM;
++
++	ret = hid_hw_raw_request(hdev, report_id, readbuf,
++				 FEATURE_KBD_REPORT_SIZE, HID_FEATURE_REPORT,
++				 HID_REQ_GET_REPORT);
++	if (ret < 0) {
++		hid_err(hdev, "Asus failed to receive handshake ack: %d\n", ret);
++	} else if (memcmp(readbuf, buf, sizeof(buf)) != 0) {
++		hid_warn(hdev, "Asus handshake returned invalid response: %*ph\n",
++			FEATURE_KBD_REPORT_SIZE, readbuf);
++		// Do not return error if handshake is wrong to avoid regressions
++	}
+ 
++	kfree(readbuf);
+ 	return ret;
+ }
+ 
+@@ -422,7 +474,7 @@ static int asus_kbd_get_functions(struct hid_device *hdev,
+ 	if (!readbuf)
+ 		return -ENOMEM;
+ 
+-	ret = hid_hw_raw_request(hdev, FEATURE_KBD_REPORT_ID, readbuf,
++	ret = hid_hw_raw_request(hdev, report_id, readbuf,
+ 				 FEATURE_KBD_REPORT_SIZE, HID_FEATURE_REPORT,
+ 				 HID_REQ_GET_REPORT);
+ 	if (ret < 0) {
+@@ -467,11 +519,8 @@ static void asus_schedule_work(struct asus_kbd_leds *led)
+ 	spin_unlock_irqrestore(&led->lock, flags);
+ }
+ 
+-static void asus_kbd_backlight_set(struct led_classdev *led_cdev,
+-				   enum led_brightness brightness)
++static void do_asus_kbd_backlight_set(struct asus_kbd_leds *led, int brightness)
+ {
+-	struct asus_kbd_leds *led = container_of(led_cdev, struct asus_kbd_leds,
+-						 cdev);
+ 	unsigned long flags;
+ 
+ 	spin_lock_irqsave(&led->lock, flags);
+@@ -481,13 +530,47 @@ static void asus_kbd_backlight_set(struct led_classdev *led_cdev,
+ 	asus_schedule_work(led);
+ }
+ 
+-static enum led_brightness asus_kbd_backlight_get(struct led_classdev *led_cdev)
++static void asus_kbd_listener_set(struct asus_hid_listener *listener,
++				   int brightness)
++{
++	struct asus_kbd_leds *led = container_of(listener, struct asus_kbd_leds,
++						 listener);
++	do_asus_kbd_backlight_set(led, brightness);
++	if (led->rgb_registered) {
++		led->mc_led.led_cdev.brightness = brightness;
++		led_classdev_notify_brightness_hw_changed(&led->mc_led.led_cdev,
++							  brightness);
++	}
++}
++
++static void asus_kbd_brightness_set(struct led_classdev *led_cdev,
++				    enum led_brightness brightness)
++{
++	struct led_classdev_mc *mc_cdev = lcdev_to_mccdev(led_cdev);
++	struct asus_kbd_leds *led = container_of(mc_cdev, struct asus_kbd_leds,
++						 mc_led);
++	unsigned long flags;
++
++	spin_lock_irqsave(&led->lock, flags);
++	led->rgb_colors[0] = mc_cdev->subled_info[0].intensity;
++	led->rgb_colors[1] = mc_cdev->subled_info[1].intensity;
++	led->rgb_colors[2] = mc_cdev->subled_info[2].intensity;
++	led->rgb_set = true;
++	spin_unlock_irqrestore(&led->lock, flags);
++
++	do_asus_kbd_backlight_set(led, brightness);
++}
++
++static enum led_brightness asus_kbd_brightness_get(struct led_classdev *led_cdev)
+ {
+-	struct asus_kbd_leds *led = container_of(led_cdev, struct asus_kbd_leds,
+-						 cdev);
++	struct led_classdev_mc *mc_led;
++	struct asus_kbd_leds *led;
+ 	enum led_brightness brightness;
+ 	unsigned long flags;
+ 
++	mc_led = lcdev_to_mccdev(led_cdev);
++	led = container_of(mc_led, struct asus_kbd_leds, mc_led);
++
+ 	spin_lock_irqsave(&led->lock, flags);
+ 	brightness = led->brightness;
+ 	spin_unlock_irqrestore(&led->lock, flags);
+@@ -495,9 +578,8 @@ static enum led_brightness asus_kbd_backlight_get(struct led_classdev *led_cdev)
+ 	return brightness;
+ }
+ 
+-static void asus_kbd_backlight_work(struct work_struct *work)
++static void asus_kbd_backlight_work(struct asus_kbd_leds *led)
+ {
+-	struct asus_kbd_leds *led = container_of(work, struct asus_kbd_leds, work);
+ 	u8 buf[] = { FEATURE_KBD_REPORT_ID, 0xba, 0xc5, 0xc4, 0x00 };
+ 	int ret;
+ 	unsigned long flags;
+@@ -511,34 +593,6 @@ static void asus_kbd_backlight_work(struct work_struct *work)
+ 		hid_err(led->hdev, "Asus failed to set keyboard backlight: %d\n", ret);
+ }
+ 
+-/* WMI-based keyboard backlight LED control (via asus-wmi driver) takes
+- * precedence. We only activate HID-based backlight control when the
+- * WMI control is not available.
+- */
+-static bool asus_kbd_wmi_led_control_present(struct hid_device *hdev)
+-{
+-	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+-	u32 value;
+-	int ret;
+-
+-	if (!IS_ENABLED(CONFIG_ASUS_WMI))
+-		return false;
+-
+-	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD &&
+-			dmi_check_system(asus_use_hid_led_dmi_ids)) {
+-		hid_info(hdev, "using HID for asus::kbd_backlight\n");
+-		return false;
+-	}
+-
+-	ret = asus_wmi_evaluate_method(ASUS_WMI_METHODID_DSTS,
+-				       ASUS_WMI_DEVID_KBD_BACKLIGHT, 0, &value);
+-	hid_dbg(hdev, "WMI backlight check: rc %d value %x", ret, value);
+-	if (ret)
+-		return false;
+-
+-	return !!(value & ASUS_WMI_DSTS_PRESENCE_BIT);
+-}
+-
+ /*
+  * We don't care about any other part of the string except the version section.
+  * Example strings: FGA80100.RC72LA.312_T01, FGA80100.RC71LS.318_T01
+@@ -601,7 +655,7 @@ static int mcu_request_version(struct hid_device *hdev)
+ 	return ret;
+ }
+ 
+-static void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
++void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
+ {
+ 	int min_version, version;
+ 
+@@ -626,58 +680,112 @@ static void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
+ 			min_version);
+ 	}
+ }
++EXPORT_SYMBOL_NS(validate_mcu_fw_version, "HID_ASUS");
++
++static void asus_kbd_rgb_work(struct asus_kbd_leds *led)
++{
++	u8 rgb_buf[][FEATURE_KBD_LED_REPORT_SIZE] = {
++		{ FEATURE_KBD_LED_REPORT_ID1, 0xB3 }, /* set mode */
++		{ FEATURE_KBD_LED_REPORT_ID1, 0xB5 }, /* apply mode */
++		{ FEATURE_KBD_LED_REPORT_ID1, 0xB4 }, /* save to mem */
++	};
++	unsigned long flags;
++	uint8_t colors[3];
++	bool rgb_init, rgb_set;
++	int ret;
++
++	spin_lock_irqsave(&led->lock, flags);
++	rgb_init = led->rgb_init;
++	rgb_set = led->rgb_set;
++	led->rgb_set = false;
++	colors[0] = led->rgb_colors[0];
++	colors[1] = led->rgb_colors[1];
++	colors[2] = led->rgb_colors[2];
++	spin_unlock_irqrestore(&led->lock, flags);
++
++	if (!rgb_set)
++		return;
++
++	if (rgb_init) {
++		ret = asus_kbd_init(led->hdev, FEATURE_KBD_LED_REPORT_ID1);
++		if (ret < 0) {
++			hid_err(led->hdev, "Asus failed to init RGB: %d\n", ret);
++			return;
++		}
++		spin_lock_irqsave(&led->lock, flags);
++		led->rgb_init = false;
++		spin_unlock_irqrestore(&led->lock, flags);
++	}
++
++	/* Protocol is: 54b3 zone (0=all) mode (0=solid) RGB */
++	rgb_buf[0][4] = colors[0];
++	rgb_buf[0][5] = colors[1];
++	rgb_buf[0][6] = colors[2];
++
++	for (size_t i = 0; i < ARRAY_SIZE(rgb_buf); i++) {
++		ret = asus_kbd_set_report(led->hdev, rgb_buf[i], sizeof(rgb_buf[i]));
++		if (ret < 0) {
++			hid_err(led->hdev, "Asus failed to set RGB: %d\n", ret);
++			return;
++		}
++	}
++}
++
++static void asus_kbd_work(struct work_struct *work)
++{
++	struct asus_kbd_leds *led = container_of(work, struct asus_kbd_leds,
++						 work);
++	asus_kbd_backlight_work(led);
++	asus_kbd_rgb_work(led);
++}
+ 
+ static int asus_kbd_register_leds(struct hid_device *hdev)
+ {
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+-	struct usb_interface *intf;
+-	struct usb_device *udev;
++	struct asus_kbd_leds *leds;
+ 	unsigned char kbd_func;
++	bool rgb_init = true;
+ 	int ret;
+ 
+-	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD) {
+-		/* Initialize keyboard */
+-		ret = asus_kbd_init(hdev, FEATURE_KBD_REPORT_ID);
+-		if (ret < 0)
+-			return ret;
++	ret = asus_kbd_init(hdev, FEATURE_KBD_REPORT_ID);
++	if (ret < 0)
++		return ret;
+ 
+-		/* The LED endpoint is initialised in two HID */
++	if (drvdata->quirks & QUIRK_ROG_NKEY_LEGACY) {
++		/*
++		 * These keyboards might need 0x5d for shortcuts to work.
++		 * As it has been more than 5 years, it is hard to verify.
++		 */
+ 		ret = asus_kbd_init(hdev, FEATURE_KBD_LED_REPORT_ID1);
+ 		if (ret < 0)
+ 			return ret;
+ 
+-		ret = asus_kbd_init(hdev, FEATURE_KBD_LED_REPORT_ID2);
+-		if (ret < 0)
+-			return ret;
+-
+-		if (dmi_match(DMI_PRODUCT_FAMILY, "ProArt P16")) {
+-			ret = asus_kbd_disable_oobe(hdev);
+-			if (ret < 0)
+-				return ret;
+-		}
+-
+-		if (drvdata->quirks & QUIRK_ROG_ALLY_XPAD) {
+-			intf = to_usb_interface(hdev->dev.parent);
+-			udev = interface_to_usbdev(intf);
+-			validate_mcu_fw_version(hdev,
+-				le16_to_cpu(udev->descriptor.idProduct));
+-		}
++		rgb_init = false;
++	}
+ 
+-	} else {
+-		/* Initialize keyboard */
+-		ret = asus_kbd_init(hdev, FEATURE_KBD_REPORT_ID);
+-		if (ret < 0)
+-			return ret;
++	/* Get keyboard functions */
++	ret = asus_kbd_get_functions(hdev, &kbd_func, FEATURE_KBD_REPORT_ID);
++	if (ret < 0)
++		return ret;
+ 
+-		/* Get keyboard functions */
+-		ret = asus_kbd_get_functions(hdev, &kbd_func, FEATURE_KBD_REPORT_ID);
++	if (dmi_match(DMI_PRODUCT_FAMILY, "ProArt P16")) {
++		ret = asus_kbd_disable_oobe(hdev);
+ 		if (ret < 0)
+ 			return ret;
++	}
+ 
+-		/* Check for backlight support */
+-		if (!(kbd_func & SUPPORT_KBD_BACKLIGHT))
+-			return -ENODEV;
++#if !IS_REACHABLE(CONFIG_HID_ASUS_ALLY)
++	if (drvdata->quirks & QUIRK_ROG_ALLY_XPAD) {
++		struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
++		struct usb_device *udev = interface_to_usbdev(intf);
++		validate_mcu_fw_version(
++			hdev, le16_to_cpu(udev->descriptor.idProduct));
+ 	}
++#endif
++
++	/* Check for backlight support */
++	if (!(kbd_func & SUPPORT_KBD_BACKLIGHT))
++		return -ENODEV;
+ 
+ 	drvdata->kbd_backlight = devm_kzalloc(&hdev->dev,
+ 					      sizeof(struct asus_kbd_leds),
+@@ -685,23 +793,47 @@ static int asus_kbd_register_leds(struct hid_device *hdev)
+ 	if (!drvdata->kbd_backlight)
+ 		return -ENOMEM;
+ 
+-	drvdata->kbd_backlight->removed = false;
+-	drvdata->kbd_backlight->brightness = 0;
+-	drvdata->kbd_backlight->hdev = hdev;
+-	drvdata->kbd_backlight->cdev.name = "asus::kbd_backlight";
+-	drvdata->kbd_backlight->cdev.max_brightness = 3;
+-	drvdata->kbd_backlight->cdev.brightness_set = asus_kbd_backlight_set;
+-	drvdata->kbd_backlight->cdev.brightness_get = asus_kbd_backlight_get;
+-	INIT_WORK(&drvdata->kbd_backlight->work, asus_kbd_backlight_work);
++	leds = drvdata->kbd_backlight;
++	leds->removed = false;
++	leds->brightness = ASUS_EV_MAX_BRIGHTNESS;
++	leds->hdev = hdev;
++	leds->listener.brightness_set = asus_kbd_listener_set;
++
++	leds->rgb_colors[0] = 0;
++	leds->rgb_colors[1] = 0;
++	leds->rgb_colors[2] = 0;
++	leds->rgb_init = rgb_init;
++	leds->rgb_set = false;
++	leds->mc_led.led_cdev.name = devm_kasprintf(&hdev->dev, GFP_KERNEL,
++					"asus-%s:rgb:peripheral",
++					strlen(hdev->uniq) ?
++					hdev->uniq : dev_name(&hdev->dev));
++	leds->mc_led.led_cdev.flags = LED_BRIGHT_HW_CHANGED;
++	leds->mc_led.led_cdev.max_brightness = ASUS_EV_MAX_BRIGHTNESS;
++	leds->mc_led.led_cdev.brightness_set = asus_kbd_brightness_set;
++	leds->mc_led.led_cdev.brightness_get = asus_kbd_brightness_get;
++	leds->mc_led.subled_info = leds->subled_info;
++	leds->mc_led.num_colors = ARRAY_SIZE(leds->subled_info);
++	leds->subled_info[0].color_index = LED_COLOR_ID_RED;
++	leds->subled_info[1].color_index = LED_COLOR_ID_GREEN;
++	leds->subled_info[2].color_index = LED_COLOR_ID_BLUE;
++
++	INIT_WORK(&drvdata->kbd_backlight->work, asus_kbd_work);
+ 	spin_lock_init(&drvdata->kbd_backlight->lock);
+ 
+-	ret = devm_led_classdev_register(&hdev->dev, &drvdata->kbd_backlight->cdev);
+-	if (ret < 0) {
+-		/* No need to have this still around */
+-		devm_kfree(&hdev->dev, drvdata->kbd_backlight);
++	ret = asus_hid_register_listener(&drvdata->kbd_backlight->listener);
++	/* Asus-wmi might not be accessible so this is not fatal. */
++	if (!ret)
++		hid_warn(hdev, "Asus-wmi brightness listener not registered\n");
++
++	if (drvdata->quirks & QUIRK_ROG_NKEY_RGB) {
++		ret = devm_led_classdev_multicolor_register(&hdev->dev, &leds->mc_led);
++		if (!ret)
++			leds->rgb_registered = true;
++		return ret;
+ 	}
+ 
+-	return ret;
++	return 0;
+ }
+ 
+ /*
+@@ -867,6 +999,10 @@ static int asus_input_configured(struct hid_device *hdev, struct hid_input *hi)
+ 	struct input_dev *input = hi->input;
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return 0;
++
+ 	/* T100CHI uses MULTI_INPUT, bind the touchpad to the mouse hid_input */
+ 	if (drvdata->quirks & QUIRK_T100CHI &&
+ 	    hi->report->id != T100CHI_MOUSE_REPORT_ID)
+@@ -920,11 +1056,6 @@ static int asus_input_configured(struct hid_device *hdev, struct hid_input *hi)
+ 
+ 	drvdata->input = input;
+ 
+-	if (drvdata->enable_backlight &&
+-	    !asus_kbd_wmi_led_control_present(hdev) &&
+-	    asus_kbd_register_leds(hdev))
+-		hid_warn(hdev, "Failed to initialize backlight.\n");
+-
+ 	return 0;
+ }
+ 
+@@ -944,6 +1075,10 @@ static int asus_input_mapping(struct hid_device *hdev,
+ 		return -1;
+ 	}
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return 0;
++
+ 	/*
+ 	 * Ignore a bunch of bogus collections in the T100CHI descriptor.
+ 	 * This avoids a bunch of non-functional hid_input devices getting
+@@ -994,15 +1129,6 @@ static int asus_input_mapping(struct hid_device *hdev,
+ 			return -1;
+ 		}
+ 
+-		/*
+-		 * Check and enable backlight only on devices with UsagePage ==
+-		 * 0xff31 to avoid initializing the keyboard firmware multiple
+-		 * times on devices with multiple HID descriptors but same
+-		 * PID/VID.
+-		 */
+-		if (drvdata->quirks & QUIRK_USE_KBD_BACKLIGHT)
+-			drvdata->enable_backlight = true;
+-
+ 		set_bit(EV_REP, hi->input->evbit);
+ 		return 1;
+ 	}
+@@ -1095,7 +1221,7 @@ static int __maybe_unused asus_resume(struct hid_device *hdev) {
+ 
+ 	if (drvdata->kbd_backlight) {
+ 		const u8 buf[] = { FEATURE_KBD_REPORT_ID, 0xba, 0xc5, 0xc4,
+-				drvdata->kbd_backlight->cdev.brightness };
++				drvdata->kbd_backlight->brightness };
+ 		ret = asus_kbd_set_report(hdev, buf, sizeof(buf));
+ 		if (ret < 0) {
+ 			hid_err(hdev, "Asus failed to set keyboard backlight: %d\n", ret);
+@@ -1119,8 +1245,12 @@ static int __maybe_unused asus_reset_resume(struct hid_device *hdev)
+ 
+ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ {
+-	int ret;
++	struct hid_report_enum *rep_enum;
+ 	struct asus_drvdata *drvdata;
++	struct usb_host_endpoint *ep;
++	struct usb_interface *intf;
++	struct hid_report *rep;
++	int ret, is_vendor = 0;
+ 
+ 	drvdata = devm_kzalloc(&hdev->dev, sizeof(*drvdata), GFP_KERNEL);
+ 	if (drvdata == NULL) {
+@@ -1132,6 +1262,18 @@ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 
+ 	drvdata->quirks = id->driver_data;
+ 
++	/* Ignore these endpoints as they are used by hid-asus-ally */
++	#if IS_REACHABLE(CONFIG_HID_ASUS_ALLY)
++	if (drvdata->quirks & QUIRK_ROG_ALLY_XPAD) {
++		intf = to_usb_interface(hdev->dev.parent);
++		ep = intf->cur_altsetting->endpoint;
++		if (ep->desc.bEndpointAddress == ROG_ALLY_X_INTF_IN ||
++			ep->desc.bEndpointAddress == ROG_ALLY_CFG_INTF_IN ||
++			ep->desc.bEndpointAddress == ROG_ALLY_CFG_INTF_OUT)
++			return -ENODEV;
++	}
++	#endif /* IS_REACHABLE(CONFIG_HID_ASUS_ALLY) */
++
+ 	/*
+ 	 * T90CHI's keyboard dock returns same ID values as T100CHI's dock.
+ 	 * Thus, identify T90CHI dock with product name string.
+@@ -1204,12 +1346,41 @@ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 		return ret;
+ 	}
+ 
++	/* Check for vendor for RGB init and handle generic devices properly. */
++	rep_enum = &hdev->report_enum[HID_INPUT_REPORT];
++	list_for_each_entry(rep, &rep_enum->report_list, list) {
++		if ((rep->application & HID_USAGE_PAGE) == HID_USAGE_PAGE_VENDOR)
++			is_vendor = true;
++	}
++
++	/*
++	 * For ROG keyboards, make them hid compliant by
++	 * creating one input per application. For interfaces other than
++	 * the vendor one, disable hid-asus handlers.
++	 */
++	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD) {
++		if (!is_vendor)
++			drvdata->quirks |= QUIRK_HANDLE_GENERIC;
++		hdev->quirks |= HID_QUIRK_INPUT_PER_APP;
++	}
++
+ 	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
+ 	if (ret) {
+ 		hid_err(hdev, "Asus hw start failed: %d\n", ret);
+ 		return ret;
+ 	}
+ 
++	if (is_vendor && (drvdata->quirks & QUIRK_USE_KBD_BACKLIGHT) &&
++	    asus_kbd_register_leds(hdev))
++		hid_warn(hdev, "Failed to initialize backlight.\n");
++
++	/*
++	 * For ROG keyboards, skip rename for consistency and ->input check as
++	 * some devices do not have inputs.
++	 */
++	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD)
++		return 0;
++
+ 	if (!drvdata->input) {
+ 		hid_err(hdev, "Asus input not registered\n");
+ 		ret = -ENOMEM;
+@@ -1240,6 +1411,8 @@ static void asus_remove(struct hid_device *hdev)
+ 	unsigned long flags;
+ 
+ 	if (drvdata->kbd_backlight) {
++		asus_hid_unregister_listener(&drvdata->kbd_backlight->listener);
++
+ 		spin_lock_irqsave(&drvdata->kbd_backlight->lock, flags);
+ 		drvdata->kbd_backlight->removed = true;
+ 		spin_unlock_irqrestore(&drvdata->kbd_backlight->lock, flags);
+@@ -1260,6 +1433,10 @@ static const __u8 *asus_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ {
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return rdesc;
++
+ 	if (drvdata->quirks & QUIRK_FIX_NOTEBOOK_REPORT &&
+ 			*rsize >= 56 && rdesc[54] == 0x25 && rdesc[55] == 0x65) {
+ 		hid_info(hdev, "Fixing up Asus notebook report descriptor\n");
+@@ -1371,22 +1548,21 @@ static const struct hid_device_id asus_devices[] = {
+ 	  QUIRK_USE_KBD_BACKLIGHT },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+ 	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD),
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_LEGACY },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+ 	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD2),
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+-	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD3),
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_LEGACY },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_Z13_LIGHTBAR),
- 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
-+
-+	/* asus-ally-hid driver takes over */
-+	#if !IS_REACHABLE(CONFIG_ASUS_ALLY_HID)
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_RGB },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY),
- 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD},
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD},
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD
++		| QUIRK_ROG_ALLY_XPAD | QUIRK_ROG_NKEY_RGB },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X),
- 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD },
-+	#endif /* !IS_REACHABLE(CONFIG_ASUS_ALLY_HID) */
-+
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD
++		| QUIRK_ROG_ALLY_XPAD | QUIRK_ROG_NKEY_RGB },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_CLAYMORE_II_KEYBOARD),
  	  QUIRK_ROG_CLAYMORE_II_KEYBOARD },
-@@ -1430,4 +1438,5 @@ static struct hid_driver asus_driver = {
- };
- module_hid_driver(asus_driver);
- 
-+MODULE_IMPORT_NS("ASUS_WMI");
- MODULE_LICENSE("GPL");
+@@ -1407,6 +1583,9 @@ static const struct hid_device_id asus_devices[] = {
+ 	 * Note bind to the HID_GROUP_GENERIC group, so that we only bind to the keyboard
+ 	 * part, while letting hid-multitouch.c handle the touchpad.
+ 	 */
++	{ HID_DEVICE(BUS_USB, HID_GROUP_GENERIC,
++		USB_VENDOR_ID_ASUSTEK, USB_DEVICE_ID_ASUSTEK_ROG_Z13_FOLIO),
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_RGB },
+ 	{ HID_DEVICE(BUS_USB, HID_GROUP_GENERIC,
+ 		USB_VENDOR_ID_ASUSTEK, USB_DEVICE_ID_ASUSTEK_T101HA_KEYBOARD) },
+ 	{ }
+diff --git a/drivers/hid/hid-asus.h b/drivers/hid/hid-asus.h
+new file mode 100644
+index 000000000..f67dd5a3a
+--- /dev/null
++++ b/drivers/hid/hid-asus.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __HID_ASUS_H
++#define __HID_ASUS_H
++
++#include <linux/hid.h>
++
++#define ROG_ALLY_CFG_INTF_IN 0x83
++#define ROG_ALLY_CFG_INTF_OUT 0x04
++#define ROG_ALLY_X_INTF_IN 0x87
++
++void validate_mcu_fw_version(struct hid_device *hdev, int idProduct);
++
++#endif	/* __HID_ASUS_H */
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index b937af010e35..965ee2da07d2 100644
+index b937af010..82f39fa14 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -221,6 +221,7 @@
+@@ -219,8 +219,9 @@
+ #define USB_DEVICE_ID_ASUSTEK_ROG_KEYBOARD3 0x1822
+ #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD	0x1866
  #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD2	0x19b6
- #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD3	0x1a30
+-#define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD3	0x1a30
++#define USB_DEVICE_ID_ASUSTEK_ROG_Z13_FOLIO		0x1a30
  #define USB_DEVICE_ID_ASUSTEK_ROG_Z13_LIGHTBAR		0x18c6
 +#define USB_DEVICE_ID_ASUSTEK_ROG_RAIKIRI_PAD		0x1abb
  #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY		0x1abe
  #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X		0x1b4c
  #define USB_DEVICE_ID_ASUSTEK_ROG_CLAYMORE_II_KEYBOARD	0x196b
 diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
-index 43407e76476b..731d18308cb6 100644
+index 43407e764..731d18308 100644
 --- a/drivers/platform/x86/Kconfig
 +++ b/drivers/platform/x86/Kconfig
 @@ -267,6 +267,18 @@ config ASUS_WIRELESS
@@ -4310,7 +3575,7 @@ index 43407e76476b..731d18308cb6 100644
  	tristate "Asus Notebook WMI Driver"
  	depends on ASUS_WMI
 diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index 650dfbebb6c8..3a0085f941d9 100644
+index 9a1884b03..c2461ca2e 100644
 --- a/drivers/platform/x86/Makefile
 +++ b/drivers/platform/x86/Makefile
 @@ -32,6 +32,7 @@ obj-$(CONFIG_APPLE_GMUX)	+= apple-gmux.o
@@ -4323,22 +3588,27 @@ index 650dfbebb6c8..3a0085f941d9 100644
  obj-$(CONFIG_ASUS_TF103C_DOCK)	+= asus-tf103c-dock.o
 diff --git a/drivers/platform/x86/asus-armoury.c b/drivers/platform/x86/asus-armoury.c
 new file mode 100644
-index 000000000000..84abc92bd365
+index 000000000..a461be936
 --- /dev/null
 +++ b/drivers/platform/x86/asus-armoury.c
-@@ -0,0 +1,1202 @@
+@@ -0,0 +1,1174 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
-+ * Asus Armoury (WMI) attributes driver. This driver uses the fw_attributes
-+ * class to expose the various WMI functions that many gaming and some
-+ * non-gaming ASUS laptops have available.
++ * Asus Armoury (WMI) attributes driver.
++ *
++ * This driver uses the fw_attributes class to expose various WMI functions
++ * that are present in many gaming and some non-gaming ASUS laptops.
++ *
 + * These typically don't fit anywhere else in the sysfs such as under LED class,
-+ * hwmon or other, and are set in Windows using the ASUS Armoury Crate tool.
++ * hwmon or others, and are set in Windows using the ASUS Armoury Crate tool.
 + *
 + * Copyright(C) 2024 Luke Jones <luke@ljones.dev>
 + */
 +
++#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
++
 +#include <linux/acpi.h>
++#include <linux/array_size.h>
 +#include <linux/bitfield.h>
 +#include <linux/device.h>
 +#include <linux/dmi.h>
@@ -4350,6 +3620,7 @@ index 000000000000..84abc92bd365
 +#include <linux/module.h>
 +#include <linux/mutex.h>
 +#include <linux/platform_data/x86/asus-wmi.h>
++#include <linux/printk.h>
 +#include <linux/power_supply.h>
 +#include <linux/types.h>
 +
@@ -4380,8 +3651,8 @@ index 000000000000..84abc92bd365
 +#define ATTR_NV_BASE_TGP        "nv_base_tgp"
 +#define ATTR_NV_TGP             "nv_tgp"
 +
-+#define ASUS_POWER_CORE_MASK GENMASK(15, 8)
-+#define ASUS_PERF_CORE_MASK GENMASK(7, 0)
++#define ASUS_POWER_CORE_MASK	GENMASK(15, 8)
++#define ASUS_PERF_CORE_MASK		GENMASK(7, 0)
 +
 +enum cpu_core_type {
 +	CPU_CORE_PERF = 0,
@@ -4410,11 +3681,11 @@ index 000000000000..84abc92bd365
 +
 +struct rog_tunables {
 +	const struct power_limits *power_limits;
-+	u32 ppt_pl1_spl; // cpu
-+	u32 ppt_pl2_sppt; // cpu
-+	u32 ppt_pl3_fppt; // cpu
-+	u32 ppt_apu_sppt; // plat
-+	u32 ppt_platform_sppt; // plat
++	u32 ppt_pl1_spl;			// cpu
++	u32 ppt_pl2_sppt;			// cpu
++	u32 ppt_pl3_fppt;			// cpu
++	u32 ppt_apu_sppt;			// plat
++	u32 ppt_platform_sppt;		// plat
 +
 +	u32 nv_dynamic_boost;
 +	u32 nv_temp_target;
@@ -4507,10 +3778,10 @@ index 000000000000..84abc92bd365
 +}
 +
 +/**
-+ * attr_int_store() - Send an int to wmi method, checks if within min/max exclusive.
++ * attr_uint_store() - Send an uint to wmi method, checks if within min/max exclusive.
 + * @kobj: Pointer to the driver object.
 + * @attr: Pointer to the attribute calling this function.
-+ * @buf: The buffer to read from, this is parsed to `int` type.
++ * @buf: The buffer to read from, this is parsed to `uint` type.
 + * @count: Required by sysfs attribute macros, pass in from the callee attr.
 + * @min: Minimum accepted value. Below this returns -EINVAL.
 + * @max: Maximum accepted value. Above this returns -EINVAL.
@@ -4652,9 +3923,9 @@ index 000000000000..84abc92bd365
 +		return sysfs_emit(buf, "0;1\n");
 +	case ASUS_WMI_DEVID_MINI_LED_MODE2:
 +		return sysfs_emit(buf, "0;1;2\n");
++	default:
++		return -ENODEV;
 +	}
-+
-+	return sysfs_emit(buf, "0\n");
 +}
 +
 +ATTR_GROUP_ENUM_CUSTOM(mini_led_mode, "mini_led_mode", "Set the mini-LED backlight mode");
@@ -4690,7 +3961,7 @@ index 000000000000..84abc92bd365
 +			return err;
 +		if (result && !optimus) {
 +			pr_warn("Can not switch MUX to dGPU mode when eGPU is enabled\n");
-+			return -ENODEV;
++			return -EBUSY;
 +		}
 +	}
 +
@@ -4703,7 +3974,7 @@ index 000000000000..84abc92bd365
 +
 +	return count;
 +}
-+WMI_SHOW_INT(gpu_mux_mode_current_value, "%d\n", asus_armoury.gpu_mux_dev_id);
++WMI_SHOW_INT(gpu_mux_mode_current_value, "%u\n", asus_armoury.gpu_mux_dev_id);
 +ATTR_GROUP_BOOL_CUSTOM(gpu_mux_mode, "gpu_mux_mode", "Set the GPU display MUX mode");
 +
 +/*
@@ -4730,7 +4001,7 @@ index 000000000000..84abc92bd365
 +			return err;
 +		if (!result && disable) {
 +			pr_warn("Can not disable dGPU when the MUX is in dGPU mode\n");
-+			return -ENODEV;
++			return -EBUSY;
 +		}
 +	}
 +
@@ -4769,7 +4040,7 @@ index 000000000000..84abc92bd365
 +		err = asus_wmi_get_devstate_dsts(asus_armoury.gpu_mux_dev_id, &result);
 +		if (err) {
 +			pr_warn("Failed to get GPU MUX status: %d\n", result);
-+			return result;
++			return err;
 +		}
 +		if (!result && enable) {
 +			pr_warn("Can not enable eGPU when the MUX is in dGPU mode\n");
@@ -4790,6 +4061,19 @@ index 000000000000..84abc92bd365
 +
 +/* Device memory available to APU */
 +
++/* Values map for APU memory: some looks out of order but are actually correct */
++static u32 apu_mem_map[] = {
++	[0] = 0x000, /* called "AUTO" on the BIOS, is the minimum available */
++	[1] = 0x102,
++	[2] = 0x103,
++	[3] = 0x104,
++	[4] = 0x105,
++	[5] = 0x107,
++	[6] = 0x108,
++	[7] = 0x109,
++	[8] = 0x106,
++};
++
 +static ssize_t apu_mem_current_value_show(struct kobject *kobj, struct kobj_attribute *attr,
 +					  char *buf)
 +{
@@ -4800,40 +4084,21 @@ index 000000000000..84abc92bd365
 +	if (err)
 +		return err;
 +
-+	switch (mem) {
-+	case 0x100:
-+		mem = 0;
-+		break;
-+	case 0x102:
-+		mem = 1;
-+		break;
-+	case 0x103:
-+		mem = 2;
-+		break;
-+	case 0x104:
-+		mem = 3;
-+		break;
-+	case 0x105:
-+		mem = 4;
-+		break;
-+	case 0x106:
-+		/* This is out of order and looks wrong but is correct */
-+		mem = 8;
-+		break;
-+	case 0x107:
-+		mem = 5;
-+		break;
-+	case 0x108:
-+		mem = 6;
-+		break;
-+	case 0x109:
-+		mem = 7;
-+		break;
-+	default:
-+		mem = 4;
-+		break;
++	if ((mem & ASUS_WMI_DSTS_PRESENCE_BIT) == 0)
++		return -ENODEV;
++
++	mem &= ~ASUS_WMI_DSTS_PRESENCE_BIT;
++
++	/* After 0x000 is set, a read will return 0x100 */
++	if (mem == 0x100)
++		return sysfs_emit(buf, "0\n");
++
++	for (unsigned int i = 0; i < ARRAY_SIZE(apu_mem_map); i++) {
++		if (apu_mem_map[i] == mem)
++			return sysfs_emit(buf, "%u\n", i);
 +	}
 +
++	pr_warn("Unrecognised value for APU mem 0x%08x\n", mem);
 +	return sysfs_emit(buf, "%u\n", mem);
 +}
 +
@@ -4847,38 +4112,10 @@ index 000000000000..84abc92bd365
 +	if (result)
 +		return result;
 +
-+	switch (requested) {
-+	case 0:
-+		mem = 0x000;
-+		break;
-+	case 1:
-+		mem = 0x102;
-+		break;
-+	case 2:
-+		mem = 0x103;
-+		break;
-+	case 3:
-+		mem = 0x104;
-+		break;
-+	case 4:
-+		mem = 0x105;
-+		break;
-+	case 5:
-+		mem = 0x107;
-+		break;
-+	case 6:
-+		mem = 0x108;
-+		break;
-+	case 7:
-+		mem = 0x109;
-+		break;
-+	case 8:
-+		/* This is out of order and looks wrong but is correct */
-+		mem = 0x106;
-+		break;
-+	default:
-+		return -EIO;
-+	}
++	if (requested > ARRAY_SIZE(apu_mem_map))
++		return -EINVAL;
++
++	mem = apu_mem_map[requested];
 +
 +	err = asus_wmi_set_devstate(ASUS_WMI_DEVID_APU_MEM, mem, &result);
 +	if (err) {
@@ -4886,7 +4123,7 @@ index 000000000000..84abc92bd365
 +		return err;
 +	}
 +
-+	pr_info("APU memory changed to %uGB, reboot required\n", requested);
++	pr_info("APU memory changed to %uGB, reboot required\n", requested+1);
 +	sysfs_notify(kobj, NULL, attr->attr.name);
 +
 +	asus_set_reboot_and_signal_event();
@@ -4897,6 +4134,7 @@ index 000000000000..84abc92bd365
 +static ssize_t apu_mem_possible_values_show(struct kobject *kobj, struct kobj_attribute *attr,
 +					    char *buf)
 +{
++	BUILD_BUG_ON(ARRAY_SIZE(apu_mem_map) != 9);
 +	return sysfs_emit(buf, "0;1;2;3;4;5;6;7;8\n");
 +}
 +ATTR_GROUP_ENUM_CUSTOM(apu_mem, "apu_mem", "Set available system RAM (in GB) for the APU to use");
@@ -4906,18 +4144,27 @@ index 000000000000..84abc92bd365
 +	u32 cores;
 +	int err;
 +
++	asus_armoury.cpu_cores = kzalloc(sizeof(struct cpu_cores), GFP_KERNEL);
++	if (!asus_armoury.cpu_cores)
++		return -ENOMEM;
++
 +	err = asus_wmi_get_devstate_dsts(ASUS_WMI_DEVID_CORES_MAX, &cores);
 +	if (err)
 +		return err;
 +
-+	cores &= ~ASUS_WMI_DSTS_PRESENCE_BIT;
++	if ((cores & ASUS_WMI_DSTS_PRESENCE_BIT) == 0) {
++		pr_err("ACPI does not support CPU core count control\n");
++		err = -ENODEV;
++		goto init_max_cpu_cores_err;
++	}
++
 +	asus_armoury.cpu_cores->max_power_cores = FIELD_GET(ASUS_POWER_CORE_MASK, cores);
 +	asus_armoury.cpu_cores->max_perf_cores = FIELD_GET(ASUS_PERF_CORE_MASK, cores);
 +
 +	err = asus_wmi_get_devstate_dsts(ASUS_WMI_DEVID_CORES, &cores);
 +	if (err) {
-+		pr_err("Could not get CPU core count: error %d", err);
-+		return err;
++		pr_err("Could not get CPU core count: error %d\n", err);
++		goto init_max_cpu_cores_err;
 +	}
 +
 +	asus_armoury.cpu_cores->cur_perf_cores = FIELD_GET(ASUS_PERF_CORE_MASK, cores);
@@ -4927,6 +4174,10 @@ index 000000000000..84abc92bd365
 +	asus_armoury.cpu_cores->min_power_cores = CPU_POWR_CORE_COUNT_MIN;
 +
 +	return 0;
++
++init_max_cpu_cores_err:
++	kfree(asus_armoury.cpu_cores);
++	return err;
 +}
 +
 +static ssize_t cores_value_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf,
@@ -4938,17 +4189,17 @@ index 000000000000..84abc92bd365
 +	case CPU_CORE_DEFAULT:
 +	case CPU_CORE_MAX:
 +		if (core_type == CPU_CORE_PERF)
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->max_perf_cores);
 +		else
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->max_power_cores);
 +	case CPU_CORE_MIN:
 +		if (core_type == CPU_CORE_PERF)
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->min_perf_cores);
 +		else
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->min_power_cores);
 +	default:
 +		break;
@@ -4959,7 +4210,7 @@ index 000000000000..84abc92bd365
 +	else
 +		cores = asus_armoury.cpu_cores->cur_power_cores;
 +
-+	return sysfs_emit(buf, "%d\n", cores);
++	return sysfs_emit(buf, "%u\n", cores);
 +}
 +
 +static ssize_t cores_current_value_store(struct kobject *kobj, struct kobj_attribute *attr,
@@ -4972,45 +4223,38 @@ index 000000000000..84abc92bd365
 +	if (result)
 +		return result;
 +
-+	mutex_lock(&asus_armoury.cpu_core_mutex);
++	scoped_guard(mutex, &asus_armoury.cpu_core_mutex) {
++		if (core_type == CPU_CORE_PERF) {
++			perf_cores = new_cores;
++			power_cores = asus_armoury.cpu_cores->cur_power_cores;
++			min = asus_armoury.cpu_cores->min_perf_cores;
++			max = asus_armoury.cpu_cores->max_perf_cores;
++		} else {
++			perf_cores = asus_armoury.cpu_cores->cur_perf_cores;
++			power_cores = new_cores;
++			min = asus_armoury.cpu_cores->min_power_cores;
++			max = asus_armoury.cpu_cores->max_power_cores;
++		}
 +
-+	if (core_type == CPU_CORE_PERF) {
-+		perf_cores = new_cores;
-+		power_cores = out_val = asus_armoury.cpu_cores->cur_power_cores;
-+		min = asus_armoury.cpu_cores->min_perf_cores;
-+		max = asus_armoury.cpu_cores->max_perf_cores;
-+	} else {
-+		perf_cores = asus_armoury.cpu_cores->cur_perf_cores;
-+		power_cores = out_val = new_cores;
-+		min = asus_armoury.cpu_cores->min_power_cores;
-+		max = asus_armoury.cpu_cores->max_power_cores;
-+	}
++		if (new_cores < min || new_cores > max)
++			return -EINVAL;
 +
-+	if (new_cores < min || new_cores > max) {
-+		mutex_unlock(&asus_armoury.cpu_core_mutex);
-+		return -EINVAL;
-+	}
++		out_val = FIELD_PREP(ASUS_PERF_CORE_MASK, perf_cores) |
++			FIELD_PREP(ASUS_POWER_CORE_MASK, power_cores);
 +
-+	out_val = 0;
-+	out_val |= FIELD_PREP(ASUS_PERF_CORE_MASK, perf_cores);
-+	out_val |= FIELD_PREP(ASUS_POWER_CORE_MASK, power_cores);
++		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_CORES, out_val, &result);
++		if (err) {
++			pr_warn("Failed to set CPU core count: %d\n", err);
++			return err;
++		}
 +
-+	err = asus_wmi_set_devstate(ASUS_WMI_DEVID_CORES, out_val, &result);
-+
-+	if (err) {
-+		pr_warn("Failed to set CPU core count: %d\n", err);
-+		mutex_unlock(&asus_armoury.cpu_core_mutex);
-+		return err;
-+	}
-+
-+	if (result > 1) {
-+		pr_warn("Failed to set CPU core count (result): 0x%x\n", result);
-+		mutex_unlock(&asus_armoury.cpu_core_mutex);
-+		return -EIO;
++		if (result > 1) {
++			pr_warn("Failed to set CPU core count (result): 0x%x\n", result);
++			return -EIO;
++		}
 +	}
 +
 +	pr_info("CPU core count changed, reboot required\n");
-+	mutex_unlock(&asus_armoury.cpu_core_mutex);
 +
 +	sysfs_notify(kobj, NULL, attr->attr.name);
 +	asus_set_reboot_and_signal_event();
@@ -5165,6 +4409,7 @@ index 000000000000..84abc92bd365
 +	{ &mcu_powersave_attr_group, ASUS_WMI_DEVID_MCU_POWERSAVE },
 +	{ &panel_od_attr_group, ASUS_WMI_DEVID_PANEL_OD },
 +	{ &panel_hd_mode_attr_group, ASUS_WMI_DEVID_PANEL_HD },
++	{ &screen_auto_brightness_attr_group, ASUS_WMI_DEVID_SCREEN_AUTO_BRIGHTNESS },
 +};
 +
 +/**
@@ -5185,7 +4430,7 @@ index 000000000000..84abc92bd365
 +		ATTR_NV_TGP
 +	};
 +
-+	for (int i = 0; i < ARRAY_SIZE(power_tunable_attrs); i++) {
++	for (unsigned int i = 0; i < ARRAY_SIZE(power_tunable_attrs); i++) {
 +		if (!strcmp(name, power_tunable_attrs[i]))
 +			return true;
 +	}
@@ -5298,21 +4543,18 @@ index 000000000000..84abc92bd365
 +
 +		/* Check if this is a power-related tunable requiring limits */
 +		if (asus_armoury.rog_tunables[1] && asus_armoury.rog_tunables[1]->power_limits &&
-+			is_power_tunable_attr(name)) {
++		    is_power_tunable_attr(name)) {
 +			limits = asus_armoury.rog_tunables[1]->power_limits;
 +			/* Check only AC, if DC is not present then AC won't be either */
 +			should_create = has_valid_limit(name, limits);
 +			if (!should_create) {
-+				pr_debug(
-+					"Missing max value on %s for tunable: %s\n",
-+					dmi_get_system_info(DMI_BOARD_NAME),
-+					name);
++				pr_debug("Missing max value on %s for tunable: %s\n",
++					 dmi_get_system_info(DMI_BOARD_NAME), name);
 +			}
 +		}
 +
 +		if (should_create) {
-+			err = sysfs_create_group(
-+				&asus_armoury.fw_attr_kset->kobj,
++			err = sysfs_create_group(&asus_armoury.fw_attr_kset->kobj,
 +				armoury_attr_groups[i].attr_group);
 +			if (err) {
 +				pr_err("Failed to create sysfs-group for %s\n",
@@ -5325,7 +4567,7 @@ index 000000000000..84abc92bd365
 +	return 0;
 +
 +err_remove_groups:
-+	while (--i >= 0) {
++	while (i--) {
 +		if (asus_wmi_is_present(armoury_attr_groups[i].wmi_devid))
 +			sysfs_remove_group(&asus_armoury.fw_attr_kset->kobj,
 +					   armoury_attr_groups[i].attr_group);
@@ -5373,7 +4615,7 @@ index 000000000000..84abc92bd365
 +	ac_limits = power_data->ac_data;
 +	if (ac_limits) {
 +		asus_armoury.rog_tunables[1] =
-+			kzalloc(sizeof(struct rog_tunables), GFP_KERNEL);
++			kzalloc(sizeof(*asus_armoury.rog_tunables[1]), GFP_KERNEL);
 +		if (!asus_armoury.rog_tunables[1])
 +			goto err_nomem;
 +
@@ -5419,7 +4661,7 @@ index 000000000000..84abc92bd365
 +	dc_limits = power_data->dc_data;
 +	if (dc_limits) {
 +		asus_armoury.rog_tunables[0] =
-+			kzalloc(sizeof(struct rog_tunables), GFP_KERNEL);
++			kzalloc(sizeof(*asus_armoury.rog_tunables[0]), GFP_KERNEL);
 +		if (!asus_armoury.rog_tunables[0]) {
 +			if (ac_initialized)
 +				kfree(asus_armoury.rog_tunables[1]);
@@ -5493,13 +4735,8 @@ index 000000000000..84abc92bd365
 +		return -ENODEV;
 +
 +	if (asus_wmi_is_present(ASUS_WMI_DEVID_CORES_MAX)) {
-+		asus_armoury.cpu_cores = kzalloc(sizeof(struct cpu_cores), GFP_KERNEL);
-+		if (!asus_armoury.cpu_cores)
-+			return -ENOMEM;
-+
 +		err = init_max_cpu_cores();
 +		if (err) {
-+			kfree(asus_armoury.cpu_cores);
 +			pr_err("Could not initialise CPU core control %d\n", err);
 +			return err;
 +		}
@@ -5531,7 +4768,7 @@ index 000000000000..84abc92bd365
 +MODULE_ALIAS("wmi:" ASUS_NB_WMI_EVENT_GUID);
 diff --git a/drivers/platform/x86/asus-armoury.h b/drivers/platform/x86/asus-armoury.h
 new file mode 100644
-index 000000000000..438768ea14cc
+index 000000000..438768ea1
 --- /dev/null
 +++ b/drivers/platform/x86/asus-armoury.h
 @@ -0,0 +1,1278 @@
@@ -6813,8 +6050,77 @@ index 000000000000..438768ea14cc
 +};
 +
 +#endif /* _ASUS_ARMOURY_H_ */
+diff --git a/drivers/platform/x86/asus-nb-wmi.c b/drivers/platform/x86/asus-nb-wmi.c
+index f84c3d03c..0c6bdf93f 100644
+--- a/drivers/platform/x86/asus-nb-wmi.c
++++ b/drivers/platform/x86/asus-nb-wmi.c
+@@ -146,8 +146,12 @@ static struct quirk_entry quirk_asus_ignore_fan = {
+ 	.wmi_ignore_fan = true,
+ };
+ 
+-static struct quirk_entry quirk_asus_zenbook_duo_kbd = {
+-	.ignore_key_wlan = true,
++static struct quirk_entry quirk_asus_wlan_ignore = {
++	.key_wlan_event = ASUS_WMI_KEY_IGNORE,
++};
++
++static struct quirk_entry quirk_asus_wlan_armoury = {
++	.key_wlan_event = ASUS_WMI_KEY_ARMOURY,
+ };
+ 
+ static int dmi_matched(const struct dmi_system_id *dmi)
+@@ -528,7 +532,16 @@ static const struct dmi_system_id asus_quirks[] = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "UX8406MA"),
+ 		},
+-		.driver_data = &quirk_asus_zenbook_duo_kbd,
++		.driver_data = &quirk_asus_wlan_ignore,
++	},
++	{
++		.callback = dmi_matched,
++		.ident = "ASUS ROG Z13 2025",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_PRODUCT_NAME, "ROG Flow Z13 GZ302"),
++		},
++		.driver_data = &quirk_asus_wlan_armoury,
+ 	},
+ 	{
+ 		.callback = dmi_matched,
+@@ -537,7 +550,7 @@ static const struct dmi_system_id asus_quirks[] = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "UX8406CA"),
+ 		},
+-		.driver_data = &quirk_asus_zenbook_duo_kbd,
++		.driver_data = &quirk_asus_wlan_ignore,
+ 	},
+ 	{},
+ };
+@@ -636,6 +649,7 @@ static const struct key_entry asus_nb_wmi_keymap[] = {
+ 	{ KE_IGNORE, 0xCF, },	/* AC mode */
+ 	{ KE_KEY, 0xFA, { KEY_PROG2 } },           /* Lid flip action */
+ 	{ KE_KEY, 0xBD, { KEY_PROG2 } },           /* Lid flip action on ROG xflow laptops */
++	{ KE_KEY, ASUS_WMI_KEY_ARMOURY, { KEY_PROG3 } },
+ 	{ KE_END, 0},
+ };
+ 
+@@ -655,11 +669,9 @@ static void asus_nb_wmi_key_filter(struct asus_wmi_driver *asus_wmi, int *code,
+ 		if (atkbd_reports_vol_keys)
+ 			*code = ASUS_WMI_KEY_IGNORE;
+ 		break;
+-	case 0x5D: /* Wireless console Toggle */
+-	case 0x5E: /* Wireless console Enable */
+-	case 0x5F: /* Wireless console Disable */
+-		if (quirks->ignore_key_wlan)
+-			*code = ASUS_WMI_KEY_IGNORE;
++	case 0x5F: /* Wireless console Disable / Special Key */
++		if (quirks->key_wlan_event)
++			*code = quirks->key_wlan_event;
+ 		break;
+ 	}
+ }
 diff --git a/drivers/platform/x86/asus-wmi.c b/drivers/platform/x86/asus-wmi.c
-index 47cc766624d7..942f1013d6cb 100644
+index 47cc76662..44eeb8803 100644
 --- a/drivers/platform/x86/asus-wmi.c
 +++ b/drivers/platform/x86/asus-wmi.c
 @@ -55,8 +55,6 @@ module_param(fnlock_default, bool, 0444);
@@ -6835,15 +6141,7 @@ index 47cc766624d7..942f1013d6cb 100644
  #define WMI_EVENT_MASK			0xFFFF
  
  #define FAN_CURVE_POINTS		8
-@@ -127,7 +123,6 @@ module_param(fnlock_default, bool, 0444);
- #define NVIDIA_TEMP_MIN		75
- #define NVIDIA_TEMP_MAX		87
- 
--#define ASUS_SCREENPAD_BRIGHT_MIN 20
- #define ASUS_SCREENPAD_BRIGHT_MAX 255
- #define ASUS_SCREENPAD_BRIGHT_DEFAULT 60
- 
-@@ -142,16 +137,20 @@ module_param(fnlock_default, bool, 0444);
+@@ -142,16 +138,20 @@ module_param(fnlock_default, bool, 0444);
  #define ASUS_MINI_LED_2024_STRONG	0x01
  #define ASUS_MINI_LED_2024_OFF		0x02
  
@@ -6868,7 +6166,16 @@ index 47cc766624d7..942f1013d6cb 100644
  	{
  		.matches = {
  			DMI_MATCH(DMI_BOARD_NAME, "RC71L"),
-@@ -274,9 +273,6 @@ struct asus_wmi {
+@@ -254,6 +254,8 @@ struct asus_wmi {
+ 	int tpd_led_wk;
+ 	struct led_classdev kbd_led;
+ 	int kbd_led_wk;
++	bool kbd_led_avail;
++	bool kbd_led_registered;
+ 	struct led_classdev lightbar_led;
+ 	int lightbar_led_wk;
+ 	struct led_classdev micmute_led;
+@@ -274,9 +276,6 @@ struct asus_wmi {
  	u32 tablet_switch_dev_id;
  	bool tablet_switch_inverted;
  
@@ -6878,7 +6185,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	enum fan_type fan_type;
  	enum fan_type gpu_fan_type;
  	enum fan_type mid_fan_type;
-@@ -336,6 +332,16 @@ struct asus_wmi {
+@@ -336,6 +335,16 @@ struct asus_wmi {
  	struct asus_wmi_driver *driver;
  };
  
@@ -6895,7 +6202,7 @@ index 47cc766624d7..942f1013d6cb 100644
  /* WMI ************************************************************************/
  
  static int asus_wmi_evaluate_method3(u32 method_id,
-@@ -386,7 +392,7 @@ int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1, u32 *retval)
+@@ -386,7 +395,7 @@ int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1, u32 *retval)
  {
  	return asus_wmi_evaluate_method3(method_id, arg0, arg1, 0, retval);
  }
@@ -6904,21 +6211,19 @@ index 47cc766624d7..942f1013d6cb 100644
  
  static int asus_wmi_evaluate_method5(u32 method_id,
  		u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32 arg4, u32 *retval)
-@@ -550,12 +556,51 @@ static int asus_wmi_get_devstate(struct asus_wmi *asus, u32 dev_id, u32 *retval)
+@@ -550,12 +559,46 @@ static int asus_wmi_get_devstate(struct asus_wmi *asus, u32 dev_id, u32 *retval)
  	return 0;
  }
  
 -static int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param,
 -				 u32 *retval)
-+
 +/**
 + * asus_wmi_get_devstate_dsts() - Get the WMI function state.
 + * @dev_id: The WMI method ID to call.
 + * @retval: A pointer to where to store the value returned from WMI.
-+ *
-+ * On success the return value is 0, and the retval is a valid value returned
-+ * by the successful WMI function call otherwise an error is returned if the
-+ * call failed, or if the WMI method ID is unsupported.
++ * @return: 0 on success and retval is filled.
++ * @return: -ENODEV if the method ID is unsupported.
++ * @return: everything else is an error from WMI call.
 + */
 +int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval)
 +{
@@ -6940,14 +6245,11 @@ index 47cc766624d7..942f1013d6cb 100644
 + * @dev_id: The WMI function to call.
 + * @ctrl_param: The argument to be used for this WMI function.
 + * @retval: A pointer to where to store the value returned from WMI.
++ * @return: 0 on success and retval is filled.
++ * @return: everything else is an error from WMI call.
 + *
-+ * The returned WMI function state if not checked here for error as
-+ * asus_wmi_set_devstate() is not called unless first paired with a call to
-+ * asus_wmi_get_devstate_dsts() to check that the WMI function is supported.
-+ *
-+ * On success the return value is 0, and the retval is a valid value returned
-+ * by the successful WMI function call. An error value is returned only if the
-+ * WMI function failed.
++ * A asus_wmi_set_devstate() call must be paired with a
++ * asus_wmi_get_devstate_dsts() to check if the WMI function is supported.
 + */
 +int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval)
  {
@@ -6958,7 +6260,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Helper for special devices with magic return codes */
  static int asus_wmi_get_devstate_bits(struct asus_wmi *asus,
-@@ -688,6 +733,7 @@ static void asus_wmi_tablet_mode_get_state(struct asus_wmi *asus)
+@@ -688,6 +731,7 @@ static void asus_wmi_tablet_mode_get_state(struct asus_wmi *asus)
  }
  
  /* Charging mode, 1=Barrel, 2=USB ******************************************/
@@ -6966,7 +6268,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t charge_mode_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -698,12 +744,16 @@ static ssize_t charge_mode_show(struct device *dev,
+@@ -698,12 +742,16 @@ static ssize_t charge_mode_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -6983,7 +6285,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t dgpu_disable_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -714,6 +764,8 @@ static ssize_t dgpu_disable_show(struct device *dev,
+@@ -714,6 +762,8 @@ static ssize_t dgpu_disable_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -6992,7 +6294,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -767,8 +819,10 @@ static ssize_t dgpu_disable_store(struct device *dev,
+@@ -767,8 +817,10 @@ static ssize_t dgpu_disable_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(dgpu_disable);
@@ -7003,7 +6305,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t egpu_enable_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -779,6 +833,8 @@ static ssize_t egpu_enable_show(struct device *dev,
+@@ -779,6 +831,8 @@ static ssize_t egpu_enable_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7012,7 +6314,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -835,8 +891,10 @@ static ssize_t egpu_enable_store(struct device *dev,
+@@ -835,8 +889,10 @@ static ssize_t egpu_enable_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(egpu_enable);
@@ -7023,7 +6325,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t egpu_connected_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -847,12 +905,16 @@ static ssize_t egpu_connected_show(struct device *dev,
+@@ -847,12 +903,16 @@ static ssize_t egpu_connected_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7040,7 +6342,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t gpu_mux_mode_show(struct device *dev,
  				 struct device_attribute *attr, char *buf)
  {
-@@ -863,6 +925,8 @@ static ssize_t gpu_mux_mode_show(struct device *dev,
+@@ -863,6 +923,8 @@ static ssize_t gpu_mux_mode_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7049,7 +6351,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -921,6 +985,7 @@ static ssize_t gpu_mux_mode_store(struct device *dev,
+@@ -921,6 +983,7 @@ static ssize_t gpu_mux_mode_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(gpu_mux_mode);
@@ -7057,7 +6359,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* TUF Laptop Keyboard RGB Modes **********************************************/
  static ssize_t kbd_rgb_mode_store(struct device *dev,
-@@ -1044,6 +1109,7 @@ static const struct attribute_group *kbd_rgb_mode_groups[] = {
+@@ -1044,6 +1107,7 @@ static const struct attribute_group *kbd_rgb_mode_groups[] = {
  };
  
  /* Tunable: PPT: Intel=PL1, AMD=SPPT *****************************************/
@@ -7065,7 +6367,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t ppt_pl2_sppt_store(struct device *dev,
  				    struct device_attribute *attr,
  				    const char *buf, size_t count)
-@@ -1082,6 +1148,8 @@ static ssize_t ppt_pl2_sppt_show(struct device *dev,
+@@ -1082,6 +1146,8 @@ static ssize_t ppt_pl2_sppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7074,7 +6376,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_pl2_sppt);
  }
  static DEVICE_ATTR_RW(ppt_pl2_sppt);
-@@ -1124,6 +1192,8 @@ static ssize_t ppt_pl1_spl_show(struct device *dev,
+@@ -1124,6 +1190,8 @@ static ssize_t ppt_pl1_spl_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7083,7 +6385,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_pl1_spl);
  }
  static DEVICE_ATTR_RW(ppt_pl1_spl);
-@@ -1167,6 +1237,8 @@ static ssize_t ppt_fppt_show(struct device *dev,
+@@ -1167,6 +1235,8 @@ static ssize_t ppt_fppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7092,7 +6394,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_fppt);
  }
  static DEVICE_ATTR_RW(ppt_fppt);
-@@ -1210,6 +1282,8 @@ static ssize_t ppt_apu_sppt_show(struct device *dev,
+@@ -1210,6 +1280,8 @@ static ssize_t ppt_apu_sppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7101,7 +6403,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_apu_sppt);
  }
  static DEVICE_ATTR_RW(ppt_apu_sppt);
-@@ -1253,6 +1327,8 @@ static ssize_t ppt_platform_sppt_show(struct device *dev,
+@@ -1253,6 +1325,8 @@ static ssize_t ppt_platform_sppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7110,7 +6412,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_platform_sppt);
  }
  static DEVICE_ATTR_RW(ppt_platform_sppt);
-@@ -1296,6 +1372,8 @@ static ssize_t nv_dynamic_boost_show(struct device *dev,
+@@ -1296,6 +1370,8 @@ static ssize_t nv_dynamic_boost_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7119,7 +6421,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->nv_dynamic_boost);
  }
  static DEVICE_ATTR_RW(nv_dynamic_boost);
-@@ -1339,11 +1417,53 @@ static ssize_t nv_temp_target_show(struct device *dev,
+@@ -1339,11 +1415,53 @@ static ssize_t nv_temp_target_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7173,7 +6475,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t mcu_powersave_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -1354,6 +1474,8 @@ static ssize_t mcu_powersave_show(struct device *dev,
+@@ -1354,6 +1472,8 @@ static ssize_t mcu_powersave_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7182,7 +6484,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -1389,6 +1511,7 @@ static ssize_t mcu_powersave_store(struct device *dev,
+@@ -1389,6 +1509,7 @@ static ssize_t mcu_powersave_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(mcu_powersave);
@@ -7190,7 +6492,235 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Battery ********************************************************************/
  
-@@ -2262,6 +2385,7 @@ static int asus_wmi_rfkill_init(struct asus_wmi *asus)
+@@ -1488,6 +1609,92 @@ static void asus_wmi_battery_exit(struct asus_wmi *asus)
+ 
+ /* LEDs ***********************************************************************/
+ 
++struct asus_hid_ref {
++	struct list_head listeners;
++	struct asus_wmi *asus;
++	spinlock_t lock;
++};
++
++struct asus_hid_ref asus_ref = {
++	.listeners = LIST_HEAD_INIT(asus_ref.listeners),
++	.asus = NULL,
++	.lock = __SPIN_LOCK_UNLOCKED(asus_ref.lock),
++};
++
++int asus_hid_register_listener(struct asus_hid_listener *bdev)
++{
++	unsigned long flags;
++	int ret = 0;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	list_add_tail(&bdev->list, &asus_ref.listeners);
++	if (asus_ref.asus) {
++		if (asus_ref.asus->kbd_led_registered && asus_ref.asus->kbd_led_wk >= 0)
++			bdev->brightness_set(bdev, asus_ref.asus->kbd_led_wk);
++
++		if (!asus_ref.asus->kbd_led_registered) {
++			ret = led_classdev_register(
++				&asus_ref.asus->platform_device->dev,
++				&asus_ref.asus->kbd_led);
++			if (!ret)
++				asus_ref.asus->kbd_led_registered = true;
++		}
++	}
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(asus_hid_register_listener);
++
++void asus_hid_unregister_listener(struct asus_hid_listener *bdev)
++{
++	unsigned long flags;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	list_del(&bdev->list);
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++}
++EXPORT_SYMBOL_GPL(asus_hid_unregister_listener);
++
++static void do_kbd_led_set(struct led_classdev *led_cdev, int value);
++
++int asus_hid_event(enum asus_hid_event event)
++{
++	unsigned long flags;
++	int brightness;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	if (!asus_ref.asus || !asus_ref.asus->kbd_led_registered) {
++		spin_unlock_irqrestore(&asus_ref.lock, flags);
++		return -EBUSY;
++	}
++	brightness = asus_ref.asus->kbd_led_wk;
++
++	switch (event) {
++	case ASUS_EV_BRTUP:
++		brightness += 1;
++		break;
++	case ASUS_EV_BRTDOWN:
++		brightness -= 1;
++		break;
++	case ASUS_EV_BRTTOGGLE:
++		if (brightness >= ASUS_EV_MAX_BRIGHTNESS)
++			brightness = 0;
++		else
++			brightness += 1;
++		break;
++	}
++
++	do_kbd_led_set(&asus_ref.asus->kbd_led, brightness);
++	led_classdev_notify_brightness_hw_changed(&asus_ref.asus->kbd_led,
++						  asus_ref.asus->kbd_led_wk);
++
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(asus_hid_event);
++
+ /*
+  * These functions actually update the LED's, and are called from a
+  * workqueue. By doing this as separate work rather than when the LED
+@@ -1567,6 +1774,7 @@ static int kbd_led_read(struct asus_wmi *asus, int *level, int *env)
+ 
+ static void do_kbd_led_set(struct led_classdev *led_cdev, int value)
+ {
++	struct asus_hid_listener *listener;
+ 	struct asus_wmi *asus;
+ 	int max_level;
+ 
+@@ -1574,25 +1782,39 @@ static void do_kbd_led_set(struct led_classdev *led_cdev, int value)
+ 	max_level = asus->kbd_led.max_brightness;
+ 
+ 	asus->kbd_led_wk = clamp_val(value, 0, max_level);
+-	kbd_led_update(asus);
++
++	if (asus->kbd_led_avail)
++		kbd_led_update(asus);
++
++	list_for_each_entry(listener, &asus_ref.listeners, list)
++		listener->brightness_set(listener, asus->kbd_led_wk);
+ }
+ 
+ static void kbd_led_set(struct led_classdev *led_cdev,
+ 			enum led_brightness value)
+ {
++	unsigned long flags;
++
+ 	/* Prevent disabling keyboard backlight on module unregister */
+ 	if (led_cdev->flags & LED_UNREGISTERING)
+ 		return;
+ 
++	spin_lock_irqsave(&asus_ref.lock, flags);
+ 	do_kbd_led_set(led_cdev, value);
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
+ }
+ 
+ static void kbd_led_set_by_kbd(struct asus_wmi *asus, enum led_brightness value)
+ {
+-	struct led_classdev *led_cdev = &asus->kbd_led;
++	struct led_classdev *led_cdev;
++	unsigned long flags;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	led_cdev = &asus->kbd_led;
+ 
+ 	do_kbd_led_set(led_cdev, value);
+ 	led_classdev_notify_brightness_hw_changed(led_cdev, asus->kbd_led_wk);
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
+ }
+ 
+ static enum led_brightness kbd_led_get(struct led_classdev *led_cdev)
+@@ -1602,6 +1824,9 @@ static enum led_brightness kbd_led_get(struct led_classdev *led_cdev)
+ 
+ 	asus = container_of(led_cdev, struct asus_wmi, kbd_led);
+ 
++	if (!asus->kbd_led_avail)
++		return asus->kbd_led_wk;
++
+ 	retval = kbd_led_read(asus, &value, NULL);
+ 	if (retval < 0)
+ 		return retval;
+@@ -1717,7 +1942,15 @@ static int camera_led_set(struct led_classdev *led_cdev,
+ 
+ static void asus_wmi_led_exit(struct asus_wmi *asus)
+ {
+-	led_classdev_unregister(&asus->kbd_led);
++	unsigned long flags;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	asus_ref.asus = NULL;
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++
++	if (asus->kbd_led_registered)
++		led_classdev_unregister(&asus->kbd_led);
++
+ 	led_classdev_unregister(&asus->tpd_led);
+ 	led_classdev_unregister(&asus->wlan_led);
+ 	led_classdev_unregister(&asus->lightbar_led);
+@@ -1731,6 +1964,8 @@ static void asus_wmi_led_exit(struct asus_wmi *asus)
+ static int asus_wmi_led_init(struct asus_wmi *asus)
+ {
+ 	int rv = 0, num_rgb_groups = 0, led_val;
++	struct asus_hid_listener *listener;
++	unsigned long flags;
+ 
+ 	if (asus->kbd_rgb_dev)
+ 		kbd_rgb_mode_groups[num_rgb_groups++] = &kbd_rgb_mode_group;
+@@ -1755,23 +1990,38 @@ static int asus_wmi_led_init(struct asus_wmi *asus)
+ 			goto error;
+ 	}
+ 
+-	if (!kbd_led_read(asus, &led_val, NULL) && !dmi_check_system(asus_use_hid_led_dmi_ids)) {
+-		pr_info("using asus-wmi for asus::kbd_backlight\n");
++	asus->kbd_led.name = "asus::kbd_backlight";
++	asus->kbd_led.flags = LED_BRIGHT_HW_CHANGED;
++	asus->kbd_led.brightness_set = kbd_led_set;
++	asus->kbd_led.brightness_get = kbd_led_get;
++	asus->kbd_led.max_brightness = ASUS_EV_MAX_BRIGHTNESS;
++	asus->kbd_led_avail = !kbd_led_read(asus, &led_val, NULL);
++
++	if (asus->kbd_led_avail)
+ 		asus->kbd_led_wk = led_val;
+-		asus->kbd_led.name = "asus::kbd_backlight";
+-		asus->kbd_led.flags = LED_BRIGHT_HW_CHANGED;
+-		asus->kbd_led.brightness_set = kbd_led_set;
+-		asus->kbd_led.brightness_get = kbd_led_get;
+-		asus->kbd_led.max_brightness = 3;
++	else
++		asus->kbd_led_wk = -1;
+ 
+-		if (num_rgb_groups != 0)
+-			asus->kbd_led.groups = kbd_rgb_mode_groups;
++	if (asus->kbd_led_avail && num_rgb_groups != 0)
++		asus->kbd_led.groups = kbd_rgb_mode_groups;
+ 
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	if (asus->kbd_led_avail || !list_empty(&asus_ref.listeners)) {
+ 		rv = led_classdev_register(&asus->platform_device->dev,
+ 					   &asus->kbd_led);
+-		if (rv)
++		if (rv) {
++			spin_unlock_irqrestore(&asus_ref.lock, flags);
+ 			goto error;
++		}
++		asus->kbd_led_registered = true;
++
++		if (asus->kbd_led_wk >= 0) {
++			list_for_each_entry(listener, &asus_ref.listeners, list)
++				listener->brightness_set(listener, asus->kbd_led_wk);
++		}
+ 	}
++	asus_ref.asus = asus;
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
+ 
+ 	if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_WIRELESS_LED)
+ 			&& (asus->driver->quirks->wapf > 0)) {
+@@ -2262,6 +2512,7 @@ static int asus_wmi_rfkill_init(struct asus_wmi *asus)
  }
  
  /* Panel Overdrive ************************************************************/
@@ -7198,7 +6728,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t panel_od_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -2272,6 +2396,8 @@ static ssize_t panel_od_show(struct device *dev,
+@@ -2272,6 +2523,8 @@ static ssize_t panel_od_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7207,7 +6737,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -2308,9 +2434,10 @@ static ssize_t panel_od_store(struct device *dev,
+@@ -2308,9 +2561,10 @@ static ssize_t panel_od_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(panel_od);
@@ -7219,7 +6749,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t boot_sound_show(struct device *dev,
  			     struct device_attribute *attr, char *buf)
  {
-@@ -2321,6 +2448,8 @@ static ssize_t boot_sound_show(struct device *dev,
+@@ -2321,6 +2575,8 @@ static ssize_t boot_sound_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7228,7 +6758,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -2356,8 +2485,10 @@ static ssize_t boot_sound_store(struct device *dev,
+@@ -2356,8 +2612,10 @@ static ssize_t boot_sound_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(boot_sound);
@@ -7239,7 +6769,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t mini_led_mode_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -2388,6 +2519,8 @@ static ssize_t mini_led_mode_show(struct device *dev,
+@@ -2388,6 +2646,8 @@ static ssize_t mini_led_mode_show(struct device *dev,
  		}
  	}
  
@@ -7248,7 +6778,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", value);
  }
  
-@@ -2458,10 +2591,13 @@ static ssize_t available_mini_led_mode_show(struct device *dev,
+@@ -2458,10 +2718,13 @@ static ssize_t available_mini_led_mode_show(struct device *dev,
  		return sysfs_emit(buf, "0 1 2\n");
  	}
  
@@ -7262,7 +6792,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Quirks *********************************************************************/
  
-@@ -3749,6 +3885,7 @@ static int throttle_thermal_policy_set_default(struct asus_wmi *asus)
+@@ -3749,6 +4012,7 @@ static int throttle_thermal_policy_set_default(struct asus_wmi *asus)
  	return throttle_thermal_policy_write(asus);
  }
  
@@ -7270,7 +6800,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t throttle_thermal_policy_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -3792,6 +3929,7 @@ static ssize_t throttle_thermal_policy_store(struct device *dev,
+@@ -3792,6 +4056,7 @@ static ssize_t throttle_thermal_policy_store(struct device *dev,
   * Throttle thermal policy: 0 - default, 1 - overboost, 2 - silent
   */
  static DEVICE_ATTR_RW(throttle_thermal_policy);
@@ -7278,7 +6808,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Platform profile ***********************************************************/
  static int asus_wmi_platform_profile_get(struct device *dev,
-@@ -3811,7 +3949,7 @@ static int asus_wmi_platform_profile_get(struct device *dev,
+@@ -3811,7 +4076,7 @@ static int asus_wmi_platform_profile_get(struct device *dev,
  		*profile = PLATFORM_PROFILE_PERFORMANCE;
  		break;
  	case ASUS_THROTTLE_THERMAL_POLICY_SILENT:
@@ -7287,7 +6817,7 @@ index 47cc766624d7..942f1013d6cb 100644
  		break;
  	default:
  		return -EINVAL;
-@@ -3835,7 +3973,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
+@@ -3835,7 +4100,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
  	case PLATFORM_PROFILE_BALANCED:
  		tp = ASUS_THROTTLE_THERMAL_POLICY_DEFAULT;
  		break;
@@ -7296,7 +6826,7 @@ index 47cc766624d7..942f1013d6cb 100644
  		tp = ASUS_THROTTLE_THERMAL_POLICY_SILENT;
  		break;
  	default:
-@@ -3848,7 +3986,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
+@@ -3848,7 +4113,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
  
  static int asus_wmi_platform_profile_probe(void *drvdata, unsigned long *choices)
  {
@@ -7305,103 +6835,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	set_bit(PLATFORM_PROFILE_BALANCED, choices);
  	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
  
-@@ -4101,43 +4239,37 @@ static int read_screenpad_brightness(struct backlight_device *bd)
- 		return err;
- 	/* The device brightness can only be read if powered, so return stored */
- 	if (err == BACKLIGHT_POWER_OFF)
--		return asus->driver->screenpad_brightness - ASUS_SCREENPAD_BRIGHT_MIN;
-+		return bd->props.brightness;
- 
- 	err = asus_wmi_get_devstate(asus, ASUS_WMI_DEVID_SCREENPAD_LIGHT, &retval);
- 	if (err < 0)
- 		return err;
- 
--	return (retval & ASUS_WMI_DSTS_BRIGHTNESS_MASK) - ASUS_SCREENPAD_BRIGHT_MIN;
-+	return (retval & ASUS_WMI_DSTS_BRIGHTNESS_MASK);
- }
- 
- static int update_screenpad_bl_status(struct backlight_device *bd)
- {
--	struct asus_wmi *asus = bl_get_data(bd);
--	int power, err = 0;
-+	int err = 0;
- 	u32 ctrl_param;
- 
--	power = read_screenpad_backlight_power(asus);
--	if (power < 0)
--		return power;
--
--	if (bd->props.power != power) {
--		if (power != BACKLIGHT_POWER_ON) {
--			/* Only brightness > 0 can power it back on */
--			ctrl_param = asus->driver->screenpad_brightness - ASUS_SCREENPAD_BRIGHT_MIN;
--			err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_LIGHT,
--						    ctrl_param, NULL);
--		} else {
--			err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, 0, NULL);
--		}
--	} else if (power == BACKLIGHT_POWER_ON) {
--		/* Only set brightness if powered on or we get invalid/unsync state */
--		ctrl_param = bd->props.brightness + ASUS_SCREENPAD_BRIGHT_MIN;
-+	ctrl_param = bd->props.brightness;
-+	if (ctrl_param >= 0 && bd->props.power) {
-+		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, 1,
-+					    NULL);
-+		if (err < 0)
-+			return err;
-+		ctrl_param = bd->props.brightness;
- 		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_LIGHT, ctrl_param, NULL);
-+		if (err < 0)
-+			return err;
- 	}
- 
--	/* Ensure brightness is stored to turn back on with */
--	if (err == 0)
--		asus->driver->screenpad_brightness = bd->props.brightness + ASUS_SCREENPAD_BRIGHT_MIN;
-+	if (!bd->props.power) {
-+		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, 0, NULL);
-+		if (err < 0)
-+			return err;
-+	}
- 
- 	return err;
- }
-@@ -4155,22 +4287,19 @@ static int asus_screenpad_init(struct asus_wmi *asus)
- 	int err, power;
- 	int brightness = 0;
- 
--	power = read_screenpad_backlight_power(asus);
-+	power = asus_wmi_get_devstate_simple(asus, ASUS_WMI_DEVID_SCREENPAD_POWER);
- 	if (power < 0)
- 		return power;
- 
--	if (power != BACKLIGHT_POWER_OFF) {
-+	if (power) {
- 		err = asus_wmi_get_devstate(asus, ASUS_WMI_DEVID_SCREENPAD_LIGHT, &brightness);
- 		if (err < 0)
- 			return err;
- 	}
--	/* default to an acceptable min brightness on boot if too low */
--	if (brightness < ASUS_SCREENPAD_BRIGHT_MIN)
--		brightness = ASUS_SCREENPAD_BRIGHT_DEFAULT;
- 
- 	memset(&props, 0, sizeof(struct backlight_properties));
- 	props.type = BACKLIGHT_RAW; /* ensure this bd is last to be picked */
--	props.max_brightness = ASUS_SCREENPAD_BRIGHT_MAX - ASUS_SCREENPAD_BRIGHT_MIN;
-+	props.max_brightness = ASUS_SCREENPAD_BRIGHT_MAX;
- 	bd = backlight_device_register("asus_screenpad",
- 				       &asus->platform_device->dev, asus,
- 				       &asus_screenpad_bl_ops, &props);
-@@ -4181,7 +4310,7 @@ static int asus_screenpad_init(struct asus_wmi *asus)
- 
- 	asus->screenpad_backlight_device = bd;
- 	asus->driver->screenpad_brightness = brightness;
--	bd->props.brightness = brightness - ASUS_SCREENPAD_BRIGHT_MIN;
-+	bd->props.brightness = brightness;
- 	bd->props.power = power;
- 	backlight_update_status(bd);
- 
-@@ -4393,27 +4522,29 @@ static struct attribute *platform_attributes[] = {
+@@ -4393,27 +4658,29 @@ static struct attribute *platform_attributes[] = {
  	&dev_attr_camera.attr,
  	&dev_attr_cardr.attr,
  	&dev_attr_touchpad.attr,
@@ -7449,7 +6883,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	NULL
  };
  
-@@ -4435,7 +4566,11 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
+@@ -4435,7 +4702,11 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
  		devid = ASUS_WMI_DEVID_LID_RESUME;
  	else if (attr == &dev_attr_als_enable.attr)
  		devid = ASUS_WMI_DEVID_ALS_ENABLE;
@@ -7462,7 +6896,7 @@ index 47cc766624d7..942f1013d6cb 100644
  		devid = ASUS_WMI_DEVID_CHARGE_MODE;
  	else if (attr == &dev_attr_egpu_enable.attr)
  		ok = asus->egpu_enable_available;
-@@ -4473,6 +4608,7 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
+@@ -4473,6 +4744,7 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
  		ok = asus->mini_led_dev_id != 0;
  	else if (attr == &dev_attr_available_mini_led_mode.attr)
  		ok = asus->mini_led_dev_id != 0;
@@ -7470,7 +6904,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  	if (devid != -1) {
  		ok = !(asus_wmi_get_devstate_simple(asus, devid) < 0);
-@@ -4712,7 +4848,23 @@ static int asus_wmi_add(struct platform_device *pdev)
+@@ -4712,7 +4984,23 @@ static int asus_wmi_add(struct platform_device *pdev)
  	if (err)
  		goto fail_platform;
  
@@ -7494,7 +6928,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	asus->ppt_pl2_sppt = 5;
  	asus->ppt_pl1_spl = 5;
  	asus->ppt_apu_sppt = 5;
-@@ -4725,8 +4877,6 @@ static int asus_wmi_add(struct platform_device *pdev)
+@@ -4725,8 +5013,6 @@ static int asus_wmi_add(struct platform_device *pdev)
  	asus->dgpu_disable_available = asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_DGPU);
  	asus->kbd_rgb_state_available = asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_TUF_RGB_STATE);
  	asus->oobe_state_available = asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_OOBE);
@@ -7503,7 +6937,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  	if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_MINI_LED_MODE))
  		asus->mini_led_dev_id = ASUS_WMI_DEVID_MINI_LED_MODE;
-@@ -4737,17 +4887,18 @@ static int asus_wmi_add(struct platform_device *pdev)
+@@ -4737,17 +5023,18 @@ static int asus_wmi_add(struct platform_device *pdev)
  		asus->gpu_mux_dev = ASUS_WMI_DEVID_GPU_MUX;
  	else if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_GPU_MUX_VIVO))
  		asus->gpu_mux_dev = ASUS_WMI_DEVID_GPU_MUX_VIVO;
@@ -7527,7 +6961,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	err = fan_boost_mode_check_present(asus);
  	if (err)
  		goto fail_fan_boost_mode;
-@@ -4913,34 +5064,6 @@ static int asus_hotk_resume(struct device *device)
+@@ -4913,34 +5200,6 @@ static int asus_hotk_resume(struct device *device)
  	return 0;
  }
  
@@ -7562,19 +6996,10 @@ index 47cc766624d7..942f1013d6cb 100644
  static int asus_hotk_restore(struct device *device)
  {
  	struct asus_wmi *asus = dev_get_drvdata(device);
-@@ -4988,11 +5111,34 @@ static int asus_hotk_restore(struct device *device)
+@@ -4988,11 +5247,50 @@ static int asus_hotk_restore(struct device *device)
  	return 0;
  }
  
-+static void asus_ally_s2idle_restore(void)
-+{
-+	if (use_ally_mcu_hack == ASUS_WMI_ALLY_MCU_HACK_ENABLED) {
-+		acpi_execute_simple_method(NULL, ASUS_USB0_PWR_EC0_CSEE,
-+					   ASUS_USB0_PWR_EC0_CSEE_ON);
-+		msleep(ASUS_USB0_PWR_EC0_CSEE_WAIT);
-+	}
-+}
-+
 +static int asus_hotk_prepare(struct device *device)
 +{
 +	if (use_ally_mcu_hack == ASUS_WMI_ALLY_MCU_HACK_ENABLED) {
@@ -7585,10 +7010,35 @@ index 47cc766624d7..942f1013d6cb 100644
 +	return 0;
 +}
 +
++#if defined(CONFIG_SUSPEND)
++static void asus_ally_s2idle_restore(void)
++{
++	if (use_ally_mcu_hack == ASUS_WMI_ALLY_MCU_HACK_ENABLED) {
++		acpi_execute_simple_method(NULL, ASUS_USB0_PWR_EC0_CSEE,
++					   ASUS_USB0_PWR_EC0_CSEE_ON);
++		msleep(ASUS_USB0_PWR_EC0_CSEE_WAIT);
++	}
++}
++
 +/* Use only for Ally devices due to the wake_on_ac */
 +static struct acpi_s2idle_dev_ops asus_ally_s2idle_dev_ops = {
 +	.restore = asus_ally_s2idle_restore,
 +};
++
++static void asus_s2idle_check_register(void)
++{
++	if (acpi_register_lps0_dev(&asus_ally_s2idle_dev_ops))
++		pr_warn("failed to register LPS0 sleep handler in asus-wmi\n");
++}
++
++static void asus_s2idle_check_unregister(void)
++{
++	acpi_unregister_lps0_dev(&asus_ally_s2idle_dev_ops);
++}
++#else
++static void asus_s2idle_check_register(void) {}
++static void asus_s2idle_check_unregister(void) {}
++#endif /* CONFIG_SUSPEND */
 +
  static const struct dev_pm_ops asus_pm_ops = {
  	.thaw = asus_hotk_thaw,
@@ -7598,27 +7048,47 @@ index 47cc766624d7..942f1013d6cb 100644
  	.prepare = asus_hotk_prepare,
  };
  
-@@ -5020,6 +5166,10 @@ static int asus_wmi_probe(struct platform_device *pdev)
+@@ -5020,6 +5318,8 @@ static int asus_wmi_probe(struct platform_device *pdev)
  			return ret;
  	}
  
-+	ret = acpi_register_lps0_dev(&asus_ally_s2idle_dev_ops);
-+	if (ret)
-+		pr_warn("failed to register LPS0 sleep handler in asus-wmi\n");
++	asus_s2idle_check_register();
 +
  	return asus_wmi_add(pdev);
  }
  
-@@ -5052,6 +5202,7 @@ EXPORT_SYMBOL_GPL(asus_wmi_register_driver);
+@@ -5052,6 +5352,8 @@ EXPORT_SYMBOL_GPL(asus_wmi_register_driver);
  
  void asus_wmi_unregister_driver(struct asus_wmi_driver *driver)
  {
-+	acpi_unregister_lps0_dev(&asus_ally_s2idle_dev_ops);
++	asus_s2idle_check_unregister();
++
  	platform_device_unregister(driver->platform_device);
  	platform_driver_unregister(&driver->platform_driver);
  	used = false;
+diff --git a/drivers/platform/x86/asus-wmi.h b/drivers/platform/x86/asus-wmi.h
+index 018dfde40..5cd4392b9 100644
+--- a/drivers/platform/x86/asus-wmi.h
++++ b/drivers/platform/x86/asus-wmi.h
+@@ -18,6 +18,7 @@
+ #include <linux/i8042.h>
+ 
+ #define ASUS_WMI_KEY_IGNORE (-1)
++#define ASUS_WMI_KEY_ARMOURY	0xffff01
+ #define ASUS_WMI_BRN_DOWN	0x2e
+ #define ASUS_WMI_BRN_UP		0x2f
+ 
+@@ -40,7 +41,7 @@ struct quirk_entry {
+ 	bool wmi_force_als_set;
+ 	bool wmi_ignore_fan;
+ 	bool filter_i8042_e1_extended_codes;
+-	bool ignore_key_wlan;
++	int key_wlan_event;
+ 	enum asus_wmi_tablet_switch_mode tablet_switch_mode;
+ 	int wapf;
+ 	/*
 diff --git a/include/linux/platform_data/x86/asus-wmi.h b/include/linux/platform_data/x86/asus-wmi.h
-index 783e2a336861..de281fd850c0 100644
+index 783e2a336..bf428546f 100644
 --- a/include/linux/platform_data/x86/asus-wmi.h
 +++ b/include/linux/platform_data/x86/asus-wmi.h
 @@ -6,6 +6,9 @@
@@ -7663,7 +7133,7 @@ index 783e2a336861..de281fd850c0 100644
  /* gpu mux switch, 0 = dGPU, 1 = Optimus */
  #define ASUS_WMI_DEVID_GPU_MUX		0x00090016
  #define ASUS_WMI_DEVID_GPU_MUX_VIVO	0x00090026
-@@ -157,9 +172,33 @@
+@@ -157,17 +172,71 @@
  #define ASUS_WMI_DSTS_MAX_BRIGTH_MASK	0x0000FF00
  #define ASUS_WMI_DSTS_LIGHTBAR_MASK	0x0000000F
  
@@ -7673,12 +7143,29 @@ index 783e2a336861..de281fd850c0 100644
 +	ASUS_WMI_ALLY_MCU_HACK_DISABLED,
 +};
 +
++struct asus_hid_listener {
++	struct list_head list;
++	void (*brightness_set)(struct asus_hid_listener *listener, int brightness);
++};
++
++enum asus_hid_event {
++	ASUS_EV_BRTUP,
++	ASUS_EV_BRTDOWN,
++	ASUS_EV_BRTTOGGLE,
++};
++
++#define ASUS_EV_MAX_BRIGHTNESS 3
++
  #if IS_REACHABLE(CONFIG_ASUS_WMI)
 +void set_ally_mcu_hack(enum asus_ally_mcu_hack status);
 +void set_ally_mcu_powersave(bool enabled);
 +int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval);
 +int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval);
  int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1, u32 *retval);
++
++int asus_hid_register_listener(struct asus_hid_listener *cdev);
++void asus_hid_unregister_listener(struct asus_hid_listener *cdev);
++int asus_hid_event(enum asus_hid_event event);
  #else
 +static inline void set_ally_mcu_hack(enum asus_ally_mcu_hack status)
 +{
@@ -7686,17 +7173,42 @@ index 783e2a336861..de281fd850c0 100644
 +static inline void set_ally_mcu_powersave(bool enabled)
 +{
 +}
-+static inline int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval)
++static inline int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval)
 +{
 +	return -ENODEV;
 +}
-+static inline int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval)
++static inline int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval)
 +{
 +	return -ENODEV;
 +}
  static inline int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1,
  					   u32 *retval)
  {
--- 
-2.50.1
-
+ 	return -ENODEV;
+ }
++
++static inline int asus_hid_register_listener(struct asus_hid_listener *bdev)
++{
++	return -ENODEV;
++}
++static inline void asus_hid_unregister_listener(struct asus_hid_listener *bdev)
++{
++}
++static inline int asus_hid_event(enum asus_hid_event event)
++{
++	return -ENODEV;
++}
+ #endif
+ 
+ /* To be used by both hid-asus and asus-wmi to determine which controls kbd_brightness */
++#if IS_REACHABLE(CONFIG_ASUS_WMI) || IS_REACHABLE(CONFIG_HID_ASUS)
+ static const struct dmi_system_id asus_use_hid_led_dmi_ids[] = {
+ 	{
+ 		.matches = {
+@@ -206,5 +275,6 @@ static const struct dmi_system_id asus_use_hid_led_dmi_ids[] = {
+ 	},
+ 	{ },
+ };
++#endif
+ 
+ #endif	/* __PLATFORM_DATA_X86_ASUS_WMI_H */

--- a/6.15/0003-bbr3.patch
+++ b/6.15/0003-bbr3.patch
@@ -1,7 +1,7 @@
-From 3c311e38a0083539839f47260633cae7876d11a8 Mon Sep 17 00:00:00 2001
+From 54df6e1e7c824b9936f4edc3daf9bc8575742371 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:07 +0200
-Subject: [PATCH 3/6] bbr3
+Subject: [PATCH 3/7] bbr3
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -24,7 +24,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  16 files changed, 1941 insertions(+), 555 deletions(-)
 
 diff --git a/include/linux/tcp.h b/include/linux/tcp.h
-index 5c7c5038d47b..56286a2c7bca 100644
+index 5c7c5038d..56286a2c7 100644
 --- a/include/linux/tcp.h
 +++ b/include/linux/tcp.h
 @@ -248,7 +248,8 @@ struct tcp_sock {
@@ -48,7 +48,7 @@ index 5c7c5038d47b..56286a2c7bca 100644
  
  	/* RX read-write hotpath cache lines */
 diff --git a/include/net/inet_connection_sock.h b/include/net/inet_connection_sock.h
-index 1735db332aab..2c4a94af7093 100644
+index 1735db332..2c4a94af7 100644
 --- a/include/net/inet_connection_sock.h
 +++ b/include/net/inet_connection_sock.h
 @@ -132,8 +132,8 @@ struct inet_connection_sock {
@@ -63,7 +63,7 @@ index 1735db332aab..2c4a94af7093 100644
  
  #define ICSK_TIME_RETRANS	1	/* Retransmit timer */
 diff --git a/include/net/tcp.h b/include/net/tcp.h
-index 4450c384ef17..61f73ca30be3 100644
+index 4450c384e..61f73ca30 100644
 --- a/include/net/tcp.h
 +++ b/include/net/tcp.h
 @@ -379,11 +379,14 @@ static inline void tcp_dec_quickack_mode(struct sock *sk)
@@ -241,7 +241,7 @@ index 4450c384ef17..61f73ca30be3 100644
  static inline void tcp_plb_init(const struct sock *sk,
  				struct tcp_plb_state *plb)
 diff --git a/include/uapi/linux/inet_diag.h b/include/uapi/linux/inet_diag.h
-index 86bb2e8b17c9..9d9a3eb2ce9b 100644
+index 86bb2e8b1..9d9a3eb2c 100644
 --- a/include/uapi/linux/inet_diag.h
 +++ b/include/uapi/linux/inet_diag.h
 @@ -229,6 +229,29 @@ struct tcp_bbr_info {
@@ -275,7 +275,7 @@ index 86bb2e8b17c9..9d9a3eb2ce9b 100644
  
  union tcp_cc_info {
 diff --git a/include/uapi/linux/rtnetlink.h b/include/uapi/linux/rtnetlink.h
-index dab9493c791b..cce4975fdcfe 100644
+index dab9493c7..cce4975fd 100644
 --- a/include/uapi/linux/rtnetlink.h
 +++ b/include/uapi/linux/rtnetlink.h
 @@ -517,12 +517,14 @@ enum {
@@ -295,19 +295,19 @@ index dab9493c791b..cce4975fdcfe 100644
  struct rta_session {
  	__u8	proto;
 diff --git a/include/uapi/linux/tcp.h b/include/uapi/linux/tcp.h
-index dc8fdc80e16b..6b2003dbae81 100644
+index dc8fdc80e..0d579d558 100644
 --- a/include/uapi/linux/tcp.h
 +++ b/include/uapi/linux/tcp.h
 @@ -184,6 +184,7 @@ enum tcp_fastopen_client_fail {
  #define TCPI_OPT_ECN_SEEN	16 /* we received at least one packet with ECT */
  #define TCPI_OPT_SYN_DATA	32 /* SYN-ACK acked data in SYN sent or rcvd */
  #define TCPI_OPT_USEC_TS	64 /* usec timestamps */
-+#define TCPI_OPT_ECN_LOW	128 /* Low-latency ECN enabled at conn init */
++#define TCPI_OPT_ECN_LOW	128 /* Low-latency ECN configured at init */
  
  /*
   * Sender's congestion state indicating normal or abnormal situations
 diff --git a/net/ipv4/Kconfig b/net/ipv4/Kconfig
-index 6d2c97f8e9ef..ddc116ef22cb 100644
+index 6d2c97f8e..ddc116ef2 100644
 --- a/net/ipv4/Kconfig
 +++ b/net/ipv4/Kconfig
 @@ -669,15 +669,18 @@ config TCP_CONG_BBR
@@ -339,7 +339,7 @@ index 6d2c97f8e9ef..ddc116ef22cb 100644
  choice
  	prompt "Default TCP congestion control"
 diff --git a/net/ipv4/bpf_tcp_ca.c b/net/ipv4/bpf_tcp_ca.c
-index e01492234b0b..27893b774e08 100644
+index e01492234..27893b774 100644
 --- a/net/ipv4/bpf_tcp_ca.c
 +++ b/net/ipv4/bpf_tcp_ca.c
 @@ -280,7 +280,7 @@ static void bpf_tcp_ca_pkts_acked(struct sock *sk, const struct ack_sample *samp
@@ -361,7 +361,7 @@ index e01492234b0b..27893b774e08 100644
  	.undo_cwnd = bpf_tcp_ca_undo_cwnd,
  	.sndbuf_expand = bpf_tcp_ca_sndbuf_expand,
 diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
-index 905cf7635f77..c8c90c1b31ed 100644
+index 905cf7635..c8c90c1b3 100644
 --- a/net/ipv4/tcp.c
 +++ b/net/ipv4/tcp.c
 @@ -3411,6 +3411,7 @@ int tcp_disconnect(struct sock *sk, int flags)
@@ -382,7 +382,7 @@ index 905cf7635f77..c8c90c1b31ed 100644
  		info->tcpi_options |= TCPI_OPT_SYN_DATA;
  	if (tp->tcp_usec_ts)
 diff --git a/net/ipv4/tcp_bbr.c b/net/ipv4/tcp_bbr.c
-index 760941e55153..066da5e5747c 100644
+index 760941e55..066da5e57 100644
 --- a/net/ipv4/tcp_bbr.c
 +++ b/net/ipv4/tcp_bbr.c
 @@ -1,18 +1,19 @@
@@ -3028,7 +3028,7 @@ index 760941e55153..066da5e5747c 100644
  MODULE_DESCRIPTION("TCP BBR (Bottleneck Bandwidth and RTT)");
 +MODULE_VERSION(__stringify(BBR_VERSION));
 diff --git a/net/ipv4/tcp_cong.c b/net/ipv4/tcp_cong.c
-index df758adbb445..e98e5dbc050e 100644
+index df758adbb..e98e5dbc0 100644
 --- a/net/ipv4/tcp_cong.c
 +++ b/net/ipv4/tcp_cong.c
 @@ -237,6 +237,7 @@ void tcp_init_congestion_control(struct sock *sk)
@@ -3040,7 +3040,7 @@ index df758adbb445..e98e5dbc050e 100644
  		icsk->icsk_ca_ops->init(sk);
  	if (tcp_ca_needs_ecn(sk))
 diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
-index bce2a111cc9e..ba2db4641c2b 100644
+index ca24c2ea3..4181f212e 100644
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
 @@ -381,7 +381,7 @@ static void tcp_data_ecn_check(struct sock *sk, const struct sk_buff *skb)
@@ -3156,7 +3156,7 @@ index bce2a111cc9e..ba2db4641c2b 100644
  	return 1;
  
  old_ack:
-@@ -5791,13 +5816,14 @@ static void __tcp_ack_snd_check(struct sock *sk, int ofo_possible)
+@@ -5793,13 +5818,14 @@ static void __tcp_ack_snd_check(struct sock *sk, int ofo_possible)
  
  	    /* More than one full frame received... */
  	if (((tp->rcv_nxt - tp->rcv_wup) > inet_csk(sk)->icsk_ack.rcv_mss &&
@@ -3174,7 +3174,7 @@ index bce2a111cc9e..ba2db4641c2b 100644
  	    tcp_in_quickack_mode(sk) ||
  	    /* Protocol state mandates a one-time immediate ACK */
 diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
-index fb9349be36b8..3c53e39f8201 100644
+index fb9349be3..3c53e39f8 100644
 --- a/net/ipv4/tcp_minisocks.c
 +++ b/net/ipv4/tcp_minisocks.c
 @@ -472,6 +472,8 @@ void tcp_ca_openreq_child(struct sock *sk, const struct dst_entry *dst)
@@ -3187,7 +3187,7 @@ index fb9349be36b8..3c53e39f8201 100644
  		const struct tcp_congestion_ops *ca;
  
 diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
-index 13295a59d22e..3effb6e51e96 100644
+index 13295a59d..3effb6e51 100644
 --- a/net/ipv4/tcp_output.c
 +++ b/net/ipv4/tcp_output.c
 @@ -339,10 +339,9 @@ static void tcp_ecn_send_syn(struct sock *sk, struct sk_buff *skb)
@@ -3298,7 +3298,7 @@ index 13295a59d22e..3effb6e51e96 100644
  		goto rearm_timer;
  
 diff --git a/net/ipv4/tcp_rate.c b/net/ipv4/tcp_rate.c
-index a8f6d9d06f2e..8737f2134648 100644
+index a8f6d9d06..8737f2134 100644
 --- a/net/ipv4/tcp_rate.c
 +++ b/net/ipv4/tcp_rate.c
 @@ -34,6 +34,24 @@
@@ -3378,7 +3378,7 @@ index a8f6d9d06f2e..8737f2134648 100644
  	rs->interval_us = max(snd_us, ack_us);
  
 diff --git a/net/ipv4/tcp_timer.c b/net/ipv4/tcp_timer.c
-index e4c616bbd727..e4a7a25d667d 100644
+index e4c616bbd..e4a7a25d6 100644
 --- a/net/ipv4/tcp_timer.c
 +++ b/net/ipv4/tcp_timer.c
 @@ -565,7 +565,7 @@ void tcp_retransmit_timer(struct sock *sk)
@@ -3399,6 +3399,3 @@ index e4c616bbd727..e4a7a25d667d 100644
  	tcp_mstamp_refresh(tcp_sk(sk));
  	event = icsk->icsk_pending;
  
--- 
-2.50.1
-

--- a/6.15/0004-block.patch
+++ b/6.15/0004-block.patch
@@ -1,0 +1,285 @@
+From 99ebe5c8fef3a67c5bc3b92649a39ceba446ddee Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Fri, 15 Aug 2025 21:56:53 +0200
+Subject: [PATCH 4/7] block
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ block/bfq-iosched.c | 52 +++++++++++++++++++++++++++++++++++++++------
+ block/bfq-iosched.h | 12 +++++++++--
+ block/mq-deadline.c | 48 +++++++++++++++++++++++++++++++++++------
+ 3 files changed, 96 insertions(+), 16 deletions(-)
+
+diff --git a/block/bfq-iosched.c b/block/bfq-iosched.c
+index 67c42d276..2f19c38ef 100644
+--- a/block/bfq-iosched.c
++++ b/block/bfq-iosched.c
+@@ -467,6 +467,21 @@ static struct bfq_io_cq *bfq_bic_lookup(struct request_queue *q)
+ 	return icq;
+ }
+ 
++static struct bfq_io_cq *bfq_bic_try_lookup(struct request_queue *q)
++{
++	if (!current->io_context)
++		return NULL;
++	if (spin_trylock_irq(&q->queue_lock)) {
++		struct bfq_io_cq *icq;
++
++		icq = icq_to_bic(ioc_lookup_icq(q));
++		spin_unlock_irq(&q->queue_lock);
++		return icq;
++	}
++
++	return NULL;
++}
++
+ /*
+  * Scheduler run of queue, if there are requests pending and no one in the
+  * driver that will restart queueing.
+@@ -2463,10 +2478,21 @@ static bool bfq_bio_merge(struct request_queue *q, struct bio *bio,
+ 	 * returned by bfq_bic_lookup does not go away before
+ 	 * bfqd->lock is taken.
+ 	 */
+-	struct bfq_io_cq *bic = bfq_bic_lookup(q);
++	struct bfq_io_cq *bic = bfq_bic_try_lookup(q);
+ 	bool ret;
+ 
+-	spin_lock_irq(&bfqd->lock);
++	/*
++	 * bio merging is called for every bio queued, and it's very easy
++	 * to run into contention because of that. If we fail getting
++	 * the dd lock, just skip this merge attempt. For related IO, the
++	 * plug will be the successful merging point. If we get here, we
++	 * already failed doing the obvious merge. Chances of actually
++	 * getting a merge off this path is a lot slimmer, so skipping an
++	 * occassional lookup that will most likely not succeed anyway should
++	 * not be a problem.
++	 */
++	if (!spin_trylock_irq(&bfqd->lock))
++		return false;
+ 
+ 	if (bic) {
+ 		/*
+@@ -5315,6 +5341,18 @@ static struct request *bfq_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 	struct bfq_queue *in_serv_queue;
+ 	bool waiting_rq, idle_timer_disabled = false;
+ 
++	/*
++	 * If someone else is already dispatching, skip this one. This will
++	 * defer the next dispatch event to when something completes, and could
++	 * potentially lower the queue depth for contended cases.
++	 *
++	 * See the logic in blk_mq_do_dispatch_sched(), which loops and
++	 * retries if nothing is dispatched.
++	 */
++	if (test_bit(BFQ_DISPATCHING, &bfqd->run_state) ||
++	    test_and_set_bit_lock(BFQ_DISPATCHING, &bfqd->run_state))
++		return NULL;
++
+ 	spin_lock_irq(&bfqd->lock);
+ 
+ 	in_serv_queue = bfqd->in_service_queue;
+@@ -5326,6 +5364,7 @@ static struct request *bfq_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 			waiting_rq && !bfq_bfqq_wait_request(in_serv_queue);
+ 	}
+ 
++	clear_bit_unlock(BFQ_DISPATCHING, &bfqd->run_state);
+ 	spin_unlock_irq(&bfqd->lock);
+ 	bfq_update_dispatch_stats(hctx->queue, rq,
+ 			idle_timer_disabled ? in_serv_queue : NULL,
+@@ -6248,10 +6287,9 @@ static inline void bfq_update_insert_stats(struct request_queue *q,
+ 
+ static struct bfq_queue *bfq_init_rq(struct request *rq);
+ 
+-static void bfq_insert_request(struct blk_mq_hw_ctx *hctx, struct request *rq,
++static void bfq_insert_request(struct request_queue *q, struct request *rq,
+ 			       blk_insert_t flags)
+ {
+-	struct request_queue *q = hctx->queue;
+ 	struct bfq_data *bfqd = q->elevator->elevator_data;
+ 	struct bfq_queue *bfqq;
+ 	bool idle_timer_disabled = false;
+@@ -6313,7 +6351,7 @@ static void bfq_insert_requests(struct blk_mq_hw_ctx *hctx,
+ 
+ 		rq = list_first_entry(list, struct request, queuelist);
+ 		list_del_init(&rq->queuelist);
+-		bfq_insert_request(hctx, rq, flags);
++		bfq_insert_request(hctx->queue, rq, flags);
+ 	}
+ }
+ 
+@@ -7251,6 +7289,8 @@ static int bfq_init_queue(struct request_queue *q, struct elevator_type *e)
+ 	q->elevator = eq;
+ 	spin_unlock_irq(&q->queue_lock);
+ 
++	spin_lock_init(&bfqd->lock);
++
+ 	/*
+ 	 * Our fallback bfqq if bfq_find_alloc_queue() runs into OOM issues.
+ 	 * Grab a permanent reference to it, so that the normal code flow
+@@ -7368,8 +7408,6 @@ static int bfq_init_queue(struct request_queue *q, struct elevator_type *e)
+ 	/* see comments on the definition of next field inside bfq_data */
+ 	bfqd->actuator_load_threshold = 4;
+ 
+-	spin_lock_init(&bfqd->lock);
+-
+ 	/*
+ 	 * The invocation of the next bfq_create_group_hierarchy
+ 	 * function is the head of a chain of function calls
+diff --git a/block/bfq-iosched.h b/block/bfq-iosched.h
+index 31217f196..a250c5599 100644
+--- a/block/bfq-iosched.h
++++ b/block/bfq-iosched.h
+@@ -504,12 +504,22 @@ struct bfq_io_cq {
+ 	unsigned int requests;	/* Number of requests this process has in flight */
+ };
+ 
++enum {
++	BFQ_DISPATCHING	= 0,
++};
++
+ /**
+  * struct bfq_data - per-device data structure.
+  *
+  * All the fields are protected by @lock.
+  */
+ struct bfq_data {
++	struct {
++		spinlock_t lock;
++	} ____cacheline_aligned_in_smp;
++
++	unsigned long run_state;
++
+ 	/* device request queue */
+ 	struct request_queue *queue;
+ 	/* dispatch queue */
+@@ -795,8 +805,6 @@ struct bfq_data {
+ 	/* fallback dummy bfqq for extreme OOM conditions */
+ 	struct bfq_queue oom_bfqq;
+ 
+-	spinlock_t lock;
+-
+ 	/*
+ 	 * bic associated with the task issuing current bio for
+ 	 * merging. This and the next field are used as a support to
+diff --git a/block/mq-deadline.c b/block/mq-deadline.c
+index ed0e0f70f..ccfbd61bd 100644
+--- a/block/mq-deadline.c
++++ b/block/mq-deadline.c
+@@ -79,10 +79,20 @@ struct dd_per_prio {
+ 	struct io_stats_per_prio stats;
+ };
+ 
++enum {
++	DD_DISPATCHING	= 0,
++};
++
+ struct deadline_data {
+ 	/*
+ 	 * run time data
+ 	 */
++	struct {
++		spinlock_t lock;
++		spinlock_t zone_lock;
++	} ____cacheline_aligned_in_smp;
++
++	unsigned long run_state;
+ 
+ 	struct dd_per_prio per_prio[DD_PRIO_COUNT];
+ 
+@@ -100,8 +110,6 @@ struct deadline_data {
+ 	int front_merges;
+ 	u32 async_depth;
+ 	int prio_aging_expire;
+-
+-	spinlock_t lock;
+ };
+ 
+ /* Maps an I/O priority class to a deadline scheduler priority. */
+@@ -466,6 +474,18 @@ static struct request *dd_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 	struct request *rq;
+ 	enum dd_prio prio;
+ 
++	/*
++	 * If someone else is already dispatching, skip this one. This will
++	 * defer the next dispatch event to when something completes, and could
++	 * potentially lower the queue depth for contended cases.
++	 *
++	 * See the logic in blk_mq_do_dispatch_sched(), which loops and
++	 * retries if nothing is dispatched.
++	 */
++	if (test_bit(DD_DISPATCHING, &dd->run_state) ||
++	    test_and_set_bit_lock(DD_DISPATCHING, &dd->run_state))
++		return NULL;
++
+ 	spin_lock(&dd->lock);
+ 	rq = dd_dispatch_prio_aged_requests(dd, now);
+ 	if (rq)
+@@ -482,6 +502,7 @@ static struct request *dd_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 	}
+ 
+ unlock:
++	clear_bit_unlock(DD_DISPATCHING, &dd->run_state);
+ 	spin_unlock(&dd->lock);
+ 
+ 	return rq;
+@@ -571,6 +592,9 @@ static int dd_init_sched(struct request_queue *q, struct elevator_type *e)
+ 
+ 	eq->elevator_data = dd;
+ 
++	spin_lock_init(&dd->lock);
++	spin_lock_init(&dd->zone_lock);
++
+ 	for (prio = 0; prio <= DD_PRIO_MAX; prio++) {
+ 		struct dd_per_prio *per_prio = &dd->per_prio[prio];
+ 
+@@ -587,7 +611,6 @@ static int dd_init_sched(struct request_queue *q, struct elevator_type *e)
+ 	dd->last_dir = DD_WRITE;
+ 	dd->fifo_batch = fifo_batch;
+ 	dd->prio_aging_expire = prio_aging_expire;
+-	spin_lock_init(&dd->lock);
+ 
+ 	/* We dispatch from request queue wide instead of hw queue */
+ 	blk_queue_flag_set(QUEUE_FLAG_SQ_SCHED, q);
+@@ -643,7 +666,19 @@ static bool dd_bio_merge(struct request_queue *q, struct bio *bio,
+ 	struct request *free = NULL;
+ 	bool ret;
+ 
+-	spin_lock(&dd->lock);
++	/*
++	 * bio merging is called for every bio queued, and it's very easy
++	 * to run into contention because of that. If we fail getting
++	 * the dd lock, just skip this merge attempt. For related IO, the
++	 * plug will be the successful merging point. If we get here, we
++	 * already failed doing the obvious merge. Chances of actually
++	 * getting a merge off this path is a lot slimmer, so skipping an
++	 * occassional lookup that will most likely not succeed anyway should
++	 * not be a problem.
++	 */
++	if (!spin_trylock(&dd->lock))
++		return false;
++
+ 	ret = blk_mq_sched_try_merge(q, bio, nr_segs, &free);
+ 	spin_unlock(&dd->lock);
+ 
+@@ -656,10 +691,9 @@ static bool dd_bio_merge(struct request_queue *q, struct bio *bio,
+ /*
+  * add rq to rbtree and fifo
+  */
+-static void dd_insert_request(struct blk_mq_hw_ctx *hctx, struct request *rq,
++static void dd_insert_request(struct request_queue *q, struct request *rq,
+ 			      blk_insert_t flags, struct list_head *free)
+ {
+-	struct request_queue *q = hctx->queue;
+ 	struct deadline_data *dd = q->elevator->elevator_data;
+ 	const enum dd_data_dir data_dir = rq_data_dir(rq);
+ 	u16 ioprio = req_get_ioprio(rq);
+@@ -717,7 +751,7 @@ static void dd_insert_requests(struct blk_mq_hw_ctx *hctx,
+ 
+ 		rq = list_first_entry(list, struct request, queuelist);
+ 		list_del_init(&rq->queuelist);
+-		dd_insert_request(hctx, rq, flags, &free);
++		dd_insert_request(q, rq, flags, &free);
+ 	}
+ 	spin_unlock(&dd->lock);
+ 

--- a/6.15/0005-cachy.patch
+++ b/6.15/0005-cachy.patch
@@ -7539,17 +7539,17 @@ index 000000000..e70a381fe
 +	  will be called vhba.
 diff --git a/drivers/scsi/vhba/Makefile b/drivers/scsi/vhba/Makefile
 new file mode 100644
-index 000000000..2d7524b66
+index 000000000..560d24689
 --- /dev/null
 +++ b/drivers/scsi/vhba/Makefile
 @@ -0,0 +1,4 @@
-+VHBA_VERSION := 20240917
++VHBA_VERSION := 20250329
 +
 +obj-$(CONFIG_VHBA)		+= vhba.o
 +ccflags-y := -DVHBA_VERSION=\"$(VHBA_VERSION)\" -Werror
 diff --git a/drivers/scsi/vhba/vhba.c b/drivers/scsi/vhba/vhba.c
 new file mode 100644
-index 000000000..878a3be0b
+index 000000000..64b09ece2
 --- /dev/null
 +++ b/drivers/scsi/vhba/vhba.c
 @@ -0,0 +1,1132 @@
@@ -8092,10 +8092,10 @@ index 000000000..878a3be0b
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
 +    .slave_alloc = vhba_slave_alloc,
 +#endif
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
-+    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
-+#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 +    .tag_alloc_policy_rr = true,
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
++    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
 +#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
 +    .use_blk_tags = 1,

--- a/6.15/0005-cachy.patch
+++ b/6.15/0005-cachy.patch
@@ -1,4 +1,4 @@
-From 121167381198a57897e6f2e408c7672835138ce6 Mon Sep 17 00:00:00 2001
+From 950ca5d450a2c5e8f0d4d829ddb26d69a3ae88ee Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:21 +0200
 Subject: [PATCH 5/7] cachy
@@ -147,7 +147,7 @@ index 76a34e0ae..186454e1c 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/Documentation/admin-guide/sysctl/vm.rst b/Documentation/admin-guide/sysctl/vm.rst
-index 8290177b4..2a94faa5a 100644
+index 8290177b4..f2e601171 100644
 --- a/Documentation/admin-guide/sysctl/vm.rst
 +++ b/Documentation/admin-guide/sysctl/vm.rst
 @@ -25,6 +25,9 @@ files can be found in mm/swap.c.
@@ -180,7 +180,7 @@ index 8290177b4..2a94faa5a 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 1.
++The default value is 15.
 +
 +
 +clean_low_ratio
@@ -201,7 +201,7 @@ index 8290177b4..2a94faa5a 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 15.
++The default value is 0.
 +
 +
 +clean_min_ratio
@@ -222,7 +222,7 @@ index 8290177b4..2a94faa5a 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 4.
++The default value is 15.
 +
 +
  compact_memory
@@ -9080,7 +9080,7 @@ index 682f40d56..434a25f7b 100644
  static DEFINE_MUTEX(userns_state_mutex);
  
 diff --git a/mm/Kconfig b/mm/Kconfig
-index e113f713b..825b5932d 100644
+index e113f713b..5fc1934a3 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
 @@ -462,6 +462,69 @@ config ARCH_WANT_OPTIMIZE_HUGETLB_VMEMMAP
@@ -9091,7 +9091,7 @@ index e113f713b..825b5932d 100644
 +	int "Default value for vm.anon_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 1
++	default 15
 +	help
 +	  This option sets the default value for vm.anon_min_ratio sysctl knob.
 +
@@ -9109,7 +9109,7 @@ index e113f713b..825b5932d 100644
 +	int "Default value for vm.clean_low_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 15
++	default 0
 +	help
 +	  This option sets the default value for vm.clean_low_ratio sysctl knob.
 +
@@ -9131,7 +9131,7 @@ index e113f713b..825b5932d 100644
 +	int "Default value for vm.clean_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 4
++	default 15
 +	help
 +	  This option sets the default value for vm.clean_min_ratio sysctl knob.
 +
@@ -9195,14 +9195,14 @@ index 213780e73..b6278caf4 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index eedce9321..8201039f1 100644
+index eedce9321..4e5329337 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -2732,6 +2732,7 @@ static void __init mem_init_print_info(void)
  		, K(totalhigh_pages())
  #endif
  		);
-+	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15a by Masahito Suzuki (forked from hakavlad's original le9 patch)");
++	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15 by Masahito Suzuki (forked from hakavlad's original le9 patch)");
  }
  
  void __init __weak arch_mm_preinit(void)

--- a/6.15/0005-cachy.patch
+++ b/6.15/0005-cachy.patch
@@ -1,16 +1,14 @@
-From 9e1ba99ba55457abd78c90121b3b77b84ba728e6 Mon Sep 17 00:00:00 2001
+From 121167381198a57897e6f2e408c7672835138ce6 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:21 +0200
-Subject: [PATCH 4/6] cachy
+Subject: [PATCH 5/7] cachy
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
- .gitignore                                    |    3 +
- .../ABI/testing/sysfs-driver-intel-xe-hwmon   |   24 +
+ .gitignore                                    |    2 +
  .../admin-guide/kernel-parameters.txt         |   12 +
  Documentation/admin-guide/sysctl/vm.rst       |   72 +
- MAINTAINERS                                   |    5 +
- Makefile                                      |   48 +-
+ Makefile                                      |   33 +-
  arch/Kconfig                                  |   19 +
  arch/x86/Kconfig.cpu                          |   70 +
  arch/x86/Makefile                             |   17 +
@@ -18,7 +16,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  arch/x86/pci/common.c                         |    7 +-
  block/Kconfig.iosched                         |   14 +
  block/Makefile                                |    8 +
- block/adios.c                                 | 1450 ++++++++
+ block/adios.c                                 | 1593 ++++++++
  block/elevator.c                              |   12 +
  drivers/Makefile                              |   13 +-
  drivers/ata/ahci.c                            |   23 +-
@@ -38,13 +36,17 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  drivers/gpu/drm/xe/xe_hwmon.c                 |  125 +-
  drivers/gpu/drm/xe/xe_pci.c                   |    4 +
  drivers/gpu/drm/xe/xe_pcode_api.h             |    3 +
+ drivers/hid/amd-sfh-hid/amd_sfh_client.c      |   23 +
+ drivers/hid/amd-sfh-hid/amd_sfh_hid.h         |    2 +-
+ drivers/hid/amd-sfh-hid/amd_sfh_pcie.c        |    4 +
+ drivers/hid/amd-sfh-hid/amd_sfh_pcie.h        |    1 +
  drivers/input/evdev.c                         |   19 +-
  drivers/md/dm-crypt.c                         |    5 +
  drivers/media/v4l2-core/Kconfig               |    5 +
  drivers/media/v4l2-core/Makefile              |    2 +
- drivers/media/v4l2-core/v4l2loopback.c        | 3313 +++++++++++++++++
+ drivers/media/v4l2-core/v4l2loopback.c        | 3315 +++++++++++++++++
  drivers/media/v4l2-core/v4l2loopback.h        |  108 +
- .../media/v4l2-core/v4l2loopback_formats.h    |  445 +++
+ .../media/v4l2-core/v4l2loopback_formats.h    |  453 +++
  drivers/pci/controller/Makefile               |    6 +
  drivers/pci/controller/intel-nvme-remap.c     |  462 +++
  drivers/pci/quirks.c                          |  101 +
@@ -79,12 +81,10 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  mm/vmpressure.c                               |    4 +
  mm/vmscan.c                                   |  157 +-
  net/ipv4/inet_connection_sock.c               |    2 +-
- scripts/Makefile.build                        |   52 +-
- scripts/Makefile.lib                          |    7 +-
- scripts/Makefile.vmlinux_o                    |   16 +-
- scripts/Makefile.vmlinux_thinlink             |   53 +
- scripts/head-object-list.txt                  |    1 +
- 79 files changed, 8103 insertions(+), 68 deletions(-)
+ scripts/Makefile.thinlto                      |   38 +
+ scripts/Makefile.vmlinux_a                    |   83 +
+ scripts/mod/modpost.c                         |   15 +-
+ 79 files changed, 8245 insertions(+), 71 deletions(-)
  create mode 100644 block/adios.c
  create mode 100644 drivers/media/v4l2-core/v4l2loopback.c
  create mode 100644 drivers/media/v4l2-core/v4l2loopback.h
@@ -93,70 +93,31 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  create mode 100644 drivers/scsi/vhba/Kconfig
  create mode 100644 drivers/scsi/vhba/Makefile
  create mode 100644 drivers/scsi/vhba/vhba.c
- create mode 100644 scripts/Makefile.vmlinux_thinlink
+ create mode 100644 scripts/Makefile.thinlto
+ create mode 100644 scripts/Makefile.vmlinux_a
 
 diff --git a/.gitignore b/.gitignore
-index f2f63e47fb88..b83a68185ef4 100644
+index f2f63e47f..dc1dfd672 100644
 --- a/.gitignore
 +++ b/.gitignore
-@@ -12,6 +12,7 @@
+@@ -54,6 +54,7 @@
+ *.zst
+ Module.symvers
+ dtbs-list
++builtin.order
+ modules.order
+ 
  #
- .*
- *.a
-+*.a_thinlto_native
- *.asn1.[ch]
- *.bin
- *.bz2
-@@ -39,6 +40,7 @@
- *.mod.c
- *.o
- *.o.*
-+*.o_thinlto_native
- *.patch
- *.rmeta
- *.rpm
-@@ -64,6 +66,7 @@ modules.order
- /vmlinux
+@@ -65,6 +66,7 @@ modules.order
  /vmlinux.32
  /vmlinux.map
-+/vmlinux.thinlink
  /vmlinux.symvers
++/vmlinux.thinlto-index
  /vmlinux.unstripped
  /vmlinux-gdb.py
-diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
-index cb207c79680d..6fbab98fb639 100644
---- a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
-+++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
-@@ -124,3 +124,27 @@ Contact:	intel-xe@lists.freedesktop.org
- Description:	RO. VRAM temperature in millidegree Celsius.
- 
- 		Only supported for particular Intel Xe graphics platforms.
-+
-+What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan1_input
-+Date:		March 2025
-+KernelVersion:	6.14
-+Contact:	intel-xe@lists.freedesktop.org
-+Description:	RO. Fan 1 speed in RPM.
-+
-+		Only supported for particular Intel Xe graphics platforms.
-+
-+What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan2_input
-+Date:		March 2025
-+KernelVersion:	6.14
-+Contact:	intel-xe@lists.freedesktop.org
-+Description:	RO. Fan 2 speed in RPM.
-+
-+		Only supported for particular Intel Xe graphics platforms.
-+
-+What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan3_input
-+Date:		March 2025
-+KernelVersion:	6.14
-+Contact:	intel-xe@lists.freedesktop.org
-+Description:	RO. Fan 3 speed in RPM.
-+
-+		Only supported for particular Intel Xe graphics platforms.
+ /vmlinuz
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 76a34e0aef76..186454e1c55b 100644
+index 76a34e0ae..186454e1c 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -2318,6 +2318,9 @@
@@ -186,7 +147,7 @@ index 76a34e0aef76..186454e1c55b 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/Documentation/admin-guide/sysctl/vm.rst b/Documentation/admin-guide/sysctl/vm.rst
-index 8290177b4f75..2a94faa5a4ca 100644
+index 8290177b4..2a94faa5a 100644
 --- a/Documentation/admin-guide/sysctl/vm.rst
 +++ b/Documentation/admin-guide/sysctl/vm.rst
 @@ -25,6 +25,9 @@ files can be found in mm/swap.c.
@@ -282,37 +243,11 @@ index 8290177b4f75..2a94faa5a4ca 100644
  
  unprivileged_userfaultfd
  ========================
-diff --git a/MAINTAINERS b/MAINTAINERS
-index dd844ac8d910..4feb3b9f8f73 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -5790,6 +5790,11 @@ F:	scripts/Makefile.clang
- F:	scripts/clang-tools/
- K:	\b(?i:clang|llvm)\b
- 
-+CLANG/LLVM THINLTO DISTRIBUTED BUILD
-+M:	Rong Xu <xur@google.com>
-+S:	Supported
-+F:	scripts/Makefile.vmlinux_thinlink
-+
- CLK API
- M:	Russell King <linux@armlinux.org.uk>
- L:	linux-clk@vger.kernel.org
 diff --git a/Makefile b/Makefile
-index 8e2d03723368..9db3d9c480d3 100644
+index 3a9650df9..f30488d35 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -298,7 +298,8 @@ no-dot-config-targets := $(clean-targets) \
- 			 outputmakefile rustavailable rustfmt rustfmtcheck
- no-sync-config-targets := $(no-dot-config-targets) %install modules_sign kernelrelease \
- 			  image_name
--single-targets := %.a %.i %.ko %.lds %.ll %.lst %.mod %.o %.rsi %.s %/
-+single-targets := %.a %.i %.ko %.lds %.ll %.lst %.mod %.o %.rsi %.s %.o_thinlto_native \
-+	          %.a_thinlto_native %.o.thinlto.bc %/
- 
- config-build	:=
- mixed-build	:=
-@@ -857,11 +858,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
+@@ -857,11 +857,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
  KBUILD_CFLAGS += -O2
  KBUILD_RUSTFLAGS += -Copt-level=2
@@ -332,7 +267,7 @@ index 8e2d03723368..9db3d9c480d3 100644
  # Always set `debug-assertions` and `overflow-checks` because their default
  # depends on `opt-level` and `debug-assertions`, respectively.
  KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
-@@ -991,10 +1000,10 @@ export CC_FLAGS_SCS
+@@ -991,10 +999,10 @@ export CC_FLAGS_SCS
  endif
  
  ifdef CONFIG_LTO_CLANG
@@ -341,67 +276,61 @@ index 8e2d03723368..9db3d9c480d3 100644
 -else
 +ifdef CONFIG_LTO_CLANG_FULL
  CC_FLAGS_LTO	:= -flto
-+else # for CONFIG_LTO_CLANG_THIN or CONFIG_LTO_CLANG_THIN_DIST
++else
 +CC_FLAGS_LTO	:= -flto=thin -fsplit-lto-unit
  endif
  CC_FLAGS_LTO	+= -fvisibility=hidden
  
-@@ -1213,8 +1222,34 @@ vmlinux.a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
- 	$(call if_changed,ar_vmlinux.a)
+@@ -1192,7 +1200,7 @@ else
+ KBUILD_VMLINUX_LIBS := $(patsubst %/,%/lib.a, $(libs-y))
+ endif
+ 
+-export KBUILD_VMLINUX_LIBS
++export KBUILD_VMLINUX_OBJS KBUILD_VMLINUX_LIBS
+ export KBUILD_LDS          := arch/$(SRCARCH)/kernel/vmlinux.lds
+ 
+ ifdef CONFIG_TRIM_UNUSED_KSYMS
+@@ -1201,16 +1209,12 @@ ifdef CONFIG_TRIM_UNUSED_KSYMS
+ KBUILD_MODULES := 1
+ endif
+ 
+-# '$(AR) mPi' needs 'T' to workaround the bug of llvm-ar <= 14
+-quiet_cmd_ar_vmlinux.a = AR      $@
+-      cmd_ar_vmlinux.a = \
+-	rm -f $@; \
+-	$(AR) cDPrST $@ $(KBUILD_VMLINUX_OBJS); \
+-	$(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep -F -f $(srctree)/scripts/head-object-list.txt)
++PHONY += vmlinux_a
++vmlinux_a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
++	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.vmlinux_a
+ 
+-targets += vmlinux.a
+-vmlinux.a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
+-	$(call if_changed,ar_vmlinux.a)
++vmlinux.a: vmlinux_a
++	@:
  
  PHONY += vmlinux_o
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+vmlinux.thinlink: vmlinux.a $(KBUILD_VMLINUX_LIBS) FORCE
-+	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.vmlinux_thinlink
-+targets += vmlinux.thinlink
-+
-+vmlinux.a_thinlto_native := $(patsubst %.a,%.a_thinlto_native,$(KBUILD_VMLINUX_OBJS))
-+quiet_cmd_ar_vmlinux.a_thinlto_native = AR      $@
-+      cmd_ar_vmlinux.a_thinlto_native = \
-+	rm -f $@; \
-+	$(AR) cDPrST $@ $(vmlinux.a_thinlto_native); \
-+	$(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep -F -f $(srctree)/scripts/head-object-list.txt)
-+
-+define rule_gen_vmlinux.a_thinlto_native
-+	+$(Q)$(MAKE) $(build)=. need-builtin=1 thinlto_final_pass=1 need-modorder=1 built-in.a_thinlto_native
-+	$(call cmd_and_savecmd,ar_vmlinux.a_thinlto_native)
-+endef
-+
-+vmlinux.a_thinlto_native: vmlinux.thinlink scripts/head-object-list.txt FORCE
-+	$(call if_changed_rule,gen_vmlinux.a_thinlto_native)
-+
-+targets += vmlinux.a_thinlto_native
-+
-+vmlinux_o: vmlinux.a_thinlto_native
-+	$(Q)$(MAKE) thinlto_final_pass=1 -f $(srctree)/scripts/Makefile.vmlinux_o
-+else
  vmlinux_o: vmlinux.a $(KBUILD_VMLINUX_LIBS)
- 	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.vmlinux_o
-+endif
- 
- vmlinux.o modules.builtin.modinfo modules.builtin: vmlinux_o
- 	@:
-@@ -1572,7 +1607,8 @@ CLEAN_FILES += vmlinux.symvers modules-only.symvers \
+@@ -1570,6 +1574,7 @@ endif # CONFIG_MODULES
+ CLEAN_FILES += vmlinux.symvers modules-only.symvers \
+ 	       modules.builtin modules.builtin.modinfo modules.nsdeps \
  	       modules.builtin.ranges vmlinux.o.map vmlinux.unstripped \
++	       vmlinux.thinlto-index builtin.order \
  	       compile_commands.json rust/test \
  	       rust-project.json .vmlinux.objs .vmlinux.export.c \
--               .builtin-dtbs-list .builtin-dtb.S
-+	       .builtin-dtbs-list .builtin-dtb.S \
-+	       .vmlinux_thinlto_bc_files vmlinux.thinlink
- 
- # Directories & files removed with 'make mrproper'
- MRPROPER_FILES += include/config include/generated          \
-@@ -2023,6 +2059,8 @@ clean: $(clean-dirs)
- 		-o -name '*.symtypes' -o -name 'modules.order' \
- 		-o -name '*.c.[012]*.*' \
- 		-o -name '*.ll' \
-+		-o -name '*.a_thinlto_native' -o -name '*.o_thinlto_native' \
-+		-o -name '*.o.thinlto.bc' \
- 		-o -name '*.gcno' \
- 		\) -type f -print \
- 		-o -name '.tmp_*' -print \
+                .builtin-dtbs-list .builtin-dtb.S
+@@ -2011,7 +2016,7 @@ clean: $(clean-dirs)
+ 	$(call cmd,rmfiles)
+ 	@find . $(RCS_FIND_IGNORE) \
+ 		\( -name '*.[aios]' -o -name '*.rsi' -o -name '*.ko' -o -name '.*.cmd' \
+-		-o -name '*.ko.*' \
++		-o -name '*.ko.*' -o -name '*.o.thinlto.bc' \
+ 		-o -name '*.dtb' -o -name '*.dtbo' \
+ 		-o -name '*.dtb.S' -o -name '*.dtbo.S' \
+ 		-o -name '*.dt.yaml' -o -name 'dtbs-list' \
 diff --git a/arch/Kconfig b/arch/Kconfig
-index b0adb665041f..30dccda07c67 100644
+index b0adb6650..1c2ddb1b7 100644
 --- a/arch/Kconfig
 +++ b/arch/Kconfig
 @@ -810,6 +810,25 @@ config LTO_CLANG_THIN
@@ -419,7 +348,7 @@ index b0adb665041f..30dccda07c67 100644
 +	  ThinLTO index files. Subsequently, the build system explicitly
 +	  invokes ThinLTO backend compilation using these index files
 +	  and pre-linked IR objects. The resulting native object files
-+	  are with the .o_thinlto_native suffix.
++	  are with the .thinlto-native.o suffix.
 +
 +	  This build mode offers improved visibility into the ThinLTO
 +	  process through explicit subcommand exposure. It also makes
@@ -431,7 +360,7 @@ index b0adb665041f..30dccda07c67 100644
  
  config ARCH_SUPPORTS_AUTOFDO_CLANG
 diff --git a/arch/x86/Kconfig.cpu b/arch/x86/Kconfig.cpu
-index 753b8763abae..d4ce964d9713 100644
+index 753b8763a..d4ce964d9 100644
 --- a/arch/x86/Kconfig.cpu
 +++ b/arch/x86/Kconfig.cpu
 @@ -245,6 +245,76 @@ config MATOM
@@ -512,7 +441,7 @@ index 753b8763abae..d4ce964d9713 100644
  	bool "Generic x86 support"
  	depends on X86_32
 diff --git a/arch/x86/Makefile b/arch/x86/Makefile
-index 594723005d95..cbd234e9e743 100644
+index 594723005..cbd234e9e 100644
 --- a/arch/x86/Makefile
 +++ b/arch/x86/Makefile
 @@ -173,8 +173,25 @@ else
@@ -542,7 +471,7 @@ index 594723005d95..cbd234e9e743 100644
          KBUILD_CFLAGS += -mno-red-zone
          KBUILD_CFLAGS += -mcmodel=kernel
 diff --git a/arch/x86/include/asm/pci.h b/arch/x86/include/asm/pci.h
-index b3ab80a03365..5e883b397ff3 100644
+index b3ab80a03..5e883b397 100644
 --- a/arch/x86/include/asm/pci.h
 +++ b/arch/x86/include/asm/pci.h
 @@ -26,6 +26,7 @@ struct pci_sysdata {
@@ -566,7 +495,7 @@ index b3ab80a03365..5e883b397ff3 100644
     already-configured bus numbers - to be used for buggy BIOSes
     or architectures with incomplete PCI setup by the loader */
 diff --git a/arch/x86/pci/common.c b/arch/x86/pci/common.c
-index ddb798603201..7c20387d8202 100644
+index ddb798603..7c20387d8 100644
 --- a/arch/x86/pci/common.c
 +++ b/arch/x86/pci/common.c
 @@ -723,12 +723,15 @@ int pci_ext_cfg_avail(void)
@@ -588,7 +517,7 @@ index ddb798603201..7c20387d8202 100644
  }
 -#endif
 diff --git a/block/Kconfig.iosched b/block/Kconfig.iosched
-index 27f11320b8d1..e98585dd83e0 100644
+index 27f11320b..e98585dd8 100644
 --- a/block/Kconfig.iosched
 +++ b/block/Kconfig.iosched
 @@ -16,6 +16,20 @@ config MQ_IOSCHED_KYBER
@@ -613,7 +542,7 @@ index 27f11320b8d1..e98585dd83e0 100644
  	tristate "BFQ I/O scheduler"
  	select BLK_ICQ
 diff --git a/block/Makefile b/block/Makefile
-index 3a941dc0d27f..94e3bf608bd2 100644
+index 3a941dc0d..94e3bf608 100644
 --- a/block/Makefile
 +++ b/block/Makefile
 @@ -23,6 +23,7 @@ obj-$(CONFIG_BLK_CGROUP_IOLATENCY)	+= blk-iolatency.o
@@ -637,10 +566,10 @@ index 3a941dc0d27f..94e3bf608bd2 100644
 +
 diff --git a/block/adios.c b/block/adios.c
 new file mode 100644
-index 000000000000..b1201ac165ed
+index 000000000..1191d617b
 --- /dev/null
 +++ b/block/adios.c
-@@ -0,0 +1,1450 @@
+@@ -0,0 +1,1593 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Adaptive Deadline I/O Scheduler (ADIOS)
@@ -666,9 +595,56 @@ index 000000000000..b1201ac165ed
 +#include "blk-mq.h"
 +#include "blk-mq-sched.h"
 +
-+#define ADIOS_VERSION "2.3.0"
++#define ADIOS_VERSION "2.5.4"
 +
-+// Define operation types supported by ADIOS
++/* Request Types:
++ *
++ * Tier 0 (Highest Priority): Emergency & System Integrity Requests
++ * -----------------------------------------------------------------
++ * - Target: Requests with the BLK_MQ_INSERT_AT_HEAD flag.
++ * - Purpose: For critical, non-negotiable operations such as device error
++ *   recovery or flush sequences that must bypass all other scheduling logic.
++ * - Implementation: Placed in a dedicated, high-priority FIFO queue
++ *   (`prio_queue[0]`) for immediate dispatch.
++ *
++ * Tier 1 (High Priority): Data Persistence & Ordering Guarantees
++ * ---------------------------------------------------------------
++ * - Target: Requests with integrity-sensitive flags like REQ_FUA or
++ *   REQ_PREFLUSH, typically originating from O_DIRECT I/O.
++ * - Purpose: To ensure strict ordering and data persistence guarantees,
++ *   preventing data corruption in applications like databases.
++ * - Implementation: Handled in a separate, secondary FIFO queue
++ *   (`prio_queue[1]`) to ensure they are processed in submission order and
++ *   before any lower-priority requests.
++ *
++ * Tier 2 (Medium Priority): Application Responsiveness
++ * ----------------------------------------------------
++ * - Target: Normal synchronous requests (e.g., from standard file reads).
++ * - Purpose: To ensure correct application behavior for operations that
++ *   depend on sequential I/O completion (e.g., file system mounts) and to
++ *   provide low latency for interactive applications.
++ * - Implementation: The deadline for these requests is set to their start
++ *   time (`rq->start_time_ns`). This effectively enforces FIFO-like behavior
++ *   within the deadline-sorted red-black tree, preventing out-of-order
++ *   execution of dependent synchronous operations.
++ *
++ * Tier 3 (Normal Priority): Background Throughput
++ * -----------------------------------------------
++ * - Target: Asynchronous requests.
++ * - Purpose: To maximize disk throughput for background tasks where latency
++ *   is not critical.
++ * - Implementation: These are the only requests where ADIOS's adaptive
++ *   latency prediction model is used. A dynamic deadline is calculated based
++ *   on the predicted I/O latency, allowing for aggressive reordering to
++ *   optimize I/O efficiency.
++ *
++ * Dispatch Logic:
++ * The scheduler always dispatches requests in strict priority order:
++ * 1. prio_queue[0] (Tier 0)
++ * 2. prio_queue[1] (Tier 1)
++ * 3. The deadline-sorted batch queue (which naturally prioritizes Tier 2
++ *    over Tier 3 due to their calculated deadlines).
++ */
 +enum adios_op_type {
 +	ADIOS_READ    = 0,
 +	ADIOS_WRITE   = 1,
@@ -678,9 +654,12 @@ index 000000000000..b1201ac165ed
 +};
 +
 +// Global variable to control the latency
-+static u64 default_global_latency_window = 32000000ULL;
++static u64 default_global_latency_window = 24000000ULL;
 +// Ratio below which batch queues should be refilled
 +static u8  default_bq_refill_below_ratio = 25;
++// Use predicted latency in deadline calculation of async requests
++static u8  default_place_deadline_pred_lat = 0;
++static u64 default_lat_model_latency_limit = 500000000ULL;
 +
 +// Dynamic thresholds for shrinkage
 +static u32 default_lm_shrink_at_kreqs  =  5000;
@@ -725,7 +704,7 @@ index 000000000000..b1201ac165ed
 +	u32 count;
 +};
 +
-+// New structure to hold per-cpu buckets, improving data locality and code clarity.
++// Structure to hold per-cpu buckets, improving data locality and code clarity.
 +struct lm_buckets {
 +	struct latency_bucket_small small_bucket[LM_LAT_BUCKET_COUNT];
 +	struct latency_bucket_large large_bucket[LM_LAT_BUCKET_COUNT];
@@ -753,10 +732,15 @@ index 000000000000..b1201ac165ed
 +#define ADIOS_BQ_PAGES 2
 +#define ADIOS_MAX_INSERTS_PER_LOCK 16
 +
++static void insert_request_pre_stability(struct blk_mq_hw_ctx *hctx,
++	struct request *rq, blk_insert_t insert_flags, struct list_head *free);
++static void insert_request_post_stability(struct blk_mq_hw_ctx *hctx,
++	struct request *rq, blk_insert_t insert_flags, struct list_head *free);
++
 +// Adios scheduler data
 +struct adios_data {
 +	spinlock_t pq_lock;
-+	struct list_head prio_queue;
++	struct list_head prio_queue[2];
 +
 +	struct rb_root_cached dl_tree[2];
 +	spinlock_t lock;
@@ -764,13 +748,18 @@ index 000000000000..b1201ac165ed
 +	s64 dl_bias;
 +	s32 dl_prio[2];
 +
++	void (*insert_request_fn)(struct blk_mq_hw_ctx *, struct request *,
++								blk_insert_t, struct list_head *);
++
 +	u64 global_latency_window;
 +	u64 latency_target[ADIOS_OPTYPES];
 +	u32 batch_limit[ADIOS_OPTYPES];
 +	u32 batch_actual_max_size[ADIOS_OPTYPES];
 +	u32 batch_actual_max_total;
 +	u32 async_depth;
++	u32 lat_model_latency_limit;
 +	u8  bq_refill_below_ratio;
++	u8  place_deadline_pred_lat;
 +
 +	bool bq_page;
 +	bool more_bq_ready;
@@ -784,6 +773,7 @@ index 000000000000..b1201ac165ed
 +	struct timer_list update_timer;
 +
 +	atomic64_t total_pred_lat;
++	u64 last_completed_time;
 +
 +	struct kmem_cache *rq_data_pool;
 +	struct kmem_cache *dl_group_pool;
@@ -1064,11 +1054,12 @@ index 000000000000..b1201ac165ed
 +// Input latency data into the latency model
 +static void latency_model_input(struct adios_data *ad,
 +		struct latency_model *model, u32 block_size, u64 latency, u64 pred_lat) {
++	unsigned long flags;
 +	u8 bucket_index;
 +	struct lm_buckets *buckets;
-+	int cpu = get_cpu();
 +
-+	buckets = per_cpu_ptr(model->pcpu_buckets, cpu);
++	local_irq_save(flags);
++	buckets = per_cpu_ptr(model->pcpu_buckets, __smp_processor_id());
 +
 +	if (block_size <= LM_BLOCK_SIZE_THRESHOLD) {
 +		// Handle small requests
@@ -1080,7 +1071,7 @@ index 000000000000..b1201ac165ed
 +		buckets->small_bucket[bucket_index].count++;
 +		buckets->small_bucket[bucket_index].sum_latency += latency;
 +
-+		put_cpu();
++		local_irq_restore(flags);
 +
 +		if (unlikely(!model->base)) {
 +			latency_model_update(ad, model);
@@ -1089,7 +1080,7 @@ index 000000000000..b1201ac165ed
 +	} else {
 +		// Handle large requests
 +		if (!model->base || !pred_lat) {
-+			put_cpu();
++			local_irq_restore(flags);
 +			return;
 +		}
 +
@@ -1102,7 +1093,7 @@ index 000000000000..b1201ac165ed
 +		buckets->large_bucket[bucket_index].sum_latency += latency;
 +		buckets->large_bucket[bucket_index].sum_block_size += block_size;
 +
-+		put_cpu();
++		local_irq_restore(flags);
 +	}
 +}
 +
@@ -1157,12 +1148,19 @@ index 000000000000..b1201ac165ed
 +	struct adios_rq_data *rd = get_rq_data(rq);
 +	struct dl_group *dlg;
 +
-+	rd->block_size = blk_rq_bytes(rq);
-+	u8 optype = adios_optype(rq);
-+	rd->pred_lat =
-+		latency_model_predict(&ad->latency_model[optype], rd->block_size);
-+	rd->deadline =
-+		rq->start_time_ns + ad->latency_target[optype] + rd->pred_lat;
++	/* Tier-2: Synchronous Requests
++	 * - Needs to be FIFO within a same optype
++	 * - Relaxed order between different optypes
++	 * - basically needs to be processed in early time */
++	rd->deadline = rq->start_time_ns;
++
++	/* Tier-3: Aynchronous Requests
++	 * - Can be reordered and delayed freely */
++	if (!(rq->cmd_flags & REQ_SYNC)) {
++		rd->deadline += ad->latency_target[adios_optype(rq)];
++		if (ad->place_deadline_pred_lat)
++			rd->deadline += rd->pred_lat;
++	}
 +
 +	while (*link) {
 +		dlg = rb_entry(*link, struct dl_group, node);
@@ -1285,12 +1283,16 @@ index 000000000000..b1201ac165ed
 +// Try to merge a bio into an existing rq before associating it with an rq
 +static bool adios_bio_merge(struct request_queue *q, struct bio *bio,
 +		unsigned int nr_segs) {
++	unsigned long flags;
 +	struct adios_data *ad = q->elevator->elevator_data;
 +	struct request *free = NULL;
 +	bool ret;
 +
-+	scoped_guard(spinlock_irqsave, &ad->lock)
-+		ret = blk_mq_sched_try_merge(q, bio, nr_segs, &free);
++	if (!spin_trylock_irqsave(&ad->lock, flags))
++		return false;
++
++	ret = blk_mq_sched_try_merge(q, bio, nr_segs, &free);
++	spin_unlock_irqrestore(&ad->lock, flags);
 +
 +	if (free)
 +		blk_mq_free_request(free);
@@ -1298,16 +1300,54 @@ index 000000000000..b1201ac165ed
 +	return ret;
 +}
 +
-+// Insert a request into the scheduler
-+static void insert_request(struct blk_mq_hw_ctx *hctx, struct request *rq,
-+				  blk_insert_t insert_flags, struct list_head *free) {
-+	bool dl_idx = adios_optype_not_read(rq);
++// Insert a request into the scheduler (before Read & Write models stabilizes)
++static void insert_request_pre_stability(struct blk_mq_hw_ctx *hctx,
++		struct request *rq, blk_insert_t insert_flags, struct list_head *free) {
++	struct adios_data *ad = hctx->queue->elevator->elevator_data;
++	struct adios_rq_data *rd = get_rq_data(rq);
++	u8 optype = adios_optype(rq);
++	u8 idx = !(insert_flags & BLK_MQ_INSERT_AT_HEAD);
++
++	rd->block_size = blk_rq_bytes(rq);
++	rd->pred_lat =
++		latency_model_predict(&ad->latency_model[optype], rd->block_size);
++
++	atomic64_add(rd->pred_lat, &ad->total_pred_lat);
++	scoped_guard(spinlock_irqsave, &ad->pq_lock)
++		list_add_tail(&rq->queuelist, &ad->prio_queue[idx]);
++
++	if (ad->latency_model[ADIOS_READ].base > 0 &&
++		ad->latency_model[ADIOS_WRITE].base > 0)
++			ad->insert_request_fn = insert_request_post_stability;
++}
++
++// Insert a request into the scheduler (after Read & Write models stabilized)
++static void insert_request_post_stability(struct blk_mq_hw_ctx *hctx,
++		struct request *rq, blk_insert_t insert_flags, struct list_head *free) {
 +	struct request_queue *q = hctx->queue;
 +	struct adios_data *ad = q->elevator->elevator_data;
++	struct adios_rq_data *rd = get_rq_data(rq);
++	bool dl_idx = adios_optype_not_read(rq);
++	u8 optype = adios_optype(rq);
 +
++	rd->block_size = blk_rq_bytes(rq);
++	rd->pred_lat =
++		latency_model_predict(&ad->latency_model[optype], rd->block_size);
++
++	/* Tier-0: BLK_MQ_INSERT_AT_HEAD Requests
++	 * - Needs to be processed ASAP at all costs in any case */
 +	if (insert_flags & BLK_MQ_INSERT_AT_HEAD) {
++		atomic64_add(rd->pred_lat, &ad->total_pred_lat);
 +		scoped_guard(spinlock_irqsave, &ad->pq_lock)
-+			list_add_tail(&rq->queuelist, &ad->prio_queue);
++			list_add_tail(&rq->queuelist, &ad->prio_queue[0]);
++		return;
++	}
++	/* Tier-1: Integrity-sensitive Requests
++	 * - Needs to be FIFO across all optypes */
++	if (rq->cmd_flags & (REQ_FUA | REQ_PREFLUSH)) {
++		atomic64_add(rd->pred_lat, &ad->total_pred_lat);
++		scoped_guard(spinlock_irqsave, &ad->pq_lock)
++			list_add_tail(&rq->queuelist, &ad->prio_queue[1]);
 +		return;
 +	}
 +
@@ -1342,7 +1382,7 @@ index 000000000000..b1201ac165ed
 +			}
 +			rq = list_first_entry(list, struct request, queuelist);
 +			list_del_init(&rq->queuelist);
-+			insert_request(hctx, rq, insert_flags, &free);
++			ad->insert_request_fn(hctx, rq, insert_flags, &free);
 +		}
 +	} while (!stop);
 +
@@ -1352,7 +1392,7 @@ index 000000000000..b1201ac165ed
 +// Prepare a request before it is inserted into the scheduler
 +static void adios_prepare_request(struct request *rq) {
 +	struct adios_data *ad = rq->q->elevator->elevator_data;
-+	struct adios_rq_data *rd;
++	struct adios_rq_data *rd = get_rq_data(rq);
 +
 +	rq->elv.priv[0] = NULL;
 +
@@ -1375,13 +1415,14 @@ index 000000000000..b1201ac165ed
 +}
 +
 +// Fill the batch queues with requests from the deadline-sorted red-black tree
-+static bool fill_batch_queues(struct adios_data *ad, u64 current_lat) {
++static bool fill_batch_queues(struct adios_data *ad, u64 tpl) {
 +	struct adios_rq_data *rd;
 +	struct request *rq;
 +	u32 optype_count[ADIOS_OPTYPES] = {0};
 +	u32 count = 0;
 +	u8 optype;
 +	bool page = !ad->bq_page, dl_idx, bias_idx, reduce_bias;
++	u64 added_lat = 0;
 +
 +	// Reset batch queue counts for the back page
 +	memset(&ad->batch_count[page], 0, sizeof(ad->batch_count[page]));
@@ -1406,14 +1447,14 @@ index 000000000000..b1201ac165ed
 +				reduce_bias = (trd[bias_idx]->deadline > trd[!bias_idx]->deadline);
 +			} else
 +				reduce_bias = (bias_idx == dl_idx);
-+			
++
 +			rq = rd->rq;
 +			optype = adios_optype(rq);
 +
 +			// Check batch size and total predicted latency
 +			if (count && (!ad->latency_model[optype].base ||
 +					ad->batch_count[page][optype] >= ad->batch_limit[optype] ||
-+					(current_lat + rd->pred_lat) > ad->global_latency_window))
++					(tpl + added_lat + rd->pred_lat) > ad->global_latency_window))
 +				break;
 +
 +			if (reduce_bias) {
@@ -1430,14 +1471,14 @@ index 000000000000..b1201ac165ed
 +
 +			// Add request to the corresponding batch queue
 +			list_add_tail(&rq->queuelist, &ad->batch_queue[page][optype]);
-+			atomic64_add(rd->pred_lat, &ad->total_pred_lat);
-+			current_lat += rd->pred_lat;
++			added_lat += rd->pred_lat;
 +			ad->batch_count[page][optype]++;
 +			optype_count[optype]++;
 +			count++;
 +		}
 +
 +	if (count) {
++		atomic64_add(added_lat, &ad->total_pred_lat);
 +		ad->more_bq_ready = true;
 +		for (u8 optype = 0; optype < ADIOS_OPTYPES; optype++)
 +			if (ad->batch_actual_max_size[optype] < optype_count[optype])
@@ -1457,11 +1498,10 @@ index 000000000000..b1201ac165ed
 +// Dispatch a request from the batch queues
 +static struct request *dispatch_from_bq(struct adios_data *ad) {
 +	struct request *rq = NULL;
-+	u64 tpl;
 +
 +	guard(spinlock_irqsave)(&ad->bq_lock);
 +
-+	tpl = atomic64_read(&ad->total_pred_lat);
++	u64 tpl = atomic64_read(&ad->total_pred_lat);
 +
 +	if (!ad->more_bq_ready && (!tpl || tpl < div_u64(
 +			ad->global_latency_window * ad->bq_refill_below_ratio, 100)))
@@ -1493,9 +1533,13 @@ index 000000000000..b1201ac165ed
 +
 +	guard(spinlock_irqsave)(&ad->pq_lock);
 +
-+	if (!list_empty(&ad->prio_queue)) {
-+		rq = list_first_entry(&ad->prio_queue, struct request, queuelist);
-+		list_del_init(&rq->queuelist);
++	for (int i = 0; i < 2; i++) {
++		struct list_head *q = &ad->prio_queue[i];
++		if (!list_empty(q)) {
++			rq = list_first_entry(q, struct request, queuelist);
++			list_del_init(&rq->queuelist);
++			break;
++		}
 +	}
 +	return rq;
 +}
@@ -1527,11 +1571,16 @@ index 000000000000..b1201ac165ed
 +	struct adios_data *ad = rq->q->elevator->elevator_data;
 +	struct adios_rq_data *rd = get_rq_data(rq);
 +
-+	atomic64_sub(rd->pred_lat, &ad->total_pred_lat);
++	u64 tpl_after = atomic64_sub_return(rd->pred_lat, &ad->total_pred_lat);
++	u64 lct = ad->last_completed_time ?: rq->io_start_time_ns;
++	ad->last_completed_time = (tpl_after) ? now : 0;
 +
-+	if (!rq->io_start_time_ns || !rd->block_size)
++	if (!rq->io_start_time_ns || !rd->block_size || unlikely(now < lct))
 +		return;
-+	u64 latency = now - rq->io_start_time_ns;
++
++	u64 latency = now - lct;
++	if (latency > ad->lat_model_latency_limit)
++		return;
 +	u8 optype = adios_optype(rq);
 +	latency_model_input(ad, &ad->latency_model[optype],
 +		rd->block_size, latency, rd->pred_lat);
@@ -1551,7 +1600,9 @@ index 000000000000..b1201ac165ed
 +
 +static inline bool pq_has_work(struct adios_data *ad) {
 +	guard(spinlock_irqsave)(&ad->pq_lock);
-+	return !list_empty(&ad->prio_queue);
++	for (int i = 0; i < 2; i++)
++		if (!list_empty(&ad->prio_queue[i])) return true;
++	return false;
 +}
 +
 +static inline bool bq_has_work(struct adios_data *ad) {
@@ -1619,8 +1670,11 @@ index 000000000000..b1201ac165ed
 +
 +	ad->global_latency_window = default_global_latency_window;
 +	ad->bq_refill_below_ratio = default_bq_refill_below_ratio;
++	ad->place_deadline_pred_lat = default_place_deadline_pred_lat;
++	ad->lat_model_latency_limit = default_lat_model_latency_limit;
 +
-+	INIT_LIST_HEAD(&ad->prio_queue);
++	for (int i = 0; i < 2; i++)
++		INIT_LIST_HEAD(&ad->prio_queue[i]);
 +	for (u8 i = 0; i < 2; i++)
 +		ad->dl_tree[i] = RB_ROOT_CACHED;
 +	ad->dl_bias = 0;
@@ -1651,7 +1705,7 @@ index 000000000000..b1201ac165ed
 +		ad->batch_limit[optype] = default_batch_limit[optype];
 +	}
 +	timer_setup(&ad->update_timer, update_timer_callback, 0);
-+	
++
 +	for (u8 page = 0; page < ADIOS_BQ_PAGES; page++)
 +		for (u8 optype = 0; optype < ADIOS_OPTYPES; optype++)
 +			INIT_LIST_HEAD(&ad->batch_queue[page][optype]);
@@ -1659,6 +1713,8 @@ index 000000000000..b1201ac165ed
 +	spin_lock_init(&ad->lock);
 +	spin_lock_init(&ad->pq_lock);
 +	spin_lock_init(&ad->bq_lock);
++
++	ad->insert_request_fn = insert_request_pre_stability;
 +
 +	/* We dispatch from request queue wide instead of hw queue */
 +	blk_queue_flag_set(QUEUE_FLAG_SQ_SCHED, q);
@@ -1693,7 +1749,8 @@ index 000000000000..b1201ac165ed
 +
 +	timer_shutdown_sync(&ad->update_timer);
 +
-+	WARN_ON_ONCE(!list_empty(&ad->prio_queue));
++	for (int i = 0; i < 2; i++)
++		WARN_ON_ONCE(!list_empty(&ad->prio_queue[i]));
 +
 +	for (u8 i = 0; i < ADIOS_OPTYPES; i++) {
 +		struct latency_model *model = &ad->latency_model[i];
@@ -1763,6 +1820,11 @@ index 000000000000..b1201ac165ed
 +	reset_buckets(ad->aggr_buckets); \
 +	return count; \
 +} \
++static ssize_t adios_lat_target_##name##_show( \
++		struct elevator_queue *e, char *page) { \
++	struct adios_data *ad = e->elevator_data; \
++	return sprintf(page, "%llu\n", ad->latency_target[optype]); \
++} \
 +static ssize_t adios_lat_target_##name##_store( \
 +		struct elevator_queue *e, const char *page, size_t count) { \
 +	struct adios_data *ad = e->elevator_data; \
@@ -1775,10 +1837,10 @@ index 000000000000..b1201ac165ed
 +	ad->latency_target[optype] = nsec; \
 +	return count; \
 +} \
-+static ssize_t adios_lat_target_##name##_show( \
++static ssize_t adios_batch_limit_##name##_show( \
 +		struct elevator_queue *e, char *page) { \
 +	struct adios_data *ad = e->elevator_data; \
-+	return sprintf(page, "%llu\n", ad->latency_target[optype]); \
++	return sprintf(page, "%u\n", ad->batch_limit[optype]); \
 +} \
 +static ssize_t adios_batch_limit_##name##_store( \
 +		struct elevator_queue *e, const char *page, size_t count) { \
@@ -1790,11 +1852,6 @@ index 000000000000..b1201ac165ed
 +	struct adios_data *ad = e->elevator_data; \
 +	ad->batch_limit[optype] = max_batch; \
 +	return count; \
-+} \
-+static ssize_t adios_batch_limit_##name##_show( \
-+		struct elevator_queue *e, char *page) { \
-+	struct adios_data *ad = e->elevator_data; \
-+	return sprintf(page, "%u\n", ad->batch_limit[optype]); \
 +}
 +
 +SYSFS_OPTYPE_DECL(read, ADIOS_READ);
@@ -1817,6 +1874,13 @@ index 000000000000..b1201ac165ed
 +		total_count, discard_count, read_count, write_count);
 +}
 +
++// Show the global latency window
++static ssize_t adios_global_latency_window_show(
++		struct elevator_queue *e, char *page) {
++	struct adios_data *ad = e->elevator_data;
++	return sprintf(page, "%llu\n", ad->global_latency_window);
++}
++
 +// Set the global latency window
 +static ssize_t adios_global_latency_window_store(
 +		struct elevator_queue *e, const char *page, size_t count) {
@@ -1833,35 +1897,41 @@ index 000000000000..b1201ac165ed
 +	return count;
 +}
 +
-+// Show the global latency window
-+static ssize_t adios_global_latency_window_show(
-+		struct elevator_queue *e, char *page) {
-+	struct adios_data *ad = e->elevator_data;
-+	return sprintf(page, "%llu\n", ad->global_latency_window);
++#define SYSFS_INT_DECL(field, min_val, max_val) \
++static ssize_t adios_##field##_show( \
++		struct elevator_queue *e, char *page) { \
++	struct adios_data *ad = e->elevator_data; \
++	return sprintf(page, "%d\n", ad->field); \
++} \
++static ssize_t adios_##field##_store( \
++		struct elevator_queue *e, const char *page, size_t count) { \
++	struct adios_data *ad = e->elevator_data; \
++	int val; \
++	int ret; \
++	ret = kstrtoint(page, 10, &val); \
++	if (ret || val < (min_val) || val > (max_val)) \
++		return -EINVAL; \
++	ad->field = val; \
++	return count; \
 +}
 +
-+// Show the bq_refill_below_ratio
-+static ssize_t adios_bq_refill_below_ratio_show(
-+		struct elevator_queue *e, char *page) {
-+	struct adios_data *ad = e->elevator_data;
-+	return sprintf(page, "%d\n", ad->bq_refill_below_ratio);
-+}
-+
-+// Set the bq_refill_below_ratio
-+static ssize_t adios_bq_refill_below_ratio_store(
-+		struct elevator_queue *e, const char *page, size_t count) {
-+	struct adios_data *ad = e->elevator_data;
-+	int ratio;
-+	int ret;
-+
-+	ret = kstrtoint(page, 10, &ratio);
-+	if (ret || ratio < 0 || ratio > 100)
-+		return -EINVAL;
-+
-+	ad->bq_refill_below_ratio = ratio;
-+
-+	return count;
-+}
++SYSFS_INT_DECL(bq_refill_below_ratio, 0, 100)
++/* place_deadline_pred_lat: A sysfs-tunable switch for latency optimization
++ *
++ * This flag controls whether predicted latency (`pred_lat`) is used to
++ * calculate deadlines for asynchronous (Tier 3) requests.
++ *
++ * When enabled (1), this allows small, latency-sensitive I/Os (e.g., from
++ * interactive tasks) to be prioritized over large background transfers.
++ * This aggressive reordering may improve perceived system responsiveness.
++ *
++ * However, this can expose ordering issues in older filesystems like
++ * FAT which may implicitly assume more strict async I/O order dependencies.
++ *
++ * For maximum compatibility, this is disabled by default (0).
++ */
++SYSFS_INT_DECL(place_deadline_pred_lat, 0, 1)
++SYSFS_INT_DECL(lat_model_latency_limit, 0, 2*NSEC_PER_SEC)
 +
 +// Show the read priority
 +static ssize_t adios_read_priority_show(
@@ -2018,6 +2088,8 @@ index 000000000000..b1201ac165ed
 +	AD_ATTR_RO(batch_actual_max),
 +	AD_ATTR_RW(bq_refill_below_ratio),
 +	AD_ATTR_RW(global_latency_window),
++	AD_ATTR_RW(place_deadline_pred_lat),
++	AD_ATTR_RW(lat_model_latency_limit),
 +
 +	AD_ATTR_RW(batch_limit_read),
 +	AD_ATTR_RW(batch_limit_write),
@@ -2093,7 +2165,7 @@ index 000000000000..b1201ac165ed
 +MODULE_DESCRIPTION(ADIOS_PROGNAME);
 \ No newline at end of file
 diff --git a/block/elevator.c b/block/elevator.c
-index dc4cadef728e..6757ed11bf60 100644
+index dc4cadef7..56fc294ac 100644
 --- a/block/elevator.c
 +++ b/block/elevator.c
 @@ -556,11 +556,23 @@ static struct elevator_type *elevator_get_default(struct request_queue *q)
@@ -2102,7 +2174,7 @@ index dc4cadef728e..6757ed11bf60 100644
  
 +#ifdef CONFIG_MQ_IOSCHED_DEFAULT_ADIOS
 +	return elevator_find_get("adios");
-+#endif // CONFIG_MQ_IOSCHED_DEFAULT_ADIOS
++#endif // !CONFIG_MQ_IOSCHED_DEFAULT_ADIOS
 +
  	if (q->nr_hw_queues != 1 &&
  	    !blk_mq_is_shared_tags(q->tag_set->flags))
@@ -2121,7 +2193,7 @@ index dc4cadef728e..6757ed11bf60 100644
  
  /*
 diff --git a/drivers/Makefile b/drivers/Makefile
-index b5749cf67044..5beba9f57254 100644
+index b5749cf67..5beba9f57 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -64,14 +64,8 @@ obj-y				+= char/
@@ -2154,7 +2226,7 @@ index b5749cf67044..5beba9f57254 100644
  obj-$(CONFIG_MTD)		+= mtd/
  obj-$(CONFIG_SPI)		+= spi/
 diff --git a/drivers/ata/ahci.c b/drivers/ata/ahci.c
-index 931da4749e80..9764029754dc 100644
+index f0c4e2251..25a792684 100644
 --- a/drivers/ata/ahci.c
 +++ b/drivers/ata/ahci.c
 @@ -1662,7 +1662,7 @@ static irqreturn_t ahci_thunderx_irq_handler(int irq, void *dev_instance)
@@ -2198,7 +2270,7 @@ index 931da4749e80..9764029754dc 100644
  }
  
  static int ahci_get_irq_vector(struct ata_host *host, int port)
-@@ -1945,7 +1938,9 @@ static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
+@@ -1955,7 +1948,9 @@ static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
  		return -ENOMEM;
  
  	/* detect remapped nvme devices */
@@ -2210,7 +2282,7 @@ index 931da4749e80..9764029754dc 100644
  	sysfs_add_file_to_group(&pdev->dev.kobj,
  				&dev_attr_remapped_nvme.attr,
 diff --git a/drivers/cpufreq/Kconfig.x86 b/drivers/cpufreq/Kconfig.x86
-index 2c5c228408bf..918e2bebfe78 100644
+index 2c5c22840..918e2bebf 100644
 --- a/drivers/cpufreq/Kconfig.x86
 +++ b/drivers/cpufreq/Kconfig.x86
 @@ -9,7 +9,6 @@ config X86_INTEL_PSTATE
@@ -2230,10 +2302,10 @@ index 2c5c228408bf..918e2bebfe78 100644
  	  This driver adds a CPUFreq driver which utilizes a fine grain
  	  processor performance frequency control range instead of legacy
 diff --git a/drivers/cpufreq/intel_pstate.c b/drivers/cpufreq/intel_pstate.c
-index ba9bf06f1c77..b8ceac594acd 100644
+index c1c42c273..beda68b1d 100644
 --- a/drivers/cpufreq/intel_pstate.c
 +++ b/drivers/cpufreq/intel_pstate.c
-@@ -3828,6 +3828,8 @@ static int __init intel_pstate_setup(char *str)
+@@ -3830,6 +3830,8 @@ static int __init intel_pstate_setup(char *str)
  
  	if (!strcmp(str, "disable"))
  		no_load = 1;
@@ -2243,7 +2315,7 @@ index ba9bf06f1c77..b8ceac594acd 100644
  		default_driver = &intel_pstate;
  	else if (!strcmp(str, "passive"))
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu.h b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
-index c3641331d4de..ce1072fe4921 100644
+index c3641331d..ce1072fe4 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu.h
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
 @@ -161,6 +161,7 @@ struct amdgpu_watchdog_timer {
@@ -2255,7 +2327,7 @@ index c3641331d4de..ce1072fe4921 100644
  extern int amdgpu_gart_size;
  extern int amdgpu_gtt_size;
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 72c807f5822e..6ef3fedc1233 100644
+index 72c807f58..6ef3fedc1 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -143,6 +143,7 @@ enum AMDGPU_DEBUG_MASK {
@@ -2283,7 +2355,7 @@ index 72c807f5822e..6ef3fedc1233 100644
   * DOC: vramlimit (int)
   * Restrict the total amount of VRAM in MiB for testing.  The default is 0 (Use full VRAM).
 diff --git a/drivers/gpu/drm/amd/display/Kconfig b/drivers/gpu/drm/amd/display/Kconfig
-index abd3b6564373..46937e6fa78d 100644
+index abd3b6564..46937e6fa 100644
 --- a/drivers/gpu/drm/amd/display/Kconfig
 +++ b/drivers/gpu/drm/amd/display/Kconfig
 @@ -56,4 +56,10 @@ config DRM_AMD_SECURE_DISPLAY
@@ -2298,10 +2370,10 @@ index abd3b6564373..46937e6fa78d 100644
 +
  endmenu
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
-index 87c2bc5f64a6..927fb4992a6a 100644
+index 75e7af5c5..366437af4 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
-@@ -4574,7 +4574,7 @@ static int amdgpu_dm_mode_config_init(struct amdgpu_device *adev)
+@@ -4587,7 +4587,7 @@ static int amdgpu_dm_mode_config_init(struct amdgpu_device *adev)
  		return r;
  	}
  
@@ -2311,7 +2383,7 @@ index 87c2bc5f64a6..927fb4992a6a 100644
  		dc_state_release(state->context);
  		kfree(state);
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c
-index ebabfe3a512f..4d3ebcaacca1 100644
+index ebabfe3a5..4d3ebcaac 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c
 @@ -97,7 +97,7 @@ static inline struct fixed31_32 amdgpu_dm_fixpt_from_s3132(__u64 x)
@@ -2324,7 +2396,7 @@ index ebabfe3a512f..4d3ebcaacca1 100644
   *
   * AMD driver supports pre-defined mathematical functions for transferring
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c
-index db157b38f862..5d5210f99dcf 100644
+index db157b38f..5d5210f99 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c
 @@ -481,7 +481,7 @@ static int amdgpu_dm_crtc_late_register(struct drm_crtc *crtc)
@@ -2355,7 +2427,7 @@ index db157b38f862..5d5210f99dcf 100644
  #endif
  	return 0;
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
-index 3e0f45f1711c..f645cb7831a0 100644
+index 3e0f45f17..f645cb783 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
 @@ -1601,7 +1601,7 @@ static void amdgpu_dm_plane_drm_plane_destroy_state(struct drm_plane *plane,
@@ -2386,10 +2458,10 @@ index 3e0f45f1711c..f645cb7831a0 100644
  #endif
  	/* Create (reset) the plane state */
 diff --git a/drivers/gpu/drm/amd/pm/amdgpu_pm.c b/drivers/gpu/drm/amd/pm/amdgpu_pm.c
-index 922def51685b..da76611edb10 100644
+index 21da5123d..c13822ee6 100644
 --- a/drivers/gpu/drm/amd/pm/amdgpu_pm.c
 +++ b/drivers/gpu/drm/amd/pm/amdgpu_pm.c
-@@ -3055,6 +3055,9 @@ static ssize_t amdgpu_hwmon_show_power_cap_min(struct device *dev,
+@@ -3057,6 +3057,9 @@ static ssize_t amdgpu_hwmon_show_power_cap_min(struct device *dev,
  					 struct device_attribute *attr,
  					 char *buf)
  {
@@ -2400,7 +2472,7 @@ index 922def51685b..da76611edb10 100644
  }
  
 diff --git a/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c b/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c
-index 46cce1d2aaf3..e3adb7aea969 100644
+index 46cce1d2a..e3adb7aea 100644
 --- a/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c
 +++ b/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c
 @@ -2854,7 +2854,10 @@ int smu_get_power_limit(void *handle,
@@ -2432,7 +2504,7 @@ index 46cce1d2aaf3..e3adb7aea969 100644
  			"New power limit (%d) is out of range [%d,%d]\n",
  			limit, smu->min_power_limit, smu->max_power_limit);
 diff --git a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
-index 8846eb9ce2a4..c7d5d782e3f9 100644
+index 8846eb9ce..c7d5d782e 100644
 --- a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
 @@ -21,6 +21,9 @@
@@ -2446,7 +2518,7 @@ index 8846eb9ce2a4..c7d5d782e3f9 100644
  #define BMG_PACKAGE_TEMPERATURE			XE_REG(0x138434)
  #define BMG_PACKAGE_RAPL_LIMIT			XE_REG(0x138440)
 diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
-index 0482f26aa480..0564164935c6 100644
+index 0482f26aa..056416493 100644
 --- a/drivers/gpu/drm/xe/xe_device_types.h
 +++ b/drivers/gpu/drm/xe/xe_device_types.h
 @@ -314,6 +314,8 @@ struct xe_device {
@@ -2459,7 +2531,7 @@ index 0482f26aa480..0564164935c6 100644
  		u8 has_flat_ccs:1;
  		/** @info.has_heci_cscfi: device has heci cscfi */
 diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
-index 48d80ffdf7bb..eb293aec36a0 100644
+index 48d80ffdf..eb293aec3 100644
 --- a/drivers/gpu/drm/xe/xe_hwmon.c
 +++ b/drivers/gpu/drm/xe/xe_hwmon.c
 @@ -5,6 +5,7 @@
@@ -2679,7 +2751,7 @@ index 48d80ffdf7bb..eb293aec36a0 100644
  
  static void xe_hwmon_mutex_destroy(void *arg)
 diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
-index 57547d02daa7..ecb0cf7c66fa 100644
+index 57547d02d..ecb0cf7c6 100644
 --- a/drivers/gpu/drm/xe/xe_pci.c
 +++ b/drivers/gpu/drm/xe/xe_pci.c
 @@ -62,6 +62,7 @@ struct xe_device_desc {
@@ -2715,7 +2787,7 @@ index 57547d02daa7..ecb0cf7c66fa 100644
  	xe->info.has_heci_cscfi = desc->has_heci_cscfi;
  	xe->info.has_llc = desc->has_llc;
 diff --git a/drivers/gpu/drm/xe/xe_pcode_api.h b/drivers/gpu/drm/xe/xe_pcode_api.h
-index 2bae9afdbd35..e622ae17f08d 100644
+index 2bae9afdb..e622ae17f 100644
 --- a/drivers/gpu/drm/xe/xe_pcode_api.h
 +++ b/drivers/gpu/drm/xe/xe_pcode_api.h
 @@ -49,6 +49,9 @@
@@ -2728,8 +2800,103 @@ index 2bae9afdbd35..e622ae17f08d 100644
  #define PCODE_SCRATCH(x)		XE_REG(0x138320 + ((x) * 4))
  /* PCODE_SCRATCH0 */
  #define   AUXINFO_REG_OFFSET		REG_GENMASK(17, 15)
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_client.c b/drivers/hid/amd-sfh-hid/amd_sfh_client.c
+index 3438d3929..0f2cbae39 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_client.c
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_client.c
+@@ -146,6 +146,8 @@ static const char *get_sensor_name(int idx)
+ 		return "gyroscope";
+ 	case mag_idx:
+ 		return "magnetometer";
++	case op_idx:
++		return "operating-mode";
+ 	case als_idx:
+ 	case ACS_IDX: /* ambient color sensor */
+ 		return "ALS";
+@@ -243,6 +245,20 @@ int amd_sfh_hid_client_init(struct amd_mp2_dev *privdata)
+ 			rc = -ENOMEM;
+ 			goto cleanup;
+ 		}
++
++		if (cl_data->sensor_idx[i] == op_idx) {
++			info.period = AMD_SFH_IDLE_LOOP;
++			info.sensor_idx = cl_data->sensor_idx[i];
++			info.dma_address = cl_data->sensor_dma_addr[i];
++			mp2_ops->start(privdata, info);
++			cl_data->sensor_sts[i] = amd_sfh_wait_for_response(privdata,
++									   cl_data->sensor_idx[i],
++									   SENSOR_ENABLED);
++			if (cl_data->sensor_sts[i] == SENSOR_ENABLED)
++				cl_data->is_any_sensor_enabled = true;
++			continue;
++		}
++
+ 		cl_data->sensor_sts[i] = SENSOR_DISABLED;
+ 		cl_data->sensor_requested_cnt[i] = 0;
+ 		cl_data->cur_hid_dev = i;
+@@ -303,6 +319,13 @@ int amd_sfh_hid_client_init(struct amd_mp2_dev *privdata)
+ 
+ 	for (i = 0; i < cl_data->num_hid_devices; i++) {
+ 		cl_data->cur_hid_dev = i;
++		if (cl_data->sensor_idx[i] == op_idx) {
++			dev_dbg(dev, "sid 0x%x (%s) status 0x%x\n",
++				cl_data->sensor_idx[i], get_sensor_name(cl_data->sensor_idx[i]),
++				cl_data->sensor_sts[i]);
++			continue;
++		}
++
+ 		if (cl_data->sensor_sts[i] == SENSOR_ENABLED) {
+ 			rc = amdtp_hid_probe(i, cl_data);
+ 			if (rc)
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_hid.h b/drivers/hid/amd-sfh-hid/amd_sfh_hid.h
+index 1c91be8da..7452b0302 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_hid.h
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_hid.h
+@@ -11,7 +11,7 @@
+ #ifndef AMDSFH_HID_H
+ #define AMDSFH_HID_H
+ 
+-#define MAX_HID_DEVICES		6
++#define MAX_HID_DEVICES		7
+ #define AMD_SFH_HID_VENDOR	0x1022
+ #define AMD_SFH_HID_PRODUCT	0x0001
+ 
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c
+index 1c1fd6333..2983af969 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c
+@@ -29,6 +29,7 @@
+ #define ACEL_EN		BIT(0)
+ #define GYRO_EN		BIT(1)
+ #define MAGNO_EN	BIT(2)
++#define OP_EN		BIT(15)
+ #define HPD_EN		BIT(16)
+ #define ALS_EN		BIT(19)
+ #define ACS_EN		BIT(22)
+@@ -232,6 +233,9 @@ int amd_mp2_get_sensor_num(struct amd_mp2_dev *privdata, u8 *sensor_id)
+ 	if (MAGNO_EN & activestatus)
+ 		sensor_id[num_of_sensors++] = mag_idx;
+ 
++	if (OP_EN & activestatus)
++		sensor_id[num_of_sensors++] = op_idx;
++
+ 	if (ALS_EN & activestatus)
+ 		sensor_id[num_of_sensors++] = als_idx;
+ 
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h
+index 05e400a4a..2eb61f4e8 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h
+@@ -79,6 +79,7 @@ enum sensor_idx {
+ 	accel_idx = 0,
+ 	gyro_idx = 1,
+ 	mag_idx = 2,
++	op_idx = 15,
+ 	als_idx = 19
+ };
+ 
 diff --git a/drivers/input/evdev.c b/drivers/input/evdev.c
-index b5cbb57ee5f6..a0f7fa1518c6 100644
+index b5cbb57ee..a0f7fa151 100644
 --- a/drivers/input/evdev.c
 +++ b/drivers/input/evdev.c
 @@ -46,6 +46,7 @@ struct evdev_client {
@@ -2793,7 +2960,7 @@ index b5cbb57ee5f6..a0f7fa1518c6 100644
  }
  
 diff --git a/drivers/md/dm-crypt.c b/drivers/md/dm-crypt.c
-index 9dfdb63220d7..91aeee72a15e 100644
+index 9dfdb6322..91aeee72a 100644
 --- a/drivers/md/dm-crypt.c
 +++ b/drivers/md/dm-crypt.c
 @@ -3284,6 +3284,11 @@ static int crypt_ctr(struct dm_target *ti, unsigned int argc, char **argv)
@@ -2809,7 +2976,7 @@ index 9dfdb63220d7..91aeee72a15e 100644
  	if (ret < 0)
  		goto bad;
 diff --git a/drivers/media/v4l2-core/Kconfig b/drivers/media/v4l2-core/Kconfig
-index 331b8e535e5b..80dabeebf580 100644
+index 331b8e535..80dabeebf 100644
 --- a/drivers/media/v4l2-core/Kconfig
 +++ b/drivers/media/v4l2-core/Kconfig
 @@ -40,6 +40,11 @@ config VIDEO_TUNER
@@ -2825,7 +2992,7 @@ index 331b8e535e5b..80dabeebf580 100644
  config V4L2_H264
  	tristate
 diff --git a/drivers/media/v4l2-core/Makefile b/drivers/media/v4l2-core/Makefile
-index 2177b9d63a8f..c179507cedc4 100644
+index 2177b9d63..c179507ce 100644
 --- a/drivers/media/v4l2-core/Makefile
 +++ b/drivers/media/v4l2-core/Makefile
 @@ -33,5 +33,7 @@ obj-$(CONFIG_V4L2_JPEG_HELPER) += v4l2-jpeg.o
@@ -2838,10 +3005,10 @@ index 2177b9d63a8f..c179507cedc4 100644
  obj-$(CONFIG_VIDEO_DEV) += v4l2-dv-timings.o videodev.o
 diff --git a/drivers/media/v4l2-core/v4l2loopback.c b/drivers/media/v4l2-core/v4l2loopback.c
 new file mode 100644
-index 000000000000..74bd8125caa3
+index 000000000..80b67b283
 --- /dev/null
 +++ b/drivers/media/v4l2-core/v4l2loopback.c
-@@ -0,0 +1,3313 @@
+@@ -0,0 +1,3315 @@
 +/* -*- c-file-style: "linux" -*- */
 +/*
 + * v4l2loopback.c  --  video4linux2 loopback driver
@@ -2889,7 +3056,7 @@ index 000000000000..74bd8125caa3
 +#define strscpy strlcpy
 +#endif
 +
-+#if defined(timer_setup) && defined(from_timer)
++#if defined(timer_setup)
 +#define HAVE_TIMER_SETUP
 +#endif
 +
@@ -5513,7 +5680,8 @@ index 000000000000..74bd8125caa3
 +#ifdef HAVE_TIMER_SETUP
 +static void sustain_timer_clb(struct timer_list *t)
 +{
-+	struct v4l2_loopback_device *dev = from_timer(dev, t, sustain_timer);
++	struct v4l2_loopback_device *dev =
++		container_of(t, struct v4l2_loopback_device, sustain_timer);
 +#else
 +static void sustain_timer_clb(unsigned long nr)
 +{
@@ -5538,7 +5706,8 @@ index 000000000000..74bd8125caa3
 +#ifdef HAVE_TIMER_SETUP
 +static void timeout_timer_clb(struct timer_list *t)
 +{
-+	struct v4l2_loopback_device *dev = from_timer(dev, t, timeout_timer);
++	struct v4l2_loopback_device *dev =
++		container_of(t, struct v4l2_loopback_device, timeout_timer);
 +#else
 +static void timeout_timer_clb(unsigned long nr)
 +{
@@ -6157,7 +6326,7 @@ index 000000000000..74bd8125caa3
 +module_exit(v4l2loopback_cleanup_module);
 diff --git a/drivers/media/v4l2-core/v4l2loopback.h b/drivers/media/v4l2-core/v4l2loopback.h
 new file mode 100644
-index 000000000000..e48e0ce5949d
+index 000000000..8beca10d7
 --- /dev/null
 +++ b/drivers/media/v4l2-core/v4l2loopback.h
 @@ -0,0 +1,108 @@
@@ -6175,7 +6344,7 @@ index 000000000000..e48e0ce5949d
 +
 +#define V4L2LOOPBACK_VERSION_MAJOR 0
 +#define V4L2LOOPBACK_VERSION_MINOR 15
-+#define V4L2LOOPBACK_VERSION_BUGFIX 0
++#define V4L2LOOPBACK_VERSION_BUGFIX 1
 +
 +/* /dev/v4l2loopback interface */
 +
@@ -6271,10 +6440,10 @@ index 000000000000..e48e0ce5949d
 +#endif /* _V4L2LOOPBACK_H */
 diff --git a/drivers/media/v4l2-core/v4l2loopback_formats.h b/drivers/media/v4l2-core/v4l2loopback_formats.h
 new file mode 100644
-index 000000000000..d855a3796554
+index 000000000..ac2f1cbc0
 --- /dev/null
 +++ b/drivers/media/v4l2-core/v4l2loopback_formats.h
-@@ -0,0 +1,445 @@
+@@ -0,0 +1,453 @@
 +static const struct v4l2l_format formats[] = {
 +#ifndef V4L2_PIX_FMT_VP9
 +#define V4L2_PIX_FMT_VP9 v4l2_fourcc('V', 'P', '9', '0')
@@ -6312,6 +6481,14 @@ index 000000000000..d855a3796554
 +	{
 +		.name = "32 bpp RGBA, le",
 +		.fourcc = V4L2_PIX_FMT_ABGR32,
++		.depth = 32,
++		.flags = 0,
++	},
++#endif
++#ifdef V4L2_PIX_FMT_XBGR32
++	{
++		.name = "32 bpp BGRX-8-8-8-8",
++		.fourcc = V4L2_PIX_FMT_XBGR32,
 +		.depth = 32,
 +		.flags = 0,
 +	},
@@ -6721,7 +6898,7 @@ index 000000000000..d855a3796554
 +#endif /* V4L2_PIX_FMT_HEVC */
 +};
 diff --git a/drivers/pci/controller/Makefile b/drivers/pci/controller/Makefile
-index 038ccbd9e3ba..de5e4f5145af 100644
+index 038ccbd9e..de5e4f514 100644
 --- a/drivers/pci/controller/Makefile
 +++ b/drivers/pci/controller/Makefile
 @@ -1,4 +1,10 @@
@@ -6737,7 +6914,7 @@ index 038ccbd9e3ba..de5e4f5145af 100644
  obj-$(CONFIG_PCI_IXP4XX) += pci-ixp4xx.o
 diff --git a/drivers/pci/controller/intel-nvme-remap.c b/drivers/pci/controller/intel-nvme-remap.c
 new file mode 100644
-index 000000000000..e105e6f5cc91
+index 000000000..e105e6f5c
 --- /dev/null
 +++ b/drivers/pci/controller/intel-nvme-remap.c
 @@ -0,0 +1,462 @@
@@ -7204,10 +7381,10 @@ index 000000000000..e105e6f5cc91
 +MODULE_AUTHOR("Daniel Drake <drake@endlessm.com>");
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index d0f7b749b9a6..f5aaa23b254a 100644
+index 6e29f2b39..3c6593048 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3747,6 +3747,106 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
+@@ -3749,6 +3749,106 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
  	dev->dev_flags |= PCI_DEV_FLAGS_NO_BUS_RESET;
  }
  
@@ -7314,7 +7491,7 @@ index d0f7b749b9a6..f5aaa23b254a 100644
  /*
   * Some NVIDIA GPU devices do not work with bus reset, SBR needs to be
   * prevented for those affected devices.
-@@ -5194,6 +5294,7 @@ static const struct pci_dev_acs_enabled {
+@@ -5196,6 +5296,7 @@ static const struct pci_dev_acs_enabled {
  	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
  	/* Wangxun nics */
  	{ PCI_VENDOR_ID_WANGXUN, PCI_ANY_ID, pci_quirk_wangxun_nic_acs },
@@ -7323,7 +7500,7 @@ index d0f7b749b9a6..f5aaa23b254a 100644
  };
  
 diff --git a/drivers/scsi/Kconfig b/drivers/scsi/Kconfig
-index 5a3c670aec27..831ffcf7c730 100644
+index 5a3c670ae..831ffcf7c 100644
 --- a/drivers/scsi/Kconfig
 +++ b/drivers/scsi/Kconfig
 @@ -1521,4 +1521,6 @@ endif # SCSI_LOWLEVEL
@@ -7334,7 +7511,7 @@ index 5a3c670aec27..831ffcf7c730 100644
 +
  endmenu
 diff --git a/drivers/scsi/Makefile b/drivers/scsi/Makefile
-index 16de3e41f94c..4e88f6e3e67b 100644
+index 16de3e41f..4e88f6e3e 100644
 --- a/drivers/scsi/Makefile
 +++ b/drivers/scsi/Makefile
 @@ -152,6 +152,7 @@ obj-$(CONFIG_CHR_DEV_SCH)	+= ch.o
@@ -7347,7 +7524,7 @@ index 16de3e41f94c..4e88f6e3e67b 100644
  obj-$(CONFIG_SCSI_DEBUG)	+= scsi_debug.o
 diff --git a/drivers/scsi/vhba/Kconfig b/drivers/scsi/vhba/Kconfig
 new file mode 100644
-index 000000000000..e70a381fe3df
+index 000000000..e70a381fe
 --- /dev/null
 +++ b/drivers/scsi/vhba/Kconfig
 @@ -0,0 +1,9 @@
@@ -7362,7 +7539,7 @@ index 000000000000..e70a381fe3df
 +	  will be called vhba.
 diff --git a/drivers/scsi/vhba/Makefile b/drivers/scsi/vhba/Makefile
 new file mode 100644
-index 000000000000..2d7524b66199
+index 000000000..2d7524b66
 --- /dev/null
 +++ b/drivers/scsi/vhba/Makefile
 @@ -0,0 +1,4 @@
@@ -7372,7 +7549,7 @@ index 000000000000..2d7524b66199
 +ccflags-y := -DVHBA_VERSION=\"$(VHBA_VERSION)\" -Werror
 diff --git a/drivers/scsi/vhba/vhba.c b/drivers/scsi/vhba/vhba.c
 new file mode 100644
-index 000000000000..878a3be0ba2b
+index 000000000..878a3be0b
 --- /dev/null
 +++ b/drivers/scsi/vhba/vhba.c
 @@ -0,0 +1,1132 @@
@@ -8509,7 +8686,7 @@ index 000000000000..878a3be0ba2b
 +module_exit(vhba_exit);
 +
 diff --git a/fs/select.c b/fs/select.c
-index 7da531b1cf6b..0eaf3522abe9 100644
+index 7da531b1c..0eaf3522a 100644
 --- a/fs/select.c
 +++ b/fs/select.c
 @@ -857,7 +857,7 @@ static inline __poll_t do_pollfd(struct pollfd *pollfd, poll_table *pwait,
@@ -8522,10 +8699,10 @@ index 7da531b1cf6b..0eaf3522abe9 100644
  
  	CLASS(fd, f)(fd);
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index 2e4584e1bfcd..9ff3f9a1f7b4 100644
+index 82b7bea9f..9daa7444d 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
-@@ -193,6 +193,14 @@ static inline void __mm_zero_struct_page(struct page *page)
+@@ -194,6 +194,14 @@ static inline void __mm_zero_struct_page(struct page *page)
  
  extern int sysctl_max_map_count;
  
@@ -8541,7 +8718,7 @@ index 2e4584e1bfcd..9ff3f9a1f7b4 100644
  extern unsigned long sysctl_admin_reserve_kbytes;
  
 diff --git a/include/linux/pagemap.h b/include/linux/pagemap.h
-index 26baa78f1ca7..8fa2ff2682bc 100644
+index 26baa78f1..8fa2ff268 100644
 --- a/include/linux/pagemap.h
 +++ b/include/linux/pagemap.h
 @@ -1341,7 +1341,7 @@ struct readahead_control {
@@ -8554,7 +8731,7 @@ index 26baa78f1ca7..8fa2ff2682bc 100644
  void page_cache_ra_unbounded(struct readahead_control *,
  		unsigned long nr_to_read, unsigned long lookahead_count);
 diff --git a/include/linux/user_namespace.h b/include/linux/user_namespace.h
-index a0bb6d012137..93129fea552e 100644
+index a0bb6d012..93129fea5 100644
 --- a/include/linux/user_namespace.h
 +++ b/include/linux/user_namespace.h
 @@ -168,6 +168,8 @@ static inline void set_userns_rlimit_max(struct user_namespace *ns,
@@ -8576,7 +8753,7 @@ index a0bb6d012137..93129fea552e 100644
  {
  	return &init_user_ns;
 diff --git a/include/linux/wait.h b/include/linux/wait.h
-index 965a19809c7e..3d442267a256 100644
+index 965a19809..3d442267a 100644
 --- a/include/linux/wait.h
 +++ b/include/linux/wait.h
 @@ -163,6 +163,7 @@ static inline bool wq_has_sleeper(struct wait_queue_head *wq_head)
@@ -8596,7 +8773,7 @@ index 965a19809c7e..3d442267a256 100644
  void finish_wait(struct wait_queue_head *wq_head, struct wait_queue_entry *wq_entry);
  long wait_woken(struct wait_queue_entry *wq_entry, unsigned mode, long timeout);
 diff --git a/init/Kconfig b/init/Kconfig
-index bf3a920064be..c524858118d2 100644
+index b2367239a..3bd8f03f9 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -163,6 +163,10 @@ config THREAD_INFO_IN_TASK
@@ -8647,7 +8824,7 @@ index bf3a920064be..c524858118d2 100644
  	bool "Optimize for size (-Os)"
  	help
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index ce1435cb08b1..e1359db5561e 100644
+index ce1435cb0..e1359db55 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -40,6 +40,27 @@ choice
@@ -8689,7 +8866,7 @@ index ce1435cb08b1..e1359db5561e 100644
  
  config SCHED_HRTICK
 diff --git a/kernel/Kconfig.preempt b/kernel/Kconfig.preempt
-index 54ea59ff8fbe..18f87e0dd137 100644
+index 54ea59ff8..18f87e0dd 100644
 --- a/kernel/Kconfig.preempt
 +++ b/kernel/Kconfig.preempt
 @@ -88,7 +88,7 @@ endchoice
@@ -8702,7 +8879,7 @@ index 54ea59ff8fbe..18f87e0dd137 100644
  	help
  	  This option turns the kernel into a real-time kernel by replacing
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 168681fc4b25..39e47bfaea58 100644
+index 168681fc4..39e47bfae 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -106,6 +106,10 @@
@@ -8741,7 +8918,7 @@ index 168681fc4b25..39e47bfaea58 100644
  	if (err)
  		goto bad_unshare_out;
 diff --git a/kernel/locking/rwsem.c b/kernel/locking/rwsem.c
-index 2ddb827e3bea..464049c4af3f 100644
+index 2ddb827e3..464049c4a 100644
 --- a/kernel/locking/rwsem.c
 +++ b/kernel/locking/rwsem.c
 @@ -747,6 +747,7 @@ rwsem_spin_on_owner(struct rw_semaphore *sem)
@@ -8763,7 +8940,7 @@ index 2ddb827e3bea..464049c4af3f 100644
  
  	return state;
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 1a1caae2b2f7..ff9070239624 100644
+index 9bf6931c8..86db81fb8 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -76,10 +76,19 @@ unsigned int sysctl_sched_tunable_scaling = SCHED_TUNABLESCALING_LOG;
@@ -8800,7 +8977,7 @@ index 1a1caae2b2f7..ff9070239624 100644
  #ifdef CONFIG_NUMA_BALANCING
  /* Restrict the NUMA promotion throughput (MB/s) for each target node. */
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index d6f82833f652..ad6cbf2d9683 100644
+index d6f82833f..ad6cbf2d9 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2790,7 +2790,7 @@ extern void deactivate_task(struct rq *rq, struct task_struct *p, int flags);
@@ -8813,7 +8990,7 @@ index d6f82833f652..ad6cbf2d9683 100644
  #else
  # define SCHED_NR_MIGRATE_BREAK 32
 diff --git a/kernel/sched/wait.c b/kernel/sched/wait.c
-index 51e38f5f4701..c5cc616484ba 100644
+index 51e38f5f4..c5cc61648 100644
 --- a/kernel/sched/wait.c
 +++ b/kernel/sched/wait.c
 @@ -47,6 +47,17 @@ void add_wait_queue_priority(struct wait_queue_head *wq_head, struct wait_queue_
@@ -8855,7 +9032,7 @@ index 51e38f5f4701..c5cc616484ba 100644
  {
  	wq_entry->flags = flags;
 diff --git a/kernel/sysctl.c b/kernel/sysctl.c
-index 3b7a7308e35b..fe7bec454345 100644
+index 3b7a7308e..fe7bec454 100644
 --- a/kernel/sysctl.c
 +++ b/kernel/sysctl.c
 @@ -70,6 +70,9 @@
@@ -8885,7 +9062,7 @@ index 3b7a7308e35b..fe7bec454345 100644
  	{
  		.procname	= "tainted",
 diff --git a/kernel/user_namespace.c b/kernel/user_namespace.c
-index 682f40d5632d..434a25f7b2ed 100644
+index 682f40d56..434a25f7b 100644
 --- a/kernel/user_namespace.c
 +++ b/kernel/user_namespace.c
 @@ -22,6 +22,13 @@
@@ -8903,7 +9080,7 @@ index 682f40d5632d..434a25f7b2ed 100644
  static DEFINE_MUTEX(userns_state_mutex);
  
 diff --git a/mm/Kconfig b/mm/Kconfig
-index e113f713b493..825b5932debc 100644
+index e113f713b..825b5932d 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
 @@ -462,6 +462,69 @@ config ARCH_WANT_OPTIMIZE_HUGETLB_VMEMMAP
@@ -8986,7 +9163,7 @@ index e113f713b493..825b5932debc 100644
  
  #
 diff --git a/mm/compaction.c b/mm/compaction.c
-index ca71fd3c3181..2070b1e5106f 100644
+index ca71fd3c3..2070b1e51 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -1923,7 +1923,11 @@ static int sysctl_compact_unevictable_allowed __read_mostly = CONFIG_COMPACT_UNE
@@ -9002,7 +9179,7 @@ index ca71fd3c3181..2070b1e5106f 100644
  static int __read_mostly sysctl_compact_memory;
  
 diff --git a/mm/huge_memory.c b/mm/huge_memory.c
-index 47d76d03ce30..48615051a8cf 100644
+index 213780e73..b6278caf4 100644
 --- a/mm/huge_memory.c
 +++ b/mm/huge_memory.c
 @@ -64,7 +64,11 @@ unsigned long transparent_hugepage_flags __read_mostly =
@@ -9018,7 +9195,7 @@ index 47d76d03ce30..48615051a8cf 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index eedce9321e13..8201039f1c1c 100644
+index eedce9321..8201039f1 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -2732,6 +2732,7 @@ static void __init mem_init_print_info(void)
@@ -9030,7 +9207,7 @@ index eedce9321e13..8201039f1c1c 100644
  
  void __init __weak arch_mm_preinit(void)
 diff --git a/mm/page-writeback.c b/mm/page-writeback.c
-index 20e1d76f1eba..2d1f99f1ef3d 100644
+index 20e1d76f1..2d1f99f1e 100644
 --- a/mm/page-writeback.c
 +++ b/mm/page-writeback.c
 @@ -71,7 +71,11 @@ static long ratelimit_pages = 32;
@@ -9058,7 +9235,7 @@ index 20e1d76f1eba..2d1f99f1ef3d 100644
  EXPORT_SYMBOL_GPL(dirty_writeback_interval);
  
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 4f29e393f6af..4632022638a5 100644
+index 4f29e393f..463202263 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -274,7 +274,11 @@ const char * const migratetype_names[MIGRATE_TYPES] = {
@@ -9074,7 +9251,7 @@ index 4f29e393f6af..4632022638a5 100644
  int defrag_mode;
  
 diff --git a/mm/swap.c b/mm/swap.c
-index 77b2d5997873..443eb4a8b42b 100644
+index 77b2d5997..443eb4a8b 100644
 --- a/mm/swap.c
 +++ b/mm/swap.c
 @@ -1091,6 +1091,10 @@ static const struct ctl_table swap_sysctl_table[] = {
@@ -9097,7 +9274,7 @@ index 77b2d5997873..443eb4a8b42b 100644
  	 * Right now other parts of the system means that we
  	 * _really_ don't want to cluster much more
 diff --git a/mm/util.c b/mm/util.c
-index 448117da071f..b9334775c51d 100644
+index 448117da0..b9334775c 100644
 --- a/mm/util.c
 +++ b/mm/util.c
 @@ -857,6 +857,40 @@ static const struct ctl_table util_sysctl_table[] = {
@@ -9142,7 +9319,7 @@ index 448117da071f..b9334775c51d 100644
  
  static int __init init_vm_util_sysctls(void)
 diff --git a/mm/vmpressure.c b/mm/vmpressure.c
-index bd5183dfd879..3a410f53a07c 100644
+index bd5183dfd..3a410f53a 100644
 --- a/mm/vmpressure.c
 +++ b/mm/vmpressure.c
 @@ -43,7 +43,11 @@ static const unsigned long vmpressure_win = SWAP_CLUSTER_MAX * 16;
@@ -9158,7 +9335,7 @@ index bd5183dfd879..3a410f53a07c 100644
  
  /*
 diff --git a/mm/vmscan.c b/mm/vmscan.c
-index 3783e45bfc92..75f48ea2b336 100644
+index d3bce4d7a..882417c57 100644
 --- a/mm/vmscan.c
 +++ b/mm/vmscan.c
 @@ -148,6 +148,15 @@ struct scan_control {
@@ -9201,7 +9378,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  
  #ifdef CONFIG_MEMCG
  
-@@ -1147,6 +1169,10 @@ static unsigned int shrink_folio_list(struct list_head *folio_list,
+@@ -1155,6 +1177,10 @@ static unsigned int shrink_folio_list(struct list_head *folio_list,
  		if (!sc->may_unmap && folio_mapped(folio))
  			goto keep_locked;
  
@@ -9212,7 +9389,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  		/*
  		 * The number of dirty pages determines if a node is marked
  		 * reclaim_congested. kswapd will stall and start writing
-@@ -2521,6 +2547,15 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
+@@ -2529,6 +2555,15 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
  		goto out;
  	}
  
@@ -9228,7 +9405,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  	/*
  	 * If there is enough inactive page cache, we do not reclaim
  	 * anything from the anonymous working right now.
-@@ -2638,6 +2673,14 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
+@@ -2646,6 +2681,14 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
  			BUG();
  		}
  
@@ -9243,7 +9420,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  		nr[lru] = scan;
  	}
  }
-@@ -2657,6 +2700,96 @@ static bool can_age_anon_pages(struct pglist_data *pgdat,
+@@ -2665,6 +2708,96 @@ static bool can_age_anon_pages(struct pglist_data *pgdat,
  	return can_demote(pgdat->node_id, sc);
  }
  
@@ -9340,7 +9517,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  #ifdef CONFIG_LRU_GEN
  
  #ifdef CONFIG_LRU_GEN_ENABLED
-@@ -4623,11 +4756,21 @@ static int get_tier_idx(struct lruvec *lruvec, int type)
+@@ -4631,11 +4764,21 @@ static int get_tier_idx(struct lruvec *lruvec, int type)
  	return tier - 1;
  }
  
@@ -9364,7 +9541,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  		return LRU_GEN_FILE;
  
  	if (swappiness >= MAX_SWAPPINESS)
-@@ -4646,7 +4789,7 @@ static int isolate_folios(struct lruvec *lruvec, struct scan_control *sc, int sw
+@@ -4654,7 +4797,7 @@ static int isolate_folios(struct lruvec *lruvec, struct scan_control *sc, int sw
  			  int *type_scanned, struct list_head *list)
  {
  	int i;
@@ -9373,7 +9550,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  
  	for_each_evictable_type(i, swappiness) {
  		int scanned;
-@@ -4889,6 +5032,12 @@ static int shrink_one(struct lruvec *lruvec, struct scan_control *sc)
+@@ -4897,6 +5040,12 @@ static int shrink_one(struct lruvec *lruvec, struct scan_control *sc)
  	struct mem_cgroup *memcg = lruvec_memcg(lruvec);
  	struct pglist_data *pgdat = lruvec_pgdat(lruvec);
  
@@ -9386,7 +9563,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  	/* lru_gen_age_node() called mem_cgroup_calculate_protection() */
  	if (mem_cgroup_below_min(NULL, memcg))
  		return MEMCG_LRU_YOUNG;
-@@ -6027,6 +6176,8 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
+@@ -6035,6 +6184,8 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
  
  	prepare_scan_control(pgdat, sc);
  
@@ -9396,7 +9573,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  
  	flush_reclaim_state(sc);
 diff --git a/net/ipv4/inet_connection_sock.c b/net/ipv4/inet_connection_sock.c
-index dd5cf8914a28..b216088a6abd 100644
+index dd5cf8914..b216088a6 100644
 --- a/net/ipv4/inet_connection_sock.c
 +++ b/net/ipv4/inet_connection_sock.c
 @@ -632,7 +632,7 @@ static int inet_csk_wait_for_connect(struct sock *sk, long timeo)
@@ -9408,229 +9585,33 @@ index dd5cf8914a28..b216088a6abd 100644
  					  TASK_INTERRUPTIBLE);
  		release_sock(sk);
  		if (reqsk_queue_empty(&icsk->icsk_accept_queue))
-diff --git a/scripts/Makefile.build b/scripts/Makefile.build
-index eb0d27812aec..951ee1fdaa3c 100644
---- a/scripts/Makefile.build
-+++ b/scripts/Makefile.build
-@@ -50,18 +50,23 @@ endif
- 
- # ===========================================================================
- 
-+builtin_suffix := $(if $(filter %.a_thinlto_native, $(MAKECMDGOALS)),.a_thinlto_native,.a)
-+ifeq ($(thinlto_final_pass),1)
-+builtin_suffix :=.a_thinlto_native
-+endif
-+
- # subdir-builtin and subdir-modorder may contain duplications. Use $(sort ...)
--subdir-builtin := $(sort $(filter %/built-in.a, $(real-obj-y)))
-+subdir-builtin := $(sort $(filter %/built-in$(builtin_suffix), $(real-obj-y)))
- subdir-modorder := $(sort $(filter %/modules.order, $(obj-m)))
- 
- targets-for-builtin := $(extra-y)
- 
- ifneq ($(strip $(lib-y) $(lib-m) $(lib-)),)
--targets-for-builtin += $(obj)/lib.a
-+targets-for-builtin += $(obj)/lib$(builtin_suffix)
- endif
- 
- ifdef need-builtin
--targets-for-builtin += $(obj)/built-in.a
-+targets-for-builtin += $(obj)/built-in$(builtin_suffix)
- endif
- 
- targets-for-modules := $(foreach x, o mod, \
-@@ -337,6 +342,10 @@ $(obj)/%.o: $(obj)/%.S FORCE
- targets += $(filter-out $(subdir-builtin), $(real-obj-y))
- targets += $(filter-out $(subdir-modorder), $(real-obj-m))
- targets += $(lib-y) $(always-y)
-+ifeq ($(builtin_suffix),.a_thinlto_native)
-+native_targets = $(patsubst,%.o,%.o_thinlto_native,$(targets))
-+targets += $(native_targets)
-+endif
- 
- # Linker scripts preprocessor (.lds.S -> .lds)
- # ---------------------------------------------------------------------------
-@@ -347,6 +356,24 @@ quiet_cmd_cpp_lds_S = LDS     $@
- $(obj)/%.lds: $(src)/%.lds.S FORCE
- 	$(call if_changed_dep,cpp_lds_S)
- 
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+# Generate .o_thinlto_native (obj) from .o (bitcode) file
-+# ---------------------------------------------------------------------------
-+quiet_cmd_cc_o_bc = CC $(quiet_modtag) $@
-+
-+cmd_cc_o_bc      = $(if $(filter bitcode, $(shell file -b $<)),$(CC) \
-+		   $(filter-out -Wp% $(LINUXINCLUDE) %.h.gch %.h -D% \
-+		   -flto=thin, $(c_flags)) \
-+		   -Wno-unused-command-line-argument \
-+		   -x ir -fthinlto-index=$<.thinlto.bc -c -o $@ \
-+		   $(if $(findstring ../,$<), \
-+		   $$(realpath --relative-to=$(srcroot) $<), $<), \
-+		   cp $< $@)
-+
-+$(obj)/%.o_thinlto_native: $(obj)/%.o FORCE
-+	$(call if_changed,cc_o_bc)
-+endif
-+
- # ASN.1 grammar
- # ---------------------------------------------------------------------------
- quiet_cmd_asn1_compiler = ASN.1   $(basename $@).[ch]
-@@ -360,7 +387,7 @@ $(obj)/%.asn1.c $(obj)/%.asn1.h: $(src)/%.asn1 $(objtree)/scripts/asn1_compiler
- # ---------------------------------------------------------------------------
- 
- # To build objects in subdirs, we need to descend into the directories
--$(subdir-builtin): $(obj)/%/built-in.a: $(obj)/% ;
-+$(subdir-builtin): $(obj)/%/built-in$(builtin_suffix): $(obj)/% ;
- $(subdir-modorder): $(obj)/%/modules.order: $(obj)/% ;
- 
- #
-@@ -377,6 +404,12 @@ quiet_cmd_ar_builtin = AR      $@
- $(obj)/built-in.a: $(real-obj-y) FORCE
- 	$(call if_changed,ar_builtin)
- 
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+# Rule to compile a set of .o_thinlto_native files into one .a_thinlto_native file.
-+$(obj)/built-in.a_thinlto_native: $(patsubst %.o,%.o_thinlto_native,$(real-obj-y)) FORCE
-+	$(call if_changed,ar_builtin)
-+endif
-+
- # This is a list of build artifacts from the current Makefile and its
- # sub-directories. The timestamp should be updated when any of the member files.
- 
-@@ -394,6 +427,14 @@ $(obj)/modules.order: $(obj-m) FORCE
- $(obj)/lib.a: $(lib-y) FORCE
- 	$(call if_changed,ar)
- 
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+quiet_cmd_ar_native = AR      $@
-+      cmd_ar_native = rm -f $@; $(AR) cDPrsT $@ $(patsubst %.o,%.o_thinlto_native,$(real-prereqs))
-+
-+$(obj)/lib.a_thinlto_native: $(patsubst %.o,%.o_thinlto_native,$(lib-y)) FORCE
-+	$(call if_changed,ar_native)
-+endif
-+
- quiet_cmd_ld_multi_m = LD [M]  $@
-       cmd_ld_multi_m = $(LD) $(ld_flags) -r -o $@ @$< $(cmd_objtool)
- 
-@@ -459,7 +500,8 @@ $(single-subdir-goals): $(single-subdirs)
- PHONY += $(subdir-ym)
- $(subdir-ym):
- 	$(Q)$(MAKE) $(build)=$@ \
--	need-builtin=$(if $(filter $@/built-in.a, $(subdir-builtin)),1) \
-+	need-builtin=$(if $(filter $@/built-in$(builtin_suffix), $(subdir-builtin)),1) \
-+	thinlto_final_pass=$(if $(filter .a_thinlto_native, $(builtin_suffix)),1) \
- 	need-modorder=$(if $(filter $@/modules.order, $(subdir-modorder)),1) \
- 	$(filter $@/%, $(single-subdir-goals))
- 
-diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 2fe73cda0bdd..9cfd23590334 100644
---- a/scripts/Makefile.lib
-+++ b/scripts/Makefile.lib
-@@ -34,8 +34,13 @@ else
- obj-m := $(filter-out %/, $(obj-m))
- endif
- 
-+builtin_suffix := $(if $(filter %.a_thinlto_native, $(MAKECMDGOALS)),.a_thinlto_native,.a)
-+ifeq ($(thinlto_final_pass),1)
-+        builtin_suffix :=.a_thinlto_native
-+endif
-+
- ifdef need-builtin
--obj-y		:= $(patsubst %/, %/built-in.a, $(obj-y))
-+obj-y		:= $(patsubst %/, %/built-in$(builtin_suffix), $(obj-y))
- else
- obj-y		:= $(filter-out %/, $(obj-y))
- endif
-diff --git a/scripts/Makefile.vmlinux_o b/scripts/Makefile.vmlinux_o
-index b024ffb3e201..f9abc45a68b3 100644
---- a/scripts/Makefile.vmlinux_o
-+++ b/scripts/Makefile.vmlinux_o
-@@ -9,6 +9,14 @@ include $(srctree)/scripts/Kbuild.include
- # for objtool
- include $(srctree)/scripts/Makefile.lib
- 
-+ifeq ($(thinlto_final_pass),1)
-+vmlinux_a := vmlinux.a_thinlto_native
-+vmlinux_libs := $(patsubst %.a,%.a_thinlto_native,$(KBUILD_VMLINUX_LIBS))
-+else
-+vmlinux_a := vmlinux.a
-+vmlinux_libs := $(KBUILD_VMLINUX_LIBS)
-+endif
-+
- # Generate a linker script to ensure correct ordering of initcalls for Clang LTO
- # ---------------------------------------------------------------------------
- 
-@@ -18,7 +26,7 @@ quiet_cmd_gen_initcalls_lds = GEN     $@
- 	$(PERL) $(real-prereqs) > $@
- 
- .tmp_initcalls.lds: $(srctree)/scripts/generate_initcall_order.pl \
--		vmlinux.a $(KBUILD_VMLINUX_LIBS) FORCE
-+		$(vmlinux_a) $(vmlinux_libs) FORCE
- 	$(call if_changed,gen_initcalls_lds)
- 
- targets := .tmp_initcalls.lds
-@@ -59,8 +67,8 @@ quiet_cmd_ld_vmlinux.o = LD      $@
- 	$(LD) ${KBUILD_LDFLAGS} -r -o $@ \
- 	$(vmlinux-o-ld-args-y) \
- 	$(addprefix -T , $(initcalls-lds)) \
--	--whole-archive vmlinux.a --no-whole-archive \
--	--start-group $(KBUILD_VMLINUX_LIBS) --end-group \
-+	--whole-archive $(vmlinux_a) --no-whole-archive \
-+	--start-group $(vmlinux_libs) --end-group \
- 	$(cmd_objtool)
- 
- define rule_ld_vmlinux.o
-@@ -68,7 +76,7 @@ define rule_ld_vmlinux.o
- 	$(call cmd,gen_objtooldep)
- endef
- 
--vmlinux.o: $(initcalls-lds) vmlinux.a $(KBUILD_VMLINUX_LIBS) FORCE
-+vmlinux.o: $(initcalls-lds) $(vmlinux_a) $(vmlinux_libs) FORCE
- 	$(call if_changed_rule,ld_vmlinux.o)
- 
- targets += vmlinux.o
-diff --git a/scripts/Makefile.vmlinux_thinlink b/scripts/Makefile.vmlinux_thinlink
+diff --git a/scripts/Makefile.thinlto b/scripts/Makefile.thinlto
 new file mode 100644
-index 000000000000..13e4026c7d45
+index 000000000..ec98fa2ea
 --- /dev/null
-+++ b/scripts/Makefile.vmlinux_thinlink
-@@ -0,0 +1,53 @@
-+# SPDX-License-Identifier: GPL-2.0-only
-+
++++ b/scripts/Makefile.thinlto
+@@ -0,0 +1,38 @@
 +PHONY := __default
-+__default: vmlinux.thinlink
++__default:
 +
 +include include/config/auto.conf
 +include $(srctree)/scripts/Kbuild.include
++include $(srctree)/scripts/Makefile.lib
 +
++native-objs := $(patsubst %.o,%.thinlto-native.o,$(call read-file, vmlinux.thinlto-index))
 +
-+# Generate a linker script to ensure correct ordering of initcalls for Clang LTO
++__default: $(native-objs)
++
++# Generate .thinlto-native.o (obj) from .o (bitcode) and .thinlto.bc (summary) files
 +# ---------------------------------------------------------------------------
++quiet_cmd_cc_o_bc = CC $(quiet_modtag)  $@
++      cmd_cc_o_bc = \
++      $(CC) $(_c_flags) -fno-lto -Wno-unused-command-line-argument \
++      -fthinlto-index=$(word 2, $^) -c -o $@ $<
 +
-+quiet_cmd_gen_initcalls_lds = GEN     $@
-+      cmd_gen_initcalls_lds = \
-+	$(PYTHON3) $(srctree)/scripts/jobserver-exec \
-+	$(PERL) $(real-prereqs) > $@
-+
-+.tmp_initcalls_thinlink.lds: $(srctree)/scripts/generate_initcall_order.pl \
-+		vmlinux.a FORCE
-+	$(call if_changed,gen_initcalls_lds)
-+
-+targets := .tmp_initcalls_thinlink.lds
-+
-+initcalls-lds := .tmp_initcalls_thinlink.lds
-+
-+quiet_cmd_ld_vmlinux.thinlink = LD      $@
-+      cmd_ld_vmlinux.thinlink = \
-+	$(AR) t vmlinux.a > .vmlinux_thinlto_bc_files; \
-+	$(LD) ${KBUILD_LDFLAGS} -r $(addprefix -T , $(initcalls-lds)) \
-+	--thinlto-index-only @.vmlinux_thinlto_bc_files; \
-+	touch vmlinux.thinlink
-+
-+vmlinux.thinlink: vmlinux.a $(initcalls-lds) FORCE
-+	$(call if_changed,ld_vmlinux.thinlink)
-+
-+targets += vmlinux.thinlink
++targets += $(native-objs)
++$(native-objs): %.thinlto-native.o: %.o %.o.thinlto.bc   FORCE
++	$(call if_changed,cc_o_bc)
 +
 +# Add FORCE to the prerequisites of a target to force it to be always rebuilt.
 +# ---------------------------------------------------------------------------
@@ -9648,18 +9629,122 @@ index 000000000000..13e4026c7d45
 +-include $(foreach f,$(existing-targets),$(dir $(f)).$(notdir $(f)).cmd)
 +
 +.PHONY: $(PHONY)
-diff --git a/scripts/head-object-list.txt b/scripts/head-object-list.txt
-index 7274dfc65af6..90710b87a387 100644
---- a/scripts/head-object-list.txt
-+++ b/scripts/head-object-list.txt
-@@ -18,6 +18,7 @@ arch/arm/kernel/head.o
- arch/csky/kernel/head.o
- arch/hexagon/kernel/head.o
- arch/loongarch/kernel/head.o
-+arch/loongarch/kernel/head.o_thinlto_native
- arch/m68k/68000/head.o
- arch/m68k/coldfire/head.o
- arch/m68k/kernel/head.o
--- 
-2.50.1
-
+diff --git a/scripts/Makefile.vmlinux_a b/scripts/Makefile.vmlinux_a
+new file mode 100644
+index 000000000..73c9545de
+--- /dev/null
++++ b/scripts/Makefile.vmlinux_a
+@@ -0,0 +1,83 @@
++# SPDX-License-Identifier: GPL-2.0-only
++
++PHONY := __default
++__default: vmlinux.a
++
++include include/config/auto.conf
++include $(srctree)/scripts/Kbuild.include
++include $(srctree)/scripts/Makefile.lib
++
++# Link of built-in-fixup.a
++# ---------------------------------------------------------------------------
++
++# '$(AR) mPi' needs 'T' to workaround the bug of llvm-ar <= 14
++quiet_cmd_ar_builtin_fixup = AR      $@
++      cmd_ar_builtin_fixup = \
++	rm -f $@; \
++	$(AR) cDPrST $@ $(KBUILD_VMLINUX_OBJS); \
++	$(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep -F -f $(srctree)/scripts/head-object-list.txt)
++
++targets += built-in-fixup.a
++built-in-fixup.a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
++	$(call if_changed,ar_builtin_fixup)
++
++ifdef CONFIG_LTO_CLANG_THIN_DIST
++
++quiet_cmd_builtin.order = GEN     $@
++      cmd_builtin.order = $(AR) t $< > $@
++
++targets += builtin.order
++builtin.order: built-in-fixup.a FORCE
++	$(call if_changed,builtin.order)
++
++quiet_cmd_ld_thinlto_index = LD      $@
++      cmd_ld_thinlto_index = \
++	$(LD) $(KBUILD_LDFLAGS) -r --thinlto-index-only=$@ @$<
++
++targets += vmlinux.thinlto-index
++vmlinux.thinlto-index: builtin.order FORCE
++	$(call if_changed,ld_thinlto_index)
++
++quiet_cmd_ar_vmlinux.a = GEN     $@
++      cmd_ar_vmlinux.a =					\
++	rm -f $@;						\
++	while read -r obj; do					\
++		if grep -q $${obj} $(word 2, $^); then		\
++			echo $${obj%.o}.thinlto-native.o;	\
++		else						\
++			echo $${obj};				\
++		fi;						\
++	done < $< | xargs $(AR) cDPrS $@
++
++targets += vmlinux.a
++vmlinux.a: builtin.order vmlinux.thinlto-index FORCE
++	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.thinlto
++	$(call if_changed,ar_vmlinux.a)
++
++else
++
++# vmlinux.a
++# ---------------------------------------------------------------------------
++
++targets += vmlinux.a
++vmlinux.a: built-in-fixup.a FORCE
++	$(call if_changed,copy)
++
++endif
++
++# Add FORCE to the prerequisites of a target to force it to be always rebuilt.
++# ---------------------------------------------------------------------------
++
++PHONY += FORCE
++FORCE:
++
++# Read all saved command lines and dependencies for the $(targets) we
++# may be building above, using $(if_changed{,_dep}). As an
++# optimization, we don't need to read them if the target does not
++# exist, we will rebuild anyway in that case.
++
++existing-targets := $(wildcard $(sort $(targets)))
++
++-include $(foreach f,$(existing-targets),$(dir $(f)).$(notdir $(f)).cmd)
++
++.PHONY: $(PHONY)
+diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
+index be89921d6..01717ed0d 100644
+--- a/scripts/mod/modpost.c
++++ b/scripts/mod/modpost.c
+@@ -1471,13 +1471,22 @@ static void extract_crcs_for_object(const char *object, struct module *mod)
+ 	char cmd_file[PATH_MAX];
+ 	char *buf, *p;
+ 	const char *base;
+-	int dirlen, ret;
++	int dirlen, baselen_without_suffix, ret;
+ 
+ 	base = get_basename(object);
+ 	dirlen = base - object;
+ 
+-	ret = snprintf(cmd_file, sizeof(cmd_file), "%.*s.%s.cmd",
+-		       dirlen, object, base);
++	baselen_without_suffix = strlen(object) - dirlen - strlen(".o");
++
++	/*
++	 * When CONFIG_LTO_CLANG_THIN_DIST=y, the ELF is *.thinlto-native.o
++	 * but the symbol CRCs are recorded in *.o.cmd file.
++	 */
++	if (strends(object, ".thinlto-native.o"))
++		baselen_without_suffix -= strlen(".thinlto-native");
++
++	ret = snprintf(cmd_file, sizeof(cmd_file), "%.*s.%.*s.o.cmd",
++		       dirlen, object, baselen_without_suffix, base);
+ 	if (ret >= sizeof(cmd_file)) {
+ 		error("%s: too long path was truncated\n", cmd_file);
+ 		return;

--- a/6.15/0006-fixes.patch
+++ b/6.15/0006-fixes.patch
@@ -1,7 +1,7 @@
-From 8c46d2189dd9f554c00ed41da2d1b6dfa53b8b2a Mon Sep 17 00:00:00 2001
+From c4bb0154bfb5394712b248e5a5d2f8dadef6d63e Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:47 +0200
-Subject: [PATCH 5/6] fixes
+Subject: [PATCH 6/7] fixes
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  Documentation/kbuild/makefiles.rst        |   3 +
  arch/x86/include/asm/amd/fch.h            |  13 +
  arch/x86/kernel/cpu/amd.c                 |  54 ++++
- drivers/bluetooth/btusb.c                 |   2 +
+ drivers/gpu/drm/drm_atomic_uapi.c         |  51 ++-
  drivers/gpu/drm/i915/display/intel_dsb.c  |   4 +
  drivers/hid/hid-quirks.c                  |   5 +-
  drivers/i2c/busses/Kconfig                |   2 +-
@@ -22,13 +22,13 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  scripts/Makefile.lib                      |   5 +
  scripts/checkpatch.pl                     |  14 +
  scripts/package/PKGBUILD                  |   5 +
- 17 files changed, 509 insertions(+), 12 deletions(-)
+ 17 files changed, 542 insertions(+), 28 deletions(-)
  create mode 100644 Documentation/arch/x86/amd-debugging.rst
  create mode 100644 arch/x86/include/asm/amd/fch.h
 
 diff --git a/Documentation/arch/x86/amd-debugging.rst b/Documentation/arch/x86/amd-debugging.rst
 new file mode 100644
-index 000000000000..d92bf59d62c7
+index 000000000..d92bf59d6
 --- /dev/null
 +++ b/Documentation/arch/x86/amd-debugging.rst
 @@ -0,0 +1,368 @@
@@ -401,7 +401,7 @@ index 000000000000..d92bf59d62c7
 +the syslog. When a random reboot occurs this message can be helpful
 +to determine the next component to debug.
 diff --git a/Documentation/arch/x86/index.rst b/Documentation/arch/x86/index.rst
-index 8ac64d7de4dc..58a006525ae8 100644
+index 8ac64d7de..58a006525 100644
 --- a/Documentation/arch/x86/index.rst
 +++ b/Documentation/arch/x86/index.rst
 @@ -25,6 +25,7 @@ x86-specific Documentation
@@ -413,7 +413,7 @@ index 8ac64d7de4dc..58a006525ae8 100644
     amd_hsmp
     tdx
 diff --git a/Documentation/dev-tools/checkpatch.rst b/Documentation/dev-tools/checkpatch.rst
-index 76bd0ddb0041..abb3ff682076 100644
+index 76bd0ddb0..abb3ff682 100644
 --- a/Documentation/dev-tools/checkpatch.rst
 +++ b/Documentation/dev-tools/checkpatch.rst
 @@ -342,6 +342,24 @@ API usage
@@ -442,7 +442,7 @@ index 76bd0ddb0041..abb3ff682076 100644
      The function names used in DEVICE_ATTR is unusual.
      Typically, the store and show functions are used with <attr>_store and
 diff --git a/Documentation/kbuild/makefiles.rst b/Documentation/kbuild/makefiles.rst
-index 3b9a8bc671e2..2608aa32c762 100644
+index 3b9a8bc67..2608aa32c 100644
 --- a/Documentation/kbuild/makefiles.rst
 +++ b/Documentation/kbuild/makefiles.rst
 @@ -318,6 +318,9 @@ ccflags-y, asflags-y and ldflags-y
@@ -457,7 +457,7 @@ index 3b9a8bc671e2..2608aa32c762 100644
  
 diff --git a/arch/x86/include/asm/amd/fch.h b/arch/x86/include/asm/amd/fch.h
 new file mode 100644
-index 000000000000..2cf5153edbc2
+index 000000000..2cf5153ed
 --- /dev/null
 +++ b/arch/x86/include/asm/amd/fch.h
 @@ -0,0 +1,13 @@
@@ -475,7 +475,7 @@ index 000000000000..2cf5153edbc2
 +
 +#endif /* _ASM_X86_AMD_FCH_H_ */
 diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
-index 6f9a6185df7f..5e14474a0698 100644
+index 6f9a6185d..5e14474a0 100644
 --- a/arch/x86/kernel/cpu/amd.c
 +++ b/arch/x86/kernel/cpu/amd.c
 @@ -9,6 +9,7 @@
@@ -543,21 +543,91 @@ index 6f9a6185df7f..5e14474a0698 100644
 +	return 0;
 +}
 +late_initcall(print_s5_reset_status_mmio);
-diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 6f2fd043fd3f..0da7dc0cf8b0 100644
---- a/drivers/bluetooth/btusb.c
-+++ b/drivers/bluetooth/btusb.c
-@@ -705,6 +705,8 @@ static const struct usb_device_id quirks_table[] = {
- 						     BTUSB_WIDEBAND_SPEECH },
- 	{ USB_DEVICE(0x0489, 0xe139), .driver_info = BTUSB_MEDIATEK |
- 						     BTUSB_WIDEBAND_SPEECH },
-+	{ USB_DEVICE(0x0489, 0xe14e), .driver_info = BTUSB_MEDIATEK |
-+						     BTUSB_WIDEBAND_SPEECH },
- 	{ USB_DEVICE(0x0489, 0xe14f), .driver_info = BTUSB_MEDIATEK |
- 						     BTUSB_WIDEBAND_SPEECH },
- 	{ USB_DEVICE(0x0489, 0xe150), .driver_info = BTUSB_MEDIATEK |
+diff --git a/drivers/gpu/drm/drm_atomic_uapi.c b/drivers/gpu/drm/drm_atomic_uapi.c
+index c2726af66..2ae41a522 100644
+--- a/drivers/gpu/drm/drm_atomic_uapi.c
++++ b/drivers/gpu/drm/drm_atomic_uapi.c
+@@ -1068,7 +1068,6 @@ int drm_atomic_set_property(struct drm_atomic_state *state,
+ 		struct drm_plane *plane = obj_to_plane(obj);
+ 		struct drm_plane_state *plane_state;
+ 		struct drm_mode_config *config = &plane->dev->mode_config;
+-		const struct drm_plane_helper_funcs *plane_funcs = plane->helper_private;
+ 
+ 		plane_state = drm_atomic_get_plane_state(state, plane);
+ 		if (IS_ERR(plane_state)) {
+@@ -1084,21 +1083,8 @@ int drm_atomic_set_property(struct drm_atomic_state *state,
+ 				ret = drm_atomic_plane_get_property(plane, plane_state,
+ 								    prop, &old_val);
+ 				ret = drm_atomic_check_prop_changes(ret, old_val, prop_value, prop);
+-			}
+-
+-			/* ask the driver if this non-primary plane is supported */
+-			if (plane->type != DRM_PLANE_TYPE_PRIMARY) {
+-				ret = -EINVAL;
+-
+-				if (plane_funcs && plane_funcs->atomic_async_check)
+-					ret = plane_funcs->atomic_async_check(plane, state, true);
+-
+-				if (ret) {
+-					drm_dbg_atomic(prop->dev,
+-						       "[PLANE:%d:%s] does not support async flips\n",
+-						       obj->id, plane->name);
+-					break;
+-				}
++				if (ret)
++				    break;
+ 			}
+ 		}
+ 
+@@ -1394,6 +1380,10 @@ int drm_mode_atomic_ioctl(struct drm_device *dev,
+ 	int ret = 0;
+ 	unsigned int i, j, num_fences;
+ 	bool async_flip = false;
++	struct drm_plane *plane;
++	struct drm_plane_state *old_plane_state = NULL;
++	struct drm_plane_state *new_plane_state = NULL;
++	u64 fb_id = 0;
+ 
+ 	/* disallow for drivers not supporting atomic: */
+ 	if (!drm_core_check_feature(dev, DRIVER_ATOMIC))
+@@ -1521,6 +1511,35 @@ int drm_mode_atomic_ioctl(struct drm_device *dev,
+ 			copied_props++;
+ 		}
+ 
++		if (async_flip && obj->type == DRM_MODE_OBJECT_PLANE &&
++		    obj_to_plane(obj)->type != DRM_PLANE_TYPE_PRIMARY) {
++			/* need to ask the driver if this plane is supported */
++			plane = obj_to_plane(obj);
++			old_plane_state = drm_atomic_get_old_plane_state(state, plane);
++			new_plane_state = drm_atomic_get_new_plane_state(state, plane);
++			ret = drm_atomic_plane_get_property(plane, new_plane_state,
++							    dev->mode_config.prop_fb_id,
++							    &fb_id);
++			if (ret)
++				break;
++			/*
++			 * Only do the check if the plane was or is enabled.
++			 * Note that the new state doesn't have "visible" set yet,
++			 * so this uses fb_id instead.
++			 */
++			if (old_plane_state->visible || fb_id)
++				ret = -EINVAL;
++			if (ret && plane->helper_private &&
++			    plane->helper_private->atomic_async_check) {
++				ret = plane->helper_private->atomic_async_check(plane, state, true);
++			}
++			if (ret) {
++				drm_dbg_atomic(dev, "[PLANE:%d:%s] does not support async flips\n",
++						obj->id, plane->name);
++				break;
++			}
++		}
++
+ 		drm_mode_object_put(obj);
+ 	}
+ 
 diff --git a/drivers/gpu/drm/i915/display/intel_dsb.c b/drivers/gpu/drm/i915/display/intel_dsb.c
-index 9fc4003d1579..e5ece83a1df1 100644
+index 9fc4003d1..e5ece83a1 100644
 --- a/drivers/gpu/drm/i915/display/intel_dsb.c
 +++ b/drivers/gpu/drm/i915/display/intel_dsb.c
 @@ -806,6 +806,10 @@ struct intel_dsb *intel_dsb_prepare(struct intel_atomic_state *state,
@@ -572,7 +642,7 @@ index 9fc4003d1579..e5ece83a1df1 100644
  	if (!dsb)
  		goto out;
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index 06c27308e497..31508da93ba2 100644
+index 06c27308e..31508da93 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
 @@ -1066,7 +1066,7 @@ bool hid_ignore(struct hid_device *hdev)
@@ -595,7 +665,7 @@ index 06c27308e497..31508da93ba2 100644
  		quirks |= HID_QUIRK_HAVE_SPECIAL_DRIVER;
  
 diff --git a/drivers/i2c/busses/Kconfig b/drivers/i2c/busses/Kconfig
-index 83c88c79afe2..bbbd6240fa6e 100644
+index 83c88c79a..bbbd6240f 100644
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
 @@ -200,7 +200,7 @@ config I2C_ISMT
@@ -608,7 +678,7 @@ index 83c88c79afe2..bbbd6240fa6e 100644
  	help
  	  If you say yes to this option, support will be included for the Intel
 diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
-index dd75916157f0..59ecaa990bce 100644
+index dd7591615..59ecaa990 100644
 --- a/drivers/i2c/busses/i2c-piix4.c
 +++ b/drivers/i2c/busses/i2c-piix4.c
 @@ -34,6 +34,7 @@
@@ -669,7 +739,7 @@ index dd75916157f0..59ecaa990bce 100644
  		return;
  	}
 diff --git a/drivers/platform/x86/amd/pmc/pmc-quirks.c b/drivers/platform/x86/amd/pmc/pmc-quirks.c
-index 7ed12c1d3b34..f292111bd065 100644
+index 04686ae1e..7bd0d5340 100644
 --- a/drivers/platform/x86/amd/pmc/pmc-quirks.c
 +++ b/drivers/platform/x86/amd/pmc/pmc-quirks.c
 @@ -11,6 +11,7 @@
@@ -690,7 +760,7 @@ index 7ed12c1d3b34..f292111bd065 100644
  
  static struct quirk_entry quirk_spurious_8042 = {
 diff --git a/include/linux/hid.h b/include/linux/hid.h
-index daae1d6d11a7..a1305210b2fd 100644
+index ada27535a..ababb7d41 100644
 --- a/include/linux/hid.h
 +++ b/include/linux/hid.h
 @@ -357,6 +357,7 @@ struct hid_item {
@@ -710,7 +780,7 @@ index daae1d6d11a7..a1305210b2fd 100644
  #define HID_QUIRK_SKIP_OUTPUT_REPORT_ID		BIT(17)
  #define HID_QUIRK_NO_OUTPUT_REPORTS_ON_INTR_EP	BIT(18)
 diff --git a/scripts/Makefile.build b/scripts/Makefile.build
-index 951ee1fdaa3c..e175942e1de8 100644
+index eb0d27812..f0319f4dd 100644
 --- a/scripts/Makefile.build
 +++ b/scripts/Makefile.build
 @@ -20,6 +20,10 @@ always-m :=
@@ -725,7 +795,7 @@ index 951ee1fdaa3c..e175942e1de8 100644
  ccflags-y  :=
  rustflags-y :=
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 9cfd23590334..47d4c1808824 100644
+index 2fe73cda0..8b588a2d0 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -1,4 +1,9 @@
@@ -739,7 +809,7 @@ index 9cfd23590334..47d4c1808824 100644
  # flags that take effect in current and sub directories
  KBUILD_AFLAGS += $(subdir-asflags-y)
 diff --git a/scripts/checkpatch.pl b/scripts/checkpatch.pl
-index 3d22bf863eec..784912f570e9 100755
+index 3d22bf863..784912f57 100755
 --- a/scripts/checkpatch.pl
 +++ b/scripts/checkpatch.pl
 @@ -3690,6 +3690,20 @@ sub process {
@@ -764,7 +834,7 @@ index 3d22bf863eec..784912f570e9 100755
  		if (defined $root &&
  			(($realfile =~ /\.dtsi?$/ && $line =~ /^\+\s*compatible\s*=\s*\"/) ||
 diff --git a/scripts/package/PKGBUILD b/scripts/package/PKGBUILD
-index 452374d63c24..08f80d7c5df0 100644
+index 452374d63..08f80d7c5 100644
 --- a/scripts/package/PKGBUILD
 +++ b/scripts/package/PKGBUILD
 @@ -90,6 +90,11 @@ _package-headers() {
@@ -779,6 +849,3 @@ index 452374d63c24..08f80d7c5df0 100644
  	echo "Installing System.map and config..."
  	mkdir -p "${builddir}"
  	cp System.map "${builddir}/System.map"
--- 
-2.50.1
-

--- a/6.15/0006-fixes.patch
+++ b/6.15/0006-fixes.patch
@@ -1,4 +1,4 @@
-From c4bb0154bfb5394712b248e5a5d2f8dadef6d63e Mon Sep 17 00:00:00 2001
+From e358ee87c12a5beb9aa99c4609fa35203bb38a2f Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:47 +0200
 Subject: [PATCH 6/7] fixes
@@ -17,12 +17,13 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  drivers/i2c/busses/Kconfig                |   2 +-
  drivers/i2c/busses/i2c-piix4.c            |  18 +-
  drivers/platform/x86/amd/pmc/pmc-quirks.c |   3 +-
+ fs/proc/generic.c                         |  36 ++-
  include/linux/hid.h                       |   2 +
  scripts/Makefile.build                    |   4 +
  scripts/Makefile.lib                      |   5 +
  scripts/checkpatch.pl                     |  14 +
  scripts/package/PKGBUILD                  |   5 +
- 17 files changed, 542 insertions(+), 28 deletions(-)
+ 18 files changed, 561 insertions(+), 45 deletions(-)
  create mode 100644 Documentation/arch/x86/amd-debugging.rst
  create mode 100644 arch/x86/include/asm/amd/fch.h
 
@@ -759,6 +760,88 @@ index 04686ae1e..7bd0d5340 100644
  };
  
  static struct quirk_entry quirk_spurious_8042 = {
+diff --git a/fs/proc/generic.c b/fs/proc/generic.c
+index e0e50914a..8bc2b9606 100644
+--- a/fs/proc/generic.c
++++ b/fs/proc/generic.c
+@@ -364,6 +364,23 @@ static const struct inode_operations proc_dir_inode_operations = {
+ 	.setattr	= proc_notify_change,
+ };
+ 
++static void pde_set_flags(struct proc_dir_entry *pde)
++{
++	if (!pde->proc_ops)
++		return;
++
++	if (pde->proc_ops->proc_flags & PROC_ENTRY_PERMANENT)
++		pde->flags |= PROC_ENTRY_PERMANENT;
++	if (pde->proc_ops->proc_read_iter)
++		pde->flags |= PROC_ENTRY_proc_read_iter;
++#ifdef CONFIG_COMPAT
++	if (pde->proc_ops->proc_compat_ioctl)
++		pde->flags |= PROC_ENTRY_proc_compat_ioctl;
++#endif
++	if (pde->proc_ops->proc_lseek)
++		pde->flags |= PROC_ENTRY_proc_lseek;
++}
++
+ /* returns the registered entry, or frees dp and returns NULL on failure */
+ struct proc_dir_entry *proc_register(struct proc_dir_entry *dir,
+ 		struct proc_dir_entry *dp)
+@@ -371,6 +388,8 @@ struct proc_dir_entry *proc_register(struct proc_dir_entry *dir,
+ 	if (proc_alloc_inum(&dp->low_ino))
+ 		goto out_free_entry;
+ 
++	pde_set_flags(dp);
++
+ 	write_lock(&proc_subdir_lock);
+ 	dp->parent = dir;
+ 	if (pde_subdir_insert(dir, dp) == false) {
+@@ -559,20 +578,6 @@ struct proc_dir_entry *proc_create_reg(const char *name, umode_t mode,
+ 	return p;
+ }
+ 
+-static void pde_set_flags(struct proc_dir_entry *pde)
+-{
+-	if (pde->proc_ops->proc_flags & PROC_ENTRY_PERMANENT)
+-		pde->flags |= PROC_ENTRY_PERMANENT;
+-	if (pde->proc_ops->proc_read_iter)
+-		pde->flags |= PROC_ENTRY_proc_read_iter;
+-#ifdef CONFIG_COMPAT
+-	if (pde->proc_ops->proc_compat_ioctl)
+-		pde->flags |= PROC_ENTRY_proc_compat_ioctl;
+-#endif
+-	if (pde->proc_ops->proc_lseek)
+-		pde->flags |= PROC_ENTRY_proc_lseek;
+-}
+-
+ struct proc_dir_entry *proc_create_data(const char *name, umode_t mode,
+ 		struct proc_dir_entry *parent,
+ 		const struct proc_ops *proc_ops, void *data)
+@@ -583,7 +588,6 @@ struct proc_dir_entry *proc_create_data(const char *name, umode_t mode,
+ 	if (!p)
+ 		return NULL;
+ 	p->proc_ops = proc_ops;
+-	pde_set_flags(p);
+ 	return proc_register(parent, p);
+ }
+ EXPORT_SYMBOL(proc_create_data);
+@@ -634,7 +638,6 @@ struct proc_dir_entry *proc_create_seq_private(const char *name, umode_t mode,
+ 	p->proc_ops = &proc_seq_ops;
+ 	p->seq_ops = ops;
+ 	p->state_size = state_size;
+-	pde_set_flags(p);
+ 	return proc_register(parent, p);
+ }
+ EXPORT_SYMBOL(proc_create_seq_private);
+@@ -665,7 +668,6 @@ struct proc_dir_entry *proc_create_single_data(const char *name, umode_t mode,
+ 		return NULL;
+ 	p->proc_ops = &proc_single_ops;
+ 	p->single_show = show;
+-	pde_set_flags(p);
+ 	return proc_register(parent, p);
+ }
+ EXPORT_SYMBOL(proc_create_single_data);
 diff --git a/include/linux/hid.h b/include/linux/hid.h
 index ada27535a..ababb7d41 100644
 --- a/include/linux/hid.h

--- a/6.15/0007-t2.patch
+++ b/6.15/0007-t2.patch
@@ -1,7 +1,7 @@
-From 573474d7dca703a36e5e068bf07cbf422b890ea2 Mon Sep 17 00:00:00 2001
+From 7eeb33a77f82032610c68521313667f8b0f326dc Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:59 +0200
-Subject: [PATCH 6/6] t2
+Subject: [PATCH 7/7] t2
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -112,7 +112,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  create mode 100644 include/linux/soc/apple/dockchannel.h
 
 diff --git a/Documentation/core-api/printk-formats.rst b/Documentation/core-api/printk-formats.rst
-index 4bdc394e86af..f531873bb3c9 100644
+index 4bdc394e8..f531873bb 100644
 --- a/Documentation/core-api/printk-formats.rst
 +++ b/Documentation/core-api/printk-formats.rst
 @@ -648,6 +648,38 @@ Examples::
@@ -155,7 +155,7 @@ index 4bdc394e86af..f531873bb3c9 100644
  ----
  
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 6ef3fedc1233..59deaa42c062 100644
+index 6ef3fedc1..59deaa42c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -2281,6 +2281,9 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,
@@ -169,7 +169,7 @@ index 6ef3fedc1233..59deaa42c062 100644
  	    (pdev->class >> 8) == PCI_CLASS_DISPLAY_OTHER) {
  		if (drm_firmware_drivers_only() && amdgpu_modeset == -1)
 diff --git a/drivers/gpu/drm/i915/display/intel_ddi.c b/drivers/gpu/drm/i915/display/intel_ddi.c
-index f38c998935b9..1df3ddb366f4 100644
+index f38c99893..1df3ddb36 100644
 --- a/drivers/gpu/drm/i915/display/intel_ddi.c
 +++ b/drivers/gpu/drm/i915/display/intel_ddi.c
 @@ -4848,6 +4848,7 @@ static int intel_ddi_init_hdmi_connector(struct intel_digital_port *dig_port)
@@ -191,7 +191,7 @@ index f38c998935b9..1df3ddb366f4 100644
  	 *                     supported configuration
  	 */
 diff --git a/drivers/gpu/drm/i915/display/intel_fbdev.c b/drivers/gpu/drm/i915/display/intel_fbdev.c
-index adc19d5607de..64882765aa0a 100644
+index adc19d560..64882765a 100644
 --- a/drivers/gpu/drm/i915/display/intel_fbdev.c
 +++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
 @@ -224,10 +224,10 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
@@ -209,7 +209,7 @@ index adc19d5607de..64882765aa0a 100644
  			    fb->base.width, fb->base.height,
  			    sizes->fb_width, sizes->fb_height);
 diff --git a/drivers/gpu/drm/i915/display/intel_quirks.c b/drivers/gpu/drm/i915/display/intel_quirks.c
-index a32fae510ed2..662465733ddb 100644
+index a32fae510..662465733 100644
 --- a/drivers/gpu/drm/i915/display/intel_quirks.c
 +++ b/drivers/gpu/drm/i915/display/intel_quirks.c
 @@ -66,6 +66,18 @@ static void quirk_increase_ddi_disabled_time(struct intel_display *display)
@@ -242,7 +242,7 @@ index a32fae510ed2..662465733ddb 100644
  
  static const struct intel_dpcd_quirk intel_dpcd_quirks[] = {
 diff --git a/drivers/gpu/drm/i915/display/intel_quirks.h b/drivers/gpu/drm/i915/display/intel_quirks.h
-index cafdebda7535..a5296f82776e 100644
+index cafdebda7..a5296f827 100644
 --- a/drivers/gpu/drm/i915/display/intel_quirks.h
 +++ b/drivers/gpu/drm/i915/display/intel_quirks.h
 @@ -20,6 +20,7 @@ enum intel_quirk_id {
@@ -254,7 +254,7 @@ index cafdebda7535..a5296f82776e 100644
  
  void intel_init_quirks(struct intel_display *display);
 diff --git a/drivers/gpu/drm/tiny/appletbdrm.c b/drivers/gpu/drm/tiny/appletbdrm.c
-index 4370ba22dd88..8643216bad98 100644
+index 4370ba22d..8643216ba 100644
 --- a/drivers/gpu/drm/tiny/appletbdrm.c
 +++ b/drivers/gpu/drm/tiny/appletbdrm.c
 @@ -214,7 +214,7 @@ static int appletbdrm_read_response(struct appletbdrm_device *adev,
@@ -276,7 +276,7 @@ index 4370ba22dd88..8643216bad98 100644
  		goto free_info;
  	}
 diff --git a/drivers/gpu/vga/vga_switcheroo.c b/drivers/gpu/vga/vga_switcheroo.c
-index 18f2c92beff8..3de1bca45ed2 100644
+index 18f2c92be..3de1bca45 100644
 --- a/drivers/gpu/vga/vga_switcheroo.c
 +++ b/drivers/gpu/vga/vga_switcheroo.c
 @@ -438,12 +438,7 @@ find_active_client(struct list_head *head)
@@ -294,7 +294,7 @@ index 18f2c92beff8..3de1bca45ed2 100644
  	}
  
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index aeb4eabf3007..e7688c7fdc56 100644
+index 5bc1f086b..1c2522d95 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -129,7 +129,7 @@ config HID_APPLE
@@ -306,7 +306,7 @@ index aeb4eabf3007..e7688c7fdc56 100644
  	help
  	Support for some Apple devices which less or more break
  	HID specification.
-@@ -717,11 +717,13 @@ config LOGIWHEELS_FF
+@@ -727,11 +727,13 @@ config LOGIWHEELS_FF
  
  config HID_MAGICMOUSE
  	tristate "Apple Magic Mouse/Trackpad multi-touch support"
@@ -321,7 +321,7 @@ index aeb4eabf3007..e7688c7fdc56 100644
  
  config HID_MALTRON
  	tristate "Maltron L90 keyboard"
-@@ -771,6 +773,7 @@ config HID_MULTITOUCH
+@@ -781,6 +783,7 @@ config HID_MULTITOUCH
  	  Say Y here if you have one of the following devices:
  	  - 3M PCT touch screens
  	  - ActionStar dual touch panels
@@ -329,7 +329,7 @@ index aeb4eabf3007..e7688c7fdc56 100644
  	  - Atmel panels
  	  - Cando dual touch panels
  	  - Chunghwa panels
-@@ -1437,4 +1440,8 @@ endif # HID
+@@ -1445,4 +1448,8 @@ endif # HID
  
  source "drivers/hid/usbhid/Kconfig"
  
@@ -339,10 +339,10 @@ index aeb4eabf3007..e7688c7fdc56 100644
 +
  endif # HID_SUPPORT
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 85af5331ebd2..a0f58475434c 100644
+index 958f67193..f67db3d5d 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
-@@ -177,3 +177,7 @@ obj-$(CONFIG_ASUS_ALLY_HID)  += asus-ally-hid/
+@@ -176,3 +176,7 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
  obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
  
  obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
@@ -352,7 +352,7 @@ index 85af5331ebd2..a0f58475434c 100644
 +obj-$(CONFIG_HID_DOCKCHANNEL)   += dockchannel-hid/
 diff --git a/drivers/hid/dockchannel-hid/Kconfig b/drivers/hid/dockchannel-hid/Kconfig
 new file mode 100644
-index 000000000000..8a81d551a83d
+index 000000000..8a81d551a
 --- /dev/null
 +++ b/drivers/hid/dockchannel-hid/Kconfig
 @@ -0,0 +1,14 @@
@@ -372,7 +372,7 @@ index 000000000000..8a81d551a83d
 +endmenu
 diff --git a/drivers/hid/dockchannel-hid/Makefile b/drivers/hid/dockchannel-hid/Makefile
 new file mode 100644
-index 000000000000..7dba766b047f
+index 000000000..7dba766b0
 --- /dev/null
 +++ b/drivers/hid/dockchannel-hid/Makefile
 @@ -0,0 +1,6 @@
@@ -384,7 +384,7 @@ index 000000000000..7dba766b047f
 +obj-$(CONFIG_HID_DOCKCHANNEL)	+= dockchannel-hid.o
 diff --git a/drivers/hid/dockchannel-hid/dockchannel-hid.c b/drivers/hid/dockchannel-hid/dockchannel-hid.c
 new file mode 100644
-index 000000000000..a712a724ded3
+index 000000000..a712a724d
 --- /dev/null
 +++ b/drivers/hid/dockchannel-hid/dockchannel-hid.c
 @@ -0,0 +1,1213 @@
@@ -1602,7 +1602,7 @@ index 000000000000..a712a724ded3
 +MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
 +MODULE_LICENSE("Dual MIT/GPL");
 diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
-index ed34f5cd5a91..ed8b87f7556b 100644
+index a3405b1cc..35e41a6f9 100644
 --- a/drivers/hid/hid-apple.c
 +++ b/drivers/hid/hid-apple.c
 @@ -486,6 +486,7 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
@@ -1630,7 +1630,7 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  		else if (hid->product < 0x21d || hid->product >= 0x300)
  			table = powerbook_fn_keys;
  		else
-@@ -910,6 +921,13 @@ static int apple_probe(struct hid_device *hdev,
+@@ -911,6 +922,13 @@ static int apple_probe(struct hid_device *hdev,
  	struct apple_sc *asc;
  	int ret;
  
@@ -1644,7 +1644,7 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
  	if (asc == NULL) {
  		hid_err(hdev, "can't alloc apple descriptor\n");
-@@ -1127,21 +1145,28 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1133,21 +1151,28 @@ static const struct hid_device_id apple_devices[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS),
  		.driver_data = APPLE_HAS_FN | APPLE_RDESC_JIS },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K),
@@ -1681,7 +1681,7 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_ALU_WIRELESS_2009_ANSI),
  		.driver_data = APPLE_NUMLOCK_EMULATION | APPLE_HAS_FN },
  	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_ALU_WIRELESS_2009_ISO),
-@@ -1169,6 +1194,10 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1175,6 +1200,10 @@ static const struct hid_device_id apple_devices[] = {
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_RDESC_BATTERY },
  	{ HID_BLUETOOTH_DEVICE(BT_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_MAGIC_KEYBOARD_NUMPAD_2021),
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
@@ -1693,10 +1693,10 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  		.driver_data = APPLE_MAGIC_BACKLIGHT },
  
 diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
-index cd4215007d1a..4dd55546f446 100644
+index bd4b4cc78..ed6f23e41 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -464,7 +464,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
+@@ -468,7 +468,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
  
  	case HID_GLOBAL_ITEM_TAG_REPORT_SIZE:
  		parser->global.report_size = item_udata(item);
@@ -1708,7 +1708,7 @@ index cd4215007d1a..4dd55546f446 100644
  			hid_err(parser->device, "invalid report_size %d\n",
  					parser->global.report_size);
  			return -1;
-@@ -2303,6 +2306,12 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2307,6 +2310,12 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -1722,7 +1722,7 @@ index cd4215007d1a..4dd55546f446 100644
  		bus = "VIRTUAL";
  		break;
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 965ee2da07d2..4af0fa7c8eee 100644
+index 82f39fa14..0e1f7c966 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -93,6 +93,8 @@
@@ -1772,7 +1772,7 @@ index 965ee2da07d2..4af0fa7c8eee 100644
  #define USB_VENDOR_ID_ASETEK			0x2433
  #define USB_DEVICE_ID_ASETEK_INVICTA		0xf300
 diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index adfa329e917b..0787581a25cc 100644
+index 6d916c6c7..9d8165f7b 100644
 --- a/drivers/hid/hid-magicmouse.c
 +++ b/drivers/hid/hid-magicmouse.c
 @@ -60,8 +60,14 @@ MODULE_PARM_DESC(report_undeciphered, "Report undeciphered multi-touch state fie
@@ -2618,10 +2618,10 @@ index adfa329e917b..0787581a25cc 100644
 -		hid_err(msc->hdev, "unable to request touch data (%d)\n", ret);
 -}
 -
- static int magicmouse_fetch_battery(struct hid_device *hdev)
+ static bool is_usb_magicmouse2(__u32 vendor, __u32 product)
  {
- #ifdef CONFIG_HID_BATTERY_STRENGTH
-@@ -825,12 +1448,62 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 	if (vendor != USB_VENDOR_ID_APPLE)
+@@ -839,12 +1462,62 @@ static int magicmouse_probe(struct hid_device *hdev,
  	struct hid_report *report;
  	int ret;
  
@@ -2684,7 +2684,7 @@ index adfa329e917b..0787581a25cc 100644
  	msc->scroll_accel = SCROLL_ACCEL_DEFAULT;
  	msc->hdev = hdev;
  	INIT_DEFERRABLE_WORK(&msc->work, magicmouse_enable_mt_work);
-@@ -868,25 +1541,51 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -883,25 +1556,51 @@ static int magicmouse_probe(struct hid_device *hdev,
  		goto err_stop_hw;
  	}
  
@@ -2753,7 +2753,7 @@ index adfa329e917b..0787581a25cc 100644
  	}
  
  	if (!report) {
-@@ -896,21 +1595,14 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -911,21 +1610,14 @@ static int magicmouse_probe(struct hid_device *hdev,
  	}
  	report->size = 6;
  
@@ -2783,7 +2783,7 @@ index adfa329e917b..0787581a25cc 100644
  	}
  
  	return 0;
-@@ -981,10 +1673,42 @@ static const struct hid_device_id magic_mice[] = {
+@@ -999,10 +1691,42 @@ static const struct hid_device_id magic_mice[] = {
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
@@ -2826,7 +2826,7 @@ index adfa329e917b..0787581a25cc 100644
  static struct hid_driver magicmouse_driver = {
  	.name = "magicmouse",
  	.id_table = magic_mice,
-@@ -995,6 +1719,10 @@ static struct hid_driver magicmouse_driver = {
+@@ -1013,6 +1737,10 @@ static struct hid_driver magicmouse_driver = {
  	.event = magicmouse_event,
  	.input_mapping = magicmouse_input_mapping,
  	.input_configured = magicmouse_input_configured,
@@ -2838,7 +2838,7 @@ index adfa329e917b..0787581a25cc 100644
  module_hid_driver(magicmouse_driver);
  
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 536a0a47518f..06afcce30119 100644
+index 536a0a475..06afcce30 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -73,6 +73,7 @@ MODULE_LICENSE("GPL");
@@ -2987,7 +2987,7 @@ index 536a0a47518f..06afcce30119 100644
  	{ .driver_data = MT_CLS_GOOGLE,
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index 31508da93ba2..2cce36895a60 100644
+index 31508da93..2cce36895 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
 @@ -314,6 +314,7 @@ static const struct hid_device_id hid_have_special_driver[] = {
@@ -3015,7 +3015,7 @@ index 31508da93ba2..2cce36895a60 100644
  	{ }
 diff --git a/drivers/hid/spi-hid/Kconfig b/drivers/hid/spi-hid/Kconfig
 new file mode 100644
-index 000000000000..8e37f0fec28a
+index 000000000..8e37f0fec
 --- /dev/null
 +++ b/drivers/hid/spi-hid/Kconfig
 @@ -0,0 +1,26 @@
@@ -3047,7 +3047,7 @@ index 000000000000..8e37f0fec28a
 +	select CRC16
 diff --git a/drivers/hid/spi-hid/Makefile b/drivers/hid/spi-hid/Makefile
 new file mode 100644
-index 000000000000..f276ee12cb94
+index 000000000..f276ee12c
 --- /dev/null
 +++ b/drivers/hid/spi-hid/Makefile
 @@ -0,0 +1,10 @@
@@ -3063,7 +3063,7 @@ index 000000000000..f276ee12cb94
 +obj-$(CONFIG_SPI_HID_APPLE_OF)			+= spi-hid-apple-of.o
 diff --git a/drivers/hid/spi-hid/spi-hid-apple-core.c b/drivers/hid/spi-hid/spi-hid-apple-core.c
 new file mode 100644
-index 000000000000..1f8fa64d6d86
+index 000000000..1f8fa64d6
 --- /dev/null
 +++ b/drivers/hid/spi-hid/spi-hid-apple-core.c
 @@ -0,0 +1,1194 @@
@@ -4263,7 +4263,7 @@ index 000000000000..1f8fa64d6d86
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/spi-hid/spi-hid-apple-of.c b/drivers/hid/spi-hid/spi-hid-apple-of.c
 new file mode 100644
-index 000000000000..3f87b299351d
+index 000000000..3f87b2993
 --- /dev/null
 +++ b/drivers/hid/spi-hid/spi-hid-apple-of.c
 @@ -0,0 +1,151 @@
@@ -4420,7 +4420,7 @@ index 000000000000..3f87b299351d
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/spi-hid/spi-hid-apple.h b/drivers/hid/spi-hid/spi-hid-apple.h
 new file mode 100644
-index 000000000000..9abecd1ba780
+index 000000000..9abecd1ba
 --- /dev/null
 +++ b/drivers/hid/spi-hid/spi-hid-apple.h
 @@ -0,0 +1,35 @@
@@ -4460,7 +4460,7 @@ index 000000000000..9abecd1ba780
 +
 +#endif /* SPI_HID_APPLE_H */
 diff --git a/drivers/hwmon/applesmc.c b/drivers/hwmon/applesmc.c
-index fc6d6a9053ce..698f44794453 100644
+index fc6d6a905..698f44794 100644
 --- a/drivers/hwmon/applesmc.c
 +++ b/drivers/hwmon/applesmc.c
 @@ -6,6 +6,7 @@
@@ -6446,7 +6446,7 @@ index fc6d6a9053ce..698f44794453 100644
  MODULE_LICENSE("GPL v2");
  MODULE_DEVICE_TABLE(dmi, applesmc_whitelist);
 diff --git a/drivers/iommu/intel/dmar.c b/drivers/iommu/intel/dmar.c
-index e540092d664d..9e17e8e56308 100644
+index e540092d6..9e17e8e56 100644
 --- a/drivers/iommu/intel/dmar.c
 +++ b/drivers/iommu/intel/dmar.c
 @@ -1099,6 +1099,9 @@ static int alloc_iommu(struct dmar_drhd_unit *drhd)
@@ -6468,7 +6468,7 @@ index e540092d664d..9e17e8e56308 100644
  	kfree(iommu);
  }
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index ff07ee2940f5..a495aa76e5ee 100644
+index 91fe53d67..f80ca32f1 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -1289,52 +1289,13 @@ static void iommu_disable_translation(struct intel_iommu *iommu)
@@ -6592,7 +6592,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  	kfree(info);
  	return ret;
  }
-@@ -1435,15 +1386,14 @@ void domain_detach_iommu(struct dmar_domain *domain, struct intel_iommu *iommu)
+@@ -1435,14 +1386,13 @@ void domain_detach_iommu(struct dmar_domain *domain, struct intel_iommu *iommu)
  	if (domain->domain.type == IOMMU_DOMAIN_SVA)
  		return;
  
@@ -6603,14 +6603,13 @@ index ff07ee2940f5..a495aa76e5ee 100644
 -		clear_bit(info->did, iommu->domain_ids);
 +		ida_free(&iommu->domain_ida, info->did);
  		xa_erase(&domain->iommu_array, iommu->seq_id);
- 		domain->nid = NUMA_NO_NODE;
  		kfree(info);
  	}
 -	spin_unlock(&iommu->lock);
  }
  
  static void domain_exit(struct dmar_domain *domain)
-@@ -1681,9 +1631,8 @@ __domain_mapping(struct dmar_domain *domain, unsigned long iov_pfn,
+@@ -1680,9 +1630,8 @@ __domain_mapping(struct dmar_domain *domain, unsigned long iov_pfn,
  	}
  
  	attr = prot & (DMA_PTE_READ | DMA_PTE_WRITE | DMA_PTE_SNP);
@@ -6621,7 +6620,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  		if (prot & DMA_PTE_WRITE)
  			attr |= DMA_FL_PTE_DIRTY;
  	}
-@@ -2043,7 +1992,7 @@ static int copy_context_table(struct intel_iommu *iommu,
+@@ -2056,7 +2005,7 @@ static int copy_context_table(struct intel_iommu *iommu,
  
  		did = context_domain_id(&ce);
  		if (did >= 0 && did < cap_ndoms(iommu->cap))
@@ -6630,7 +6629,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  
  		set_context_copied(iommu, bus, devfn);
  		new_ce[idx] = ce;
-@@ -2170,11 +2119,6 @@ static int __init init_dmars(void)
+@@ -2183,11 +2132,6 @@ static int __init init_dmars(void)
  		}
  
  		intel_iommu_init_qi(iommu);
@@ -6642,7 +6641,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  		init_translation_status(iommu);
  
  		if (translation_pre_enabled(iommu) && !is_kdump_kernel()) {
-@@ -2652,9 +2596,7 @@ static int intel_iommu_add(struct dmar_drhd_unit *dmaru)
+@@ -2665,9 +2609,7 @@ static int intel_iommu_add(struct dmar_drhd_unit *dmaru)
  	if (iommu->gcmd & DMA_GCMD_TE)
  		iommu_disable_translation(iommu);
  
@@ -6653,7 +6652,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  	if (ret)
  		goto out;
  
-@@ -2745,7 +2687,6 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
+@@ -2758,7 +2700,6 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
  	struct device *tmp;
  	int i;
  
@@ -6661,7 +6660,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  	rcu_read_lock();
  
  	list_for_each_entry_rcu(satcu, &dmar_satc_units, list) {
-@@ -2762,15 +2703,16 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
+@@ -2775,15 +2716,16 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
  	return satcu;
  }
  
@@ -6683,7 +6682,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  
  	dev = pci_physfn(dev);
  	satcu = dmar_find_matched_satc_unit(dev);
-@@ -2788,11 +2730,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
+@@ -2801,11 +2743,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
  		bridge = bus->self;
  		/* If it's an integrated device, allow ATS */
  		if (!bridge)
@@ -6697,7 +6696,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  		/* If we found the root port, look it up in the ATSR */
  		if (pci_pcie_type(bridge) == PCI_EXP_TYPE_ROOT_PORT)
  			break;
-@@ -2811,11 +2753,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
+@@ -2824,11 +2766,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
  		if (atsru->include_all)
  			goto out;
  	}
@@ -6711,7 +6710,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  }
  
  int dmar_iommu_notify_scope_dev(struct dmar_pci_notify_info *info)
-@@ -2973,9 +2915,14 @@ static ssize_t domains_used_show(struct device *dev,
+@@ -2986,9 +2928,14 @@ static ssize_t domains_used_show(struct device *dev,
  				 struct device_attribute *attr, char *buf)
  {
  	struct intel_iommu *iommu = dev_to_intel_iommu(dev);
@@ -6730,10 +6729,10 @@ index ff07ee2940f5..a495aa76e5ee 100644
  static DEVICE_ATTR_RO(domains_used);
  
 diff --git a/drivers/iommu/intel/iommu.h b/drivers/iommu/intel/iommu.h
-index 814f5ed20018..a07a190c6d82 100644
+index 0f7cd96f1..910deecfe 100644
 --- a/drivers/iommu/intel/iommu.h
 +++ b/drivers/iommu/intel/iommu.h
-@@ -722,7 +722,9 @@ struct intel_iommu {
+@@ -725,7 +725,9 @@ struct intel_iommu {
  	unsigned char	name[16];    /* Device Name */
  
  #ifdef CONFIG_INTEL_IOMMU
@@ -6744,7 +6743,7 @@ index 814f5ed20018..a07a190c6d82 100644
  	unsigned long	*copied_tables; /* bitmap of copied tables */
  	spinlock_t	lock; /* protect context, domain ids */
  	struct root_entry *root_entry; /* virtual address */
-@@ -810,11 +812,22 @@ static inline struct dmar_domain *to_dmar_domain(struct iommu_domain *dom)
+@@ -813,11 +815,22 @@ static inline struct dmar_domain *to_dmar_domain(struct iommu_domain *dom)
  }
  
  /*
@@ -6771,7 +6770,7 @@ index 814f5ed20018..a07a190c6d82 100644
  /* Retrieve the domain ID which has allocated to the domain */
  static inline u16
 diff --git a/drivers/pci/vgaarb.c b/drivers/pci/vgaarb.c
-index 78748e8d2dba..2b2b558cebe6 100644
+index 78748e8d2..2b2b558ce 100644
 --- a/drivers/pci/vgaarb.c
 +++ b/drivers/pci/vgaarb.c
 @@ -143,6 +143,7 @@ void vga_set_default_device(struct pci_dev *pdev)
@@ -6783,7 +6782,7 @@ index 78748e8d2dba..2b2b558cebe6 100644
  /**
   * vga_remove_vgacon - deactivate VGA console
 diff --git a/drivers/platform/x86/apple-gmux.c b/drivers/platform/x86/apple-gmux.c
-index 1417e230edbd..e69785af8e1d 100644
+index 1417e230e..e69785af8 100644
 --- a/drivers/platform/x86/apple-gmux.c
 +++ b/drivers/platform/x86/apple-gmux.c
 @@ -21,6 +21,7 @@
@@ -6826,7 +6825,7 @@ index 1417e230edbd..e69785af8e1d 100644
  	 * Retina MacBook Pros cannot switch the panel's AUX separately
  	 * and need eDP pre-calibration. They are distinguishable from
 diff --git a/drivers/soc/apple/Kconfig b/drivers/soc/apple/Kconfig
-index 6388cbe1e56b..50f092732796 100644
+index 6388cbe1e..50f092732 100644
 --- a/drivers/soc/apple/Kconfig
 +++ b/drivers/soc/apple/Kconfig
 @@ -4,6 +4,16 @@ if ARCH_APPLE || COMPILE_TEST
@@ -6868,7 +6867,7 @@ index 6388cbe1e56b..50f092732796 100644
  	tristate "Apple SART DMA address filter"
  	depends on ARCH_APPLE || COMPILE_TEST
 diff --git a/drivers/soc/apple/Makefile b/drivers/soc/apple/Makefile
-index 4d9ab8f3037b..5e526a9edcf2 100644
+index 4d9ab8f30..5e526a9ed 100644
 --- a/drivers/soc/apple/Makefile
 +++ b/drivers/soc/apple/Makefile
 @@ -1,10 +1,16 @@
@@ -6890,7 +6889,7 @@ index 4d9ab8f3037b..5e526a9edcf2 100644
  apple-sart-y = sart.o
 diff --git a/drivers/soc/apple/dockchannel.c b/drivers/soc/apple/dockchannel.c
 new file mode 100644
-index 000000000000..3a0d7964007c
+index 000000000..3a0d79640
 --- /dev/null
 +++ b/drivers/soc/apple/dockchannel.c
 @@ -0,0 +1,406 @@
@@ -7302,7 +7301,7 @@ index 000000000000..3a0d7964007c
 +MODULE_DESCRIPTION("Apple DockChannel driver");
 diff --git a/drivers/soc/apple/rtkit-helper.c b/drivers/soc/apple/rtkit-helper.c
 new file mode 100644
-index 000000000000..080d083ed9bd
+index 000000000..080d083ed
 --- /dev/null
 +++ b/drivers/soc/apple/rtkit-helper.c
 @@ -0,0 +1,151 @@
@@ -7458,7 +7457,7 @@ index 000000000000..080d083ed9bd
 +MODULE_LICENSE("Dual MIT/GPL");
 +MODULE_DESCRIPTION("Apple RTKit helper driver");
 diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
-index 075e775d3868..e1cc0d60eeb6 100644
+index 075e775d3..e1cc0d60e 100644
 --- a/drivers/staging/Kconfig
 +++ b/drivers/staging/Kconfig
 @@ -50,4 +50,6 @@ source "drivers/staging/vme_user/Kconfig"
@@ -7469,7 +7468,7 @@ index 075e775d3868..e1cc0d60eeb6 100644
 +
  endif # STAGING
 diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
-index e681e403509c..4045c588b3b4 100644
+index e681e4035..4045c588b 100644
 --- a/drivers/staging/Makefile
 +++ b/drivers/staging/Makefile
 @@ -14,3 +14,4 @@ obj-$(CONFIG_GREYBUS)		+= greybus/
@@ -7479,7 +7478,7 @@ index e681e403509c..4045c588b3b4 100644
 +obj-$(CONFIG_APPLE_BCE)		+= apple-bce/
 diff --git a/drivers/staging/apple-bce/Kconfig b/drivers/staging/apple-bce/Kconfig
 new file mode 100644
-index 000000000000..fe92bc441e89
+index 000000000..fe92bc441
 --- /dev/null
 +++ b/drivers/staging/apple-bce/Kconfig
 @@ -0,0 +1,18 @@
@@ -7503,7 +7502,7 @@ index 000000000000..fe92bc441e89
 +	  If "M" is selected, the module will be called apple-bce.'
 diff --git a/drivers/staging/apple-bce/Makefile b/drivers/staging/apple-bce/Makefile
 new file mode 100644
-index 000000000000..8cfbd3f64af6
+index 000000000..8cfbd3f64
 --- /dev/null
 +++ b/drivers/staging/apple-bce/Makefile
 @@ -0,0 +1,28 @@
@@ -7537,7 +7536,7 @@ index 000000000000..8cfbd3f64af6
 +	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
 diff --git a/drivers/staging/apple-bce/apple_bce.c b/drivers/staging/apple-bce/apple_bce.c
 new file mode 100644
-index 000000000000..4fd2415d7028
+index 000000000..4fd2415d7
 --- /dev/null
 +++ b/drivers/staging/apple-bce/apple_bce.c
 @@ -0,0 +1,445 @@
@@ -7988,7 +7987,7 @@ index 000000000000..4fd2415d7028
 +module_exit(apple_bce_module_exit);
 diff --git a/drivers/staging/apple-bce/apple_bce.h b/drivers/staging/apple-bce/apple_bce.h
 new file mode 100644
-index 000000000000..58dbeff79e43
+index 000000000..58dbeff79
 --- /dev/null
 +++ b/drivers/staging/apple-bce/apple_bce.h
 @@ -0,0 +1,41 @@
@@ -8035,7 +8034,7 @@ index 000000000000..58dbeff79e43
 +#endif //APPLE_BCE_H
 diff --git a/drivers/staging/apple-bce/audio/audio.c b/drivers/staging/apple-bce/audio/audio.c
 new file mode 100644
-index 000000000000..bd16ddd16c1d
+index 000000000..bd16ddd16
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/audio.c
 @@ -0,0 +1,711 @@
@@ -8752,7 +8751,7 @@ index 000000000000..bd16ddd16c1d
 +MODULE_PARM_DESC(id, "ID string for Apple Internal Audio soundcard.");
 diff --git a/drivers/staging/apple-bce/audio/audio.h b/drivers/staging/apple-bce/audio/audio.h
 new file mode 100644
-index 000000000000..004bc1e22ea4
+index 000000000..004bc1e22
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/audio.h
 @@ -0,0 +1,125 @@
@@ -8883,7 +8882,7 @@ index 000000000000..004bc1e22ea4
 +#endif //AAUDIO_H
 diff --git a/drivers/staging/apple-bce/audio/description.h b/drivers/staging/apple-bce/audio/description.h
 new file mode 100644
-index 000000000000..dfef3ab68f27
+index 000000000..dfef3ab68
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/description.h
 @@ -0,0 +1,42 @@
@@ -8931,7 +8930,7 @@ index 000000000000..dfef3ab68f27
 +#endif //AAUDIO_DESCRIPTION_H
 diff --git a/drivers/staging/apple-bce/audio/pcm.c b/drivers/staging/apple-bce/audio/pcm.c
 new file mode 100644
-index 000000000000..1026e10a9ac5
+index 000000000..1026e10a9
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/pcm.c
 @@ -0,0 +1,308 @@
@@ -9245,7 +9244,7 @@ index 000000000000..1026e10a9ac5
 +}
 diff --git a/drivers/staging/apple-bce/audio/pcm.h b/drivers/staging/apple-bce/audio/pcm.h
 new file mode 100644
-index 000000000000..ea5f35fbe408
+index 000000000..ea5f35fbe
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/pcm.h
 @@ -0,0 +1,16 @@
@@ -9267,7 +9266,7 @@ index 000000000000..ea5f35fbe408
 +#endif //AAUDIO_PCM_H
 diff --git a/drivers/staging/apple-bce/audio/protocol.c b/drivers/staging/apple-bce/audio/protocol.c
 new file mode 100644
-index 000000000000..2314813aeead
+index 000000000..2314813ae
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol.c
 @@ -0,0 +1,347 @@
@@ -9621,7 +9620,7 @@ index 000000000000..2314813aeead
 \ No newline at end of file
 diff --git a/drivers/staging/apple-bce/audio/protocol.h b/drivers/staging/apple-bce/audio/protocol.h
 new file mode 100644
-index 000000000000..3427486f3f57
+index 000000000..3427486f3
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol.h
 @@ -0,0 +1,147 @@
@@ -9774,7 +9773,7 @@ index 000000000000..3427486f3f57
 +#endif //AAUDIO_PROTOCOL_H
 diff --git a/drivers/staging/apple-bce/audio/protocol_bce.c b/drivers/staging/apple-bce/audio/protocol_bce.c
 new file mode 100644
-index 000000000000..28f2dfd44d67
+index 000000000..28f2dfd44
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol_bce.c
 @@ -0,0 +1,226 @@
@@ -10006,7 +10005,7 @@ index 000000000000..28f2dfd44d67
 +}
 diff --git a/drivers/staging/apple-bce/audio/protocol_bce.h b/drivers/staging/apple-bce/audio/protocol_bce.h
 new file mode 100644
-index 000000000000..14d26c05ddf9
+index 000000000..14d26c05d
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol_bce.h
 @@ -0,0 +1,72 @@
@@ -10084,7 +10083,7 @@ index 000000000000..14d26c05ddf9
 +#endif //AAUDIO_PROTOCOL_BCE_H
 diff --git a/drivers/staging/apple-bce/mailbox.c b/drivers/staging/apple-bce/mailbox.c
 new file mode 100644
-index 000000000000..07ce11928988
+index 000000000..07ce11928
 --- /dev/null
 +++ b/drivers/staging/apple-bce/mailbox.c
 @@ -0,0 +1,155 @@
@@ -10245,7 +10244,7 @@ index 000000000000..07ce11928988
 +}
 diff --git a/drivers/staging/apple-bce/mailbox.h b/drivers/staging/apple-bce/mailbox.h
 new file mode 100644
-index 000000000000..f3323f95ba51
+index 000000000..f3323f95b
 --- /dev/null
 +++ b/drivers/staging/apple-bce/mailbox.h
 @@ -0,0 +1,53 @@
@@ -10304,7 +10303,7 @@ index 000000000000..f3323f95ba51
 +#endif //BCEDRIVER_MAILBOX_H
 diff --git a/drivers/staging/apple-bce/queue.c b/drivers/staging/apple-bce/queue.c
 new file mode 100644
-index 000000000000..bc9cd3bc6f0c
+index 000000000..bc9cd3bc6
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue.c
 @@ -0,0 +1,390 @@
@@ -10701,7 +10700,7 @@ index 000000000000..bc9cd3bc6f0c
 \ No newline at end of file
 diff --git a/drivers/staging/apple-bce/queue.h b/drivers/staging/apple-bce/queue.h
 new file mode 100644
-index 000000000000..8368ac5dfca8
+index 000000000..8368ac5df
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue.h
 @@ -0,0 +1,177 @@
@@ -10884,7 +10883,7 @@ index 000000000000..8368ac5dfca8
 +#endif //BCEDRIVER_MAILBOX_H
 diff --git a/drivers/staging/apple-bce/queue_dma.c b/drivers/staging/apple-bce/queue_dma.c
 new file mode 100644
-index 000000000000..b236613285c0
+index 000000000..b23661328
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue_dma.c
 @@ -0,0 +1,220 @@
@@ -11111,7 +11110,7 @@ index 000000000000..b236613285c0
 \ No newline at end of file
 diff --git a/drivers/staging/apple-bce/queue_dma.h b/drivers/staging/apple-bce/queue_dma.h
 new file mode 100644
-index 000000000000..f8a57e50e7a3
+index 000000000..f8a57e50e
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue_dma.h
 @@ -0,0 +1,50 @@
@@ -11167,7 +11166,7 @@ index 000000000000..f8a57e50e7a3
 +#endif //BCE_QUEUE_DMA_H
 diff --git a/drivers/staging/apple-bce/vhci/command.h b/drivers/staging/apple-bce/vhci/command.h
 new file mode 100644
-index 000000000000..26619e0bccfa
+index 000000000..26619e0bc
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/command.h
 @@ -0,0 +1,204 @@
@@ -11377,7 +11376,7 @@ index 000000000000..26619e0bccfa
 +#endif //BCE_VHCI_COMMAND_H
 diff --git a/drivers/staging/apple-bce/vhci/queue.c b/drivers/staging/apple-bce/vhci/queue.c
 new file mode 100644
-index 000000000000..7b0b5027157b
+index 000000000..7b0b50271
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/queue.c
 @@ -0,0 +1,268 @@
@@ -11651,7 +11650,7 @@ index 000000000000..7b0b5027157b
 +}
 diff --git a/drivers/staging/apple-bce/vhci/queue.h b/drivers/staging/apple-bce/vhci/queue.h
 new file mode 100644
-index 000000000000..adb705b6ba1d
+index 000000000..adb705b6b
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/queue.h
 @@ -0,0 +1,76 @@
@@ -11733,7 +11732,7 @@ index 000000000000..adb705b6ba1d
 +#endif //BCE_VHCI_QUEUE_H
 diff --git a/drivers/staging/apple-bce/vhci/transfer.c b/drivers/staging/apple-bce/vhci/transfer.c
 new file mode 100644
-index 000000000000..d77220707492
+index 000000000..d77220707
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/transfer.c
 @@ -0,0 +1,673 @@
@@ -12412,7 +12411,7 @@ index 000000000000..d77220707492
 +}
 diff --git a/drivers/staging/apple-bce/vhci/transfer.h b/drivers/staging/apple-bce/vhci/transfer.h
 new file mode 100644
-index 000000000000..b5403d5703ed
+index 000000000..b5403d570
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/transfer.h
 @@ -0,0 +1,75 @@
@@ -12493,7 +12492,7 @@ index 000000000000..b5403d5703ed
 +#endif //BCEDRIVER_TRANSFER_H
 diff --git a/drivers/staging/apple-bce/vhci/vhci.c b/drivers/staging/apple-bce/vhci/vhci.c
 new file mode 100644
-index 000000000000..3394e0aa2eef
+index 000000000..3394e0aa2
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/vhci.c
 @@ -0,0 +1,763 @@
@@ -13262,7 +13261,7 @@ index 000000000000..3394e0aa2eef
 +MODULE_PARM_DESC(vhci_port_mask, "Specifies which VHCI ports are enabled");
 diff --git a/drivers/staging/apple-bce/vhci/vhci.h b/drivers/staging/apple-bce/vhci/vhci.h
 new file mode 100644
-index 000000000000..6c2e22622f4c
+index 000000000..6c2e22622
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/vhci.h
 @@ -0,0 +1,52 @@
@@ -13319,7 +13318,7 @@ index 000000000000..6c2e22622f4c
 +
 +#endif //BCE_VHCI_H
 diff --git a/include/linux/hid.h b/include/linux/hid.h
-index a1305210b2fd..98aad4880f84 100644
+index ababb7d41..82a849cdc 100644
 --- a/include/linux/hid.h
 +++ b/include/linux/hid.h
 @@ -594,7 +594,9 @@ struct hid_input {
@@ -13344,7 +13343,7 @@ index a1305210b2fd..98aad4880f84 100644
  	.report_type = (rep)
 diff --git a/include/linux/soc/apple/dockchannel.h b/include/linux/soc/apple/dockchannel.h
 new file mode 100644
-index 000000000000..0b7093935ddf
+index 000000000..0b7093935
 --- /dev/null
 +++ b/include/linux/soc/apple/dockchannel.h
 @@ -0,0 +1,26 @@
@@ -13375,7 +13374,7 @@ index 000000000000..0b7093935ddf
 +#endif
 +#endif
 diff --git a/lib/tests/printf_kunit.c b/lib/tests/printf_kunit.c
-index 2c9f6170bacd..bc54cca2d7a6 100644
+index 2c9f6170b..bc54cca2d 100644
 --- a/lib/tests/printf_kunit.c
 +++ b/lib/tests/printf_kunit.c
 @@ -701,21 +701,46 @@ static void fwnode_pointer(struct kunit *kunittest)
@@ -13433,7 +13432,7 @@ index 2c9f6170bacd..bc54cca2d7a6 100644
  
  static void
 diff --git a/lib/vsprintf.c b/lib/vsprintf.c
-index 01699852f30c..d8a2ec083ace 100644
+index 01699852f..d8a2ec083 100644
 --- a/lib/vsprintf.c
 +++ b/lib/vsprintf.c
 @@ -1793,27 +1793,49 @@ char *fourcc_string(char *buf, char *end, const u32 *fourcc,
@@ -13506,7 +13505,7 @@ index 01699852f30c..d8a2ec083ace 100644
   *            a certain separator (' ' by default):
   *              C colon
 diff --git a/scripts/checkpatch.pl b/scripts/checkpatch.pl
-index 784912f570e9..86adc23c851a 100755
+index 784912f57..86adc23c8 100755
 --- a/scripts/checkpatch.pl
 +++ b/scripts/checkpatch.pl
 @@ -6905,7 +6905,7 @@ sub process {
@@ -13518,6 +13517,3 @@ index 784912f570e9..86adc23c851a 100755
  						$bad_specifier = $specifier;
  						last;
  					}
--- 
-2.50.1
-

--- a/6.15/all/0001-cachyos-base-all.patch
+++ b/6.15/all/0001-cachyos-base-all.patch
@@ -1,7 +1,7 @@
-From 9388ac844aa7a58ff39126c62a18b16f38535fa9 Mon Sep 17 00:00:00 2001
+From 2d2b5a7fc5d45efd8066f9560dedfd57da82b0dc Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:35 +0200
-Subject: [PATCH 1/6] amd-pstate
+Subject: [PATCH 1/7] amd-pstate
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -14,7 +14,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  6 files changed, 158 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index b961f3a3b580..12331e127d96 100644
+index b961f3a3b..12331e127 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -389,7 +389,8 @@ static inline int amd_pstate_cppc_enable(struct cpufreq_policy *policy)
@@ -247,7 +247,7 @@ index b961f3a3b580..12331e127d96 100644
  	.update_limits	= amd_pstate_update_limits,
  	.set_boost	= amd_pstate_set_boost,
 diff --git a/drivers/cpufreq/amd-pstate.h b/drivers/cpufreq/amd-pstate.h
-index fbe1c08d3f06..2f7ae364d331 100644
+index fbe1c08d3..2f7ae364d 100644
 --- a/drivers/cpufreq/amd-pstate.h
 +++ b/drivers/cpufreq/amd-pstate.h
 @@ -30,6 +30,7 @@
@@ -267,7 +267,7 @@ index fbe1c08d3f06..2f7ae364d331 100644
  	u64	val;
  };
 diff --git a/include/linux/sched/topology.h b/include/linux/sched/topology.h
-index 7b4301b7235f..198bb5cc1774 100644
+index 7b4301b72..198bb5cc1 100644
 --- a/include/linux/sched/topology.h
 +++ b/include/linux/sched/topology.h
 @@ -195,6 +195,8 @@ struct sched_domain_topology_level {
@@ -291,7 +291,7 @@ index 7b4301b7235f..198bb5cc1774 100644
  
  #if defined(CONFIG_ENERGY_MODEL) && defined(CONFIG_CPU_FREQ_GOV_SCHEDUTIL)
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 56ae54e0ce6a..557246880a7e 100644
+index 56ae54e0c..557246880 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -588,6 +588,10 @@ static void register_sd(struct sched_domain *sd, struct dentry *parent)
@@ -306,7 +306,7 @@ index 56ae54e0ce6a..557246880a7e 100644
  
  void update_sched_domain_debugfs(void)
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 138d9f4658d5..1a1caae2b2f7 100644
+index 23264fe11..9bf6931c8 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -10267,7 +10267,7 @@ sched_group_asym(struct lb_env *env, struct sg_lb_stats *sgs, struct sched_group
@@ -329,7 +329,7 @@ index 138d9f4658d5..1a1caae2b2f7 100644
  	case group_misfit_task:
  		/*
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
-index f1ebc60d967f..8426de317835 100644
+index f1ebc60d9..8426de317 100644
 --- a/kernel/sched/topology.c
 +++ b/kernel/sched/topology.c
 @@ -1333,6 +1333,64 @@ static void init_sched_groups_capacity(int cpu, struct sched_domain *sd)
@@ -397,47 +397,38 @@ index f1ebc60d967f..8426de317835 100644
  /*
   * Set of available CPUs grouped by their corresponding capacities
   * Each list entry contains a CPU mask reflecting CPUs that share the same
--- 
-2.50.1
-
-From 027f2f2ba77622cfdd2efe1cd8bb36d403fbaa2d Mon Sep 17 00:00:00 2001
+From dda5925222fd6d8f6236a3fb5d90b888c8dc3d67 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:48 +0200
-Subject: [PATCH 2/6] asus
+Subject: [PATCH 2/7] asus
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
  .../ABI/testing/sysfs-platform-asus-wmi       |   17 +
- drivers/hid/Kconfig                           |    2 +
- drivers/hid/Makefile                          |    2 +
- drivers/hid/asus-ally-hid/Kconfig             |    8 +
- drivers/hid/asus-ally-hid/Makefile            |    6 +
- .../hid/asus-ally-hid/asus-ally-hid-config.c  | 2347 +++++++++++++++++
- .../hid/asus-ally-hid/asus-ally-hid-core.c    |  600 +++++
- .../hid/asus-ally-hid/asus-ally-hid-input.c   |  345 +++
- drivers/hid/asus-ally-hid/asus-ally-rgb.c     |  356 +++
- drivers/hid/asus-ally-hid/asus-ally.h         |  314 +++
- drivers/hid/hid-asus.c                        |    9 +
- drivers/hid/hid-ids.h                         |    1 +
+ drivers/hid/Kconfig                           |   10 +
+ drivers/hid/Makefile                          |    1 +
+ drivers/hid/hid-asus-ally.c                   | 2197 +++++++++++++++++
+ drivers/hid/hid-asus-ally.h                   |  398 +++
+ drivers/hid/hid-asus.c                        |  415 +++-
+ drivers/hid/hid-asus.h                        |   13 +
+ drivers/hid/hid-ids.h                         |    3 +-
  drivers/platform/x86/Kconfig                  |   23 +
  drivers/platform/x86/Makefile                 |    1 +
- drivers/platform/x86/asus-armoury.c           | 1202 +++++++++
- drivers/platform/x86/asus-armoury.h           | 1278 +++++++++
- drivers/platform/x86/asus-wmi.c               |  359 ++-
- include/linux/platform_data/x86/asus-wmi.h    |   39 +
- 18 files changed, 6805 insertions(+), 104 deletions(-)
- create mode 100644 drivers/hid/asus-ally-hid/Kconfig
- create mode 100644 drivers/hid/asus-ally-hid/Makefile
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-hid-config.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-hid-core.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-hid-input.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally-rgb.c
- create mode 100644 drivers/hid/asus-ally-hid/asus-ally.h
+ drivers/platform/x86/asus-armoury.c           | 1174 +++++++++
+ drivers/platform/x86/asus-armoury.h           | 1278 ++++++++++
+ drivers/platform/x86/asus-nb-wmi.c            |   30 +-
+ drivers/platform/x86/asus-wmi.c               |  474 +++-
+ drivers/platform/x86/asus-wmi.h               |    3 +-
+ include/linux/platform_data/x86/asus-wmi.h    |   70 +
+ 16 files changed, 5892 insertions(+), 215 deletions(-)
+ create mode 100644 drivers/hid/hid-asus-ally.c
+ create mode 100644 drivers/hid/hid-asus-ally.h
+ create mode 100644 drivers/hid/hid-asus.h
  create mode 100644 drivers/platform/x86/asus-armoury.c
  create mode 100644 drivers/platform/x86/asus-armoury.h
 
 diff --git a/Documentation/ABI/testing/sysfs-platform-asus-wmi b/Documentation/ABI/testing/sysfs-platform-asus-wmi
-index 28144371a0f1..765d50b0d9df 100644
+index 28144371a..765d50b0d 100644
 --- a/Documentation/ABI/testing/sysfs-platform-asus-wmi
 +++ b/Documentation/ABI/testing/sysfs-platform-asus-wmi
 @@ -63,6 +63,7 @@ Date:		Aug 2022
@@ -577,63 +568,51 @@ index 28144371a0f1..765d50b0d9df 100644
  			* 0 - False,
  			* 1 - True
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 43859fc75747..aeb4eabf3007 100644
+index 43859fc75..5bc1f086b 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
-@@ -1425,6 +1425,8 @@ source "drivers/hid/intel-ish-hid/Kconfig"
+@@ -178,6 +178,7 @@ config HID_APPLETB_KBD
+ config HID_ASUS
+ 	tristate "Asus"
+ 	depends on USB_HID
++	depends on LEDS_CLASS_MULTICOLOR
+ 	depends on LEDS_CLASS
+ 	depends on ASUS_WMI || ASUS_WMI=n
+ 	select POWER_SUPPLY
+@@ -191,6 +192,15 @@ config HID_ASUS
+ 	- GL553V series
+ 	- GL753V series
  
- source "drivers/hid/amd-sfh-hid/Kconfig"
- 
-+source "drivers/hid/asus-ally-hid/Kconfig"
++config HID_ASUS_ALLY
++    tristate "Asus Ally gamepad configuration support"
++    depends on USB_HID
++    depends on LEDS_CLASS
++    depends on LEDS_CLASS_MULTICOLOR
++    select POWER_SUPPLY
++    help
++    Support for configuring the Asus ROG Ally gamepad using attributes.
 +
- source "drivers/hid/surface-hid/Kconfig"
- 
- source "drivers/hid/intel-thc-hid/Kconfig"
+ config HID_AUREAL
+ 	tristate "Aureal"
+ 	help
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 10ae5dedbd84..85af5331ebd2 100644
+index 10ae5dedb..958f67193 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
-@@ -172,6 +172,8 @@ obj-$(CONFIG_INTEL_ISH_HID)	+= intel-ish-hid/
- 
- obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
- 
-+obj-$(CONFIG_ASUS_ALLY_HID)  += asus-ally-hid/
-+
- obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
- 
- obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
-diff --git a/drivers/hid/asus-ally-hid/Kconfig b/drivers/hid/asus-ally-hid/Kconfig
+@@ -33,6 +33,7 @@ obj-$(CONFIG_HID_APPLETB_BL)	+= hid-appletb-bl.o
+ obj-$(CONFIG_HID_APPLETB_KBD)	+= hid-appletb-kbd.o
+ obj-$(CONFIG_HID_CREATIVE_SB0540)	+= hid-creative-sb0540.o
+ obj-$(CONFIG_HID_ASUS)		+= hid-asus.o
++obj-$(CONFIG_HID_ASUS_ALLY)	+= hid-asus-ally.o
+ obj-$(CONFIG_HID_AUREAL)	+= hid-aureal.o
+ obj-$(CONFIG_HID_BELKIN)	+= hid-belkin.o
+ obj-$(CONFIG_HID_BETOP_FF)	+= hid-betopff.o
+diff --git a/drivers/hid/hid-asus-ally.c b/drivers/hid/hid-asus-ally.c
 new file mode 100644
-index 000000000000..f83dda32be62
+index 000000000..e78625f70
 --- /dev/null
-+++ b/drivers/hid/asus-ally-hid/Kconfig
-@@ -0,0 +1,8 @@
-+config ASUS_ALLY_HID
-+	tristate "Asus Ally handheld support"
-+	depends on USB_HID
-+	depends on LEDS_CLASS
-+	depends on LEDS_CLASS_MULTICOLOR
-+	select POWER_SUPPLY
-+	help
-+	Support for configuring the Asus ROG Ally gamepad using attributes.
-diff --git a/drivers/hid/asus-ally-hid/Makefile b/drivers/hid/asus-ally-hid/Makefile
-new file mode 100644
-index 000000000000..5c3c304b7b53
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/Makefile
-@@ -0,0 +1,6 @@
-+# SPDX-License-Identifier: GPL-2.0+
-+#
-+# Makefile - ASUS ROG Ally handheld device driver
-+#
-+asus-ally-hid-y := asus-ally-hid-core.o asus-ally-rgb.o asus-ally-hid-input.o asus-ally-hid-config.o
-+obj-$(CONFIG_ASUS_ALLY_HID) := asus-ally-hid.o
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-hid-config.c b/drivers/hid/asus-ally-hid/asus-ally-hid-config.c
-new file mode 100644
-index 000000000000..1624880121c4
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-hid-config.c
-@@ -0,0 +1,2347 @@
++++ b/drivers/hid/hid-asus-ally.c
+@@ -0,0 +1,2197 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + *  HID driver for Asus ROG laptops and Ally
@@ -641,2370 +620,46 @@ index 000000000000..1624880121c4
 + *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
 + */
 +
-+#include <linux/device.h>
-+#include <linux/errno.h>
++#include "linux/compiler_attributes.h"
++#include "linux/device.h"
++#include <linux/platform_data/x86/asus-wmi.h>
++#include <linux/platform_device.h>
++#include "linux/pm.h"
++#include "linux/printk.h"
++#include "linux/slab.h"
 +#include <linux/hid.h>
-+#include <linux/module.h>
-+#include <linux/sysfs.h>
 +#include <linux/types.h>
-+
-+#include "asus-ally.h"
-+#include "../hid-ids.h"
-+
-+enum btn_map_type {
-+	BTN_TYPE_NONE = 0,
-+	BTN_TYPE_PAD = 0x01,
-+	BTN_TYPE_KB = 0x02,
-+	BTN_TYPE_MOUSE = 0x03,
-+	BTN_TYPE_MEDIA = 0x05,
-+};
-+
-+struct btn_code_map {
-+	unsigned char type;
-+	unsigned char value;
-+	const char *name;
-+};
-+
-+static const struct btn_code_map ally_btn_codes[] = {
-+	{ BTN_TYPE_NONE, 0x00, "NONE" },
-+	/* Gamepad button codes */
-+	{ BTN_TYPE_PAD, 0x01, "PAD_A" },
-+	{ BTN_TYPE_PAD, 0x02, "PAD_B" },
-+	{ BTN_TYPE_PAD, 0x03, "PAD_X" },
-+	{ BTN_TYPE_PAD, 0x04, "PAD_Y" },
-+	{ BTN_TYPE_PAD, 0x05, "PAD_LB" },
-+	{ BTN_TYPE_PAD, 0x06, "PAD_RB" },
-+	{ BTN_TYPE_PAD, 0x07, "PAD_LS" },
-+	{ BTN_TYPE_PAD, 0x08, "PAD_RS" },
-+	{ BTN_TYPE_PAD, 0x09, "PAD_DPAD_UP" },
-+	{ BTN_TYPE_PAD, 0x0A, "PAD_DPAD_DOWN" },
-+	{ BTN_TYPE_PAD, 0x0B, "PAD_DPAD_LEFT" },
-+	{ BTN_TYPE_PAD, 0x0C, "PAD_DPAD_RIGHT" },
-+	{ BTN_TYPE_PAD, 0x0D, "PAD_LT" },
-+	{ BTN_TYPE_PAD, 0x0E, "PAD_RT" },
-+	{ BTN_TYPE_PAD, 0x11, "PAD_VIEW" },
-+	{ BTN_TYPE_PAD, 0x12, "PAD_MENU" },
-+	{ BTN_TYPE_PAD, 0x13, "PAD_XBOX" },
-+
-+	/* Keyboard button codes */
-+	{ BTN_TYPE_KB, 0x8E, "KB_M2" },
-+	{ BTN_TYPE_KB, 0x8F, "KB_M1" },
-+	{ BTN_TYPE_KB, 0x76, "KB_ESC" },
-+	{ BTN_TYPE_KB, 0x50, "KB_F1" },
-+	{ BTN_TYPE_KB, 0x60, "KB_F2" },
-+	{ BTN_TYPE_KB, 0x40, "KB_F3" },
-+	{ BTN_TYPE_KB, 0x0C, "KB_F4" },
-+	{ BTN_TYPE_KB, 0x03, "KB_F5" },
-+	{ BTN_TYPE_KB, 0x0B, "KB_F6" },
-+	{ BTN_TYPE_KB, 0x80, "KB_F7" },
-+	{ BTN_TYPE_KB, 0x0A, "KB_F8" },
-+	{ BTN_TYPE_KB, 0x01, "KB_F9" },
-+	{ BTN_TYPE_KB, 0x09, "KB_F10" },
-+	{ BTN_TYPE_KB, 0x78, "KB_F11" },
-+	{ BTN_TYPE_KB, 0x07, "KB_F12" },
-+	{ BTN_TYPE_KB, 0x18, "KB_F14" },
-+	{ BTN_TYPE_KB, 0x10, "KB_F15" },
-+	{ BTN_TYPE_KB, 0x0E, "KB_BACKTICK" },
-+	{ BTN_TYPE_KB, 0x16, "KB_1" },
-+	{ BTN_TYPE_KB, 0x1E, "KB_2" },
-+	{ BTN_TYPE_KB, 0x26, "KB_3" },
-+	{ BTN_TYPE_KB, 0x25, "KB_4" },
-+	{ BTN_TYPE_KB, 0x2E, "KB_5" },
-+	{ BTN_TYPE_KB, 0x36, "KB_6" },
-+	{ BTN_TYPE_KB, 0x3D, "KB_7" },
-+	{ BTN_TYPE_KB, 0x3E, "KB_8" },
-+	{ BTN_TYPE_KB, 0x46, "KB_9" },
-+	{ BTN_TYPE_KB, 0x45, "KB_0" },
-+	{ BTN_TYPE_KB, 0x4E, "KB_HYPHEN" },
-+	{ BTN_TYPE_KB, 0x55, "KB_EQUALS" },
-+	{ BTN_TYPE_KB, 0x66, "KB_BACKSPACE" },
-+	{ BTN_TYPE_KB, 0x0D, "KB_TAB" },
-+	{ BTN_TYPE_KB, 0x15, "KB_Q" },
-+	{ BTN_TYPE_KB, 0x1D, "KB_W" },
-+	{ BTN_TYPE_KB, 0x24, "KB_E" },
-+	{ BTN_TYPE_KB, 0x2D, "KB_R" },
-+	{ BTN_TYPE_KB, 0x2C, "KB_T" },
-+	{ BTN_TYPE_KB, 0x35, "KB_Y" },
-+	{ BTN_TYPE_KB, 0x3C, "KB_U" },
-+	{ BTN_TYPE_KB, 0x44, "KB_O" },
-+	{ BTN_TYPE_KB, 0x4D, "KB_P" },
-+	{ BTN_TYPE_KB, 0x54, "KB_LBRACKET" },
-+	{ BTN_TYPE_KB, 0x5B, "KB_RBRACKET" },
-+	{ BTN_TYPE_KB, 0x5D, "KB_BACKSLASH" },
-+	{ BTN_TYPE_KB, 0x58, "KB_CAPS" },
-+	{ BTN_TYPE_KB, 0x1C, "KB_A" },
-+	{ BTN_TYPE_KB, 0x1B, "KB_S" },
-+	{ BTN_TYPE_KB, 0x23, "KB_D" },
-+	{ BTN_TYPE_KB, 0x2B, "KB_F" },
-+	{ BTN_TYPE_KB, 0x34, "KB_G" },
-+	{ BTN_TYPE_KB, 0x33, "KB_H" },
-+	{ BTN_TYPE_KB, 0x3B, "KB_J" },
-+	{ BTN_TYPE_KB, 0x42, "KB_K" },
-+	{ BTN_TYPE_KB, 0x4B, "KB_L" },
-+	{ BTN_TYPE_KB, 0x4C, "KB_SEMI" },
-+	{ BTN_TYPE_KB, 0x52, "KB_QUOTE" },
-+	{ BTN_TYPE_KB, 0x5A, "KB_RET" },
-+	{ BTN_TYPE_KB, 0x88, "KB_LSHIFT" },
-+	{ BTN_TYPE_KB, 0x1A, "KB_Z" },
-+	{ BTN_TYPE_KB, 0x22, "KB_X" },
-+	{ BTN_TYPE_KB, 0x21, "KB_C" },
-+	{ BTN_TYPE_KB, 0x2A, "KB_V" },
-+	{ BTN_TYPE_KB, 0x32, "KB_B" },
-+	{ BTN_TYPE_KB, 0x31, "KB_N" },
-+	{ BTN_TYPE_KB, 0x3A, "KB_M" },
-+	{ BTN_TYPE_KB, 0x41, "KB_COMMA" },
-+	{ BTN_TYPE_KB, 0x49, "KB_PERIOD" },
-+	{ BTN_TYPE_KB, 0x89, "KB_RSHIFT" },
-+	{ BTN_TYPE_KB, 0x8C, "KB_LCTL" },
-+	{ BTN_TYPE_KB, 0x82, "KB_META" },
-+	{ BTN_TYPE_KB, 0x8A, "KB_LALT" },
-+	{ BTN_TYPE_KB, 0x29, "KB_SPACE" },
-+	{ BTN_TYPE_KB, 0x8B, "KB_RALT" },
-+	{ BTN_TYPE_KB, 0x84, "KB_MENU" },
-+	{ BTN_TYPE_KB, 0x8D, "KB_RCTL" },
-+	{ BTN_TYPE_KB, 0xC3, "KB_PRNTSCN" },
-+	{ BTN_TYPE_KB, 0x7E, "KB_SCRLCK" },
-+	{ BTN_TYPE_KB, 0x91, "KB_PAUSE" },
-+	{ BTN_TYPE_KB, 0xC2, "KB_INS" },
-+	{ BTN_TYPE_KB, 0x94, "KB_HOME" },
-+	{ BTN_TYPE_KB, 0x96, "KB_PGUP" },
-+	{ BTN_TYPE_KB, 0xC0, "KB_DEL" },
-+	{ BTN_TYPE_KB, 0x95, "KB_END" },
-+	{ BTN_TYPE_KB, 0x97, "KB_PGDWN" },
-+	{ BTN_TYPE_KB, 0x98, "KB_UP_ARROW" },
-+	{ BTN_TYPE_KB, 0x99, "KB_DOWN_ARROW" },
-+	{ BTN_TYPE_KB, 0x91, "KB_LEFT_ARROW" },
-+	{ BTN_TYPE_KB, 0x9B, "KB_RIGHT_ARROW" },
-+
-+	/* Numpad button codes */
-+	{ BTN_TYPE_KB, 0x77, "NUMPAD_LOCK" },
-+	{ BTN_TYPE_KB, 0x90, "NUMPAD_FWDSLASH" },
-+	{ BTN_TYPE_KB, 0x7C, "NUMPAD_ASTERISK" },
-+	{ BTN_TYPE_KB, 0x7B, "NUMPAD_HYPHEN" },
-+	{ BTN_TYPE_KB, 0x70, "NUMPAD_0" },
-+	{ BTN_TYPE_KB, 0x69, "NUMPAD_1" },
-+	{ BTN_TYPE_KB, 0x72, "NUMPAD_2" },
-+	{ BTN_TYPE_KB, 0x7A, "NUMPAD_3" },
-+	{ BTN_TYPE_KB, 0x6B, "NUMPAD_4" },
-+	{ BTN_TYPE_KB, 0x73, "NUMPAD_5" },
-+	{ BTN_TYPE_KB, 0x74, "NUMPAD_6" },
-+	{ BTN_TYPE_KB, 0x6C, "NUMPAD_7" },
-+	{ BTN_TYPE_KB, 0x75, "NUMPAD_8" },
-+	{ BTN_TYPE_KB, 0x7D, "NUMPAD_9" },
-+	{ BTN_TYPE_KB, 0x79, "NUMPAD_PLUS" },
-+	{ BTN_TYPE_KB, 0x81, "NUMPAD_ENTER" },
-+	{ BTN_TYPE_KB, 0x71, "NUMPAD_PERIOD" },
-+
-+	/* Mouse button codes */
-+	{ BTN_TYPE_MOUSE, 0x01, "MOUSE_LCLICK" },
-+	{ BTN_TYPE_MOUSE, 0x02, "MOUSE_RCLICK" },
-+	{ BTN_TYPE_MOUSE, 0x03, "MOUSE_MCLICK" },
-+	{ BTN_TYPE_MOUSE, 0x04, "MOUSE_WHEEL_UP" },
-+	{ BTN_TYPE_MOUSE, 0x05, "MOUSE_WHEEL_DOWN" },
-+
-+	/* Media button codes */
-+	{ BTN_TYPE_MEDIA, 0x16, "MEDIA_SCREENSHOT" },
-+	{ BTN_TYPE_MEDIA, 0x19, "MEDIA_SHOW_KEYBOARD" },
-+	{ BTN_TYPE_MEDIA, 0x1C, "MEDIA_SHOW_DESKTOP" },
-+	{ BTN_TYPE_MEDIA, 0x1E, "MEDIA_START_RECORDING" },
-+	{ BTN_TYPE_MEDIA, 0x01, "MEDIA_MIC_OFF" },
-+	{ BTN_TYPE_MEDIA, 0x02, "MEDIA_VOL_DOWN" },
-+	{ BTN_TYPE_MEDIA, 0x03, "MEDIA_VOL_UP" },
-+};
-+
-+static const size_t keymap_len = ARRAY_SIZE(ally_btn_codes);
-+
-+/* Button pair indexes for mapping commands */
-+enum btn_pair_index {
-+	BTN_PAIR_DPAD_UPDOWN    = 0x01,
-+	BTN_PAIR_DPAD_LEFTRIGHT = 0x02,
-+	BTN_PAIR_STICK_LR       = 0x03,
-+	BTN_PAIR_BUMPER_LR      = 0x04,
-+	BTN_PAIR_AB             = 0x05,
-+	BTN_PAIR_XY             = 0x06,
-+	BTN_PAIR_VIEW_MENU      = 0x07,
-+	BTN_PAIR_M1M2           = 0x08,
-+	BTN_PAIR_TRIGGER_LR     = 0x09,
-+};
-+
-+struct button_map {
-+	struct btn_code_map *remap;
-+	struct btn_code_map *macro;
-+};
-+
-+struct button_pair_map {
-+	enum btn_pair_index pair_index;
-+	struct button_map first;
-+	struct button_map second;
-+};
-+
-+/* Store button mapping per gamepad mode */
-+struct ally_button_mapping {
-+	struct button_pair_map button_pairs[9]; /* 9 button pairs */
-+};
-+
-+/* Find a button code map by its name */
-+static const struct btn_code_map *find_button_by_name(const char *name)
-+{
-+	int i;
-+
-+	for (i = 0; i < keymap_len; i++) {
-+		if (strcmp(ally_btn_codes[i].name, name) == 0)
-+			return &ally_btn_codes[i];
-+	}
-+
-+	return NULL;
-+}
-+
-+/* Set button mapping for a button pair */
-+static int ally_set_button_mapping(struct hid_device *hdev, struct ally_handheld *ally,
-+				  struct button_pair_map *mapping)
-+{
-+	unsigned char packet[64] = { 0 };
-+
-+	if (!mapping)
-+		return -EINVAL;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = CMD_SET_MAPPING;
-+	packet[3] = mapping->pair_index;
-+	packet[4] = 0x2C; /* Length */
-+
-+	/* First button mapping */
-+	packet[5] = mapping->first.remap->type;
-+	/* Fill in bytes 6-14 with button code */
-+	if (mapping->first.remap->type) {
-+		unsigned char btn_bytes[10] = {0};
-+		btn_bytes[0] = mapping->first.remap->type;
-+
-+		switch (mapping->first.remap->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			btn_bytes[2] = mapping->first.remap->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			btn_bytes[4] = mapping->first.remap->value;
-+			break;
-+		}
-+		memcpy(&packet[5], btn_bytes, 10);
-+	}
-+
-+	/* Macro mapping for first button if any */
-+	packet[15] = mapping->first.macro->type;
-+	if (mapping->first.macro->type) {
-+		unsigned char macro_bytes[11] = {0};
-+		macro_bytes[0] = mapping->first.macro->type;
-+
-+		switch (mapping->first.macro->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			macro_bytes[2] = mapping->first.macro->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			macro_bytes[4] = mapping->first.macro->value;
-+			break;
-+		}
-+		memcpy(&packet[15], macro_bytes, 11);
-+	}
-+
-+	/* Second button mapping */
-+	packet[27] = mapping->second.remap->type;
-+	/* Fill in bytes 28-36 with button code */
-+	if (mapping->second.remap->type) {
-+		unsigned char btn_bytes[10] = {0};
-+		btn_bytes[0] = mapping->second.remap->type;
-+
-+		switch (mapping->second.remap->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			btn_bytes[2] = mapping->second.remap->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			btn_bytes[4] = mapping->second.remap->value;
-+			break;
-+		}
-+		memcpy(&packet[27], btn_bytes, 10);
-+	}
-+
-+	/* Macro mapping for second button if any */
-+	packet[37] = mapping->second.macro->type;
-+	if (mapping->second.macro->type) {
-+		unsigned char macro_bytes[11] = {0};
-+		macro_bytes[0] = mapping->second.macro->type;
-+
-+		switch (mapping->second.macro->type) {
-+		case BTN_TYPE_NONE:
-+			break;
-+		case BTN_TYPE_PAD:
-+		case BTN_TYPE_KB:
-+		case BTN_TYPE_MEDIA:
-+			macro_bytes[2] = mapping->second.macro->value;
-+			break;
-+		case BTN_TYPE_MOUSE:
-+			macro_bytes[4] = mapping->second.macro->value;
-+			break;
-+		}
-+		memcpy(&packet[37], macro_bytes, 11);
-+	}
-+
-+	return ally_gamepad_send_packet(ally, hdev, packet, sizeof(packet));
-+}
-+
-+/**
-+ * ally_check_capability - Check if a specific capability is supported
-+ * @hdev: HID device
-+ * @flag_code: Capability flag code to check
-+ *
-+ * Returns true if capability is supported, false otherwise
-+ */
-+static bool ally_check_capability(struct hid_device *hdev, u8 flag_code)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	bool result = false;
-+	u8 *hidbuf;
-+	int ret;
-+
-+	hidbuf = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
-+	if (!hidbuf)
-+		return false;
-+
-+	hidbuf[0] = HID_ALLY_SET_REPORT_ID;
-+	hidbuf[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	hidbuf[2] = flag_code;
-+	hidbuf[3] = 0x01;
-+
-+	ret = ally_gamepad_send_receive_packet(ally, hdev, hidbuf, HID_ALLY_REPORT_SIZE);
-+	if (ret < 0)
-+		goto cleanup;
-+
-+	if (hidbuf[1] == HID_ALLY_FEATURE_CODE_PAGE && hidbuf[2] == flag_code)
-+		result = (hidbuf[4] == 0x01);
-+
-+cleanup:
-+	kfree(hidbuf);
-+	return result;
-+}
-+
-+static int ally_detect_capabilities(struct hid_device *hdev,
-+				    struct ally_config *cfg)
-+{
-+	if (!hdev || !cfg)
-+		return -EINVAL;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->is_ally_x =
-+		(hdev->product == USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X);
-+
-+	cfg->xbox_controller_support =
-+		ally_check_capability(hdev, CMD_CHECK_XBOX_SUPPORT);
-+	cfg->user_cal_support =
-+		ally_check_capability(hdev, CMD_CHECK_USER_CAL_SUPPORT);
-+	cfg->turbo_support =
-+		ally_check_capability(hdev, CMD_CHECK_TURBO_SUPPORT);
-+	cfg->resp_curve_support =
-+		ally_check_capability(hdev, CMD_CHECK_RESP_CURVE_SUPPORT);
-+	cfg->dir_to_btn_support =
-+		ally_check_capability(hdev, CMD_CHECK_DIR_TO_BTN_SUPPORT);
-+	cfg->gyro_support =
-+		ally_check_capability(hdev, CMD_CHECK_GYRO_TO_JOYSTICK);
-+	cfg->anti_deadzone_support =
-+		ally_check_capability(hdev, CMD_CHECK_ANTI_DEADZONE);
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	hid_dbg(
-+		hdev,
-+		"Ally capabilities: %s, Xbox: %d, UserCal: %d, Turbo: %d, RespCurve: %d, DirToBtn: %d, Gyro: %d, AntiDZ: %d",
-+		cfg->is_ally_x ? "Ally X" : "Ally",
-+		cfg->xbox_controller_support, cfg->user_cal_support,
-+		cfg->turbo_support, cfg->resp_curve_support,
-+		cfg->dir_to_btn_support, cfg->gyro_support,
-+		cfg->anti_deadzone_support);
-+
-+	return 0;
-+}
-+
-+static int ally_set_xbox_controller(struct hid_device *hdev,
-+				    struct ally_config *cfg, bool enabled)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	u8 buffer[64] = { 0 };
-+	int ret;
-+
-+	if (!cfg || !cfg->xbox_controller_support)
-+		return -ENODEV;
-+
-+	buffer[0] = HID_ALLY_SET_REPORT_ID;
-+	buffer[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	buffer[2] = CMD_SET_XBOX_CONTROLLER;
-+	buffer[3] = 0x01;
-+	buffer[4] = enabled ? 0x01 : 0x00;
-+
-+	ret = ally_gamepad_send_one_byte_packet(
-+		ally, hdev, CMD_SET_XBOX_CONTROLLER,
-+		enabled ? 0x01 : 0x00);
-+	if (ret < 0) return ret;
-+
-+	cfg->xbox_controller_enabled = enabled;
-+	return 0;
-+}
-+
-+static ssize_t xbox_controller_show(struct device *dev,
-+				    struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	if (!cfg->xbox_controller_support)
-+		return sprintf(buf, "Unsupported\n");
-+
-+	return sprintf(buf, "%d\n", cfg->xbox_controller_enabled);
-+}
-+
-+static ssize_t xbox_controller_store(struct device *dev,
-+				     struct device_attribute *attr,
-+				     const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+	bool enabled;
-+	int ret;
-+
-+	cfg = ally->config;
-+	if (!cfg->xbox_controller_support)
-+		return -ENODEV;
-+
-+	ret = kstrtobool(buf, &enabled);
-+	if (ret)
-+		return ret;
-+
-+	ret = ally_set_xbox_controller(hdev, cfg, enabled);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static DEVICE_ATTR_RW(xbox_controller);
-+
-+/**
-+ * ally_set_vibration_intensity - Set vibration intensity values
-+ * @hdev: HID device
-+ * @cfg: Ally config
-+ * @left: Left motor intensity (0-100)
-+ * @right: Right motor intensity (0-100)
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+static int ally_set_vibration_intensity(struct hid_device *hdev,
-+					struct ally_config *cfg, u8 left,
-+					u8 right)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	u8 buffer[64] = { 0 };
-+	int ret;
-+
-+	if (!cfg)
-+		return -ENODEV;
-+
-+	buffer[0] = HID_ALLY_SET_REPORT_ID;
-+	buffer[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	buffer[2] = CMD_SET_VIBRATION_INTENSITY;
-+	buffer[3] = 0x02; /* Length */
-+	buffer[4] = left;
-+	buffer[5] = right;
-+
-+	ret = ally_gamepad_send_two_byte_packet(
-+		ally, hdev, CMD_SET_VIBRATION_INTENSITY, left, right);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->vibration_intensity_left = left;
-+	cfg->vibration_intensity_right = right;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return 0;
-+}
-+
-+static ssize_t vibration_intensity_show(struct device *dev,
-+					struct device_attribute *attr,
-+					char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	return sprintf(buf, "%u,%u\n", cfg->vibration_intensity_left,
-+		       cfg->vibration_intensity_right);
-+}
-+
-+static ssize_t vibration_intensity_store(struct device *dev,
-+					 struct device_attribute *attr,
-+					 const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+	u8 left, right;
-+	int ret;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	ret = sscanf(buf, "%hhu %hhu", &left, &right);
-+	if (ret != 2 || left > 100 || right > 100)
-+		return -EINVAL;
-+
-+	ret = ally_set_vibration_intensity(hdev, cfg, left, right);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static DEVICE_ATTR_RW(vibration_intensity);
-+
-+/**
-+ * ally_set_dzot_ranges - Generic function to set joystick or trigger ranges
-+ * @hdev: HID device
-+ * @cfg: Ally config struct
-+ * @command: Command to use (CMD_SET_JOYSTICK_DEADZONE or CMD_SET_TRIGGER_RANGE)
-+ * @param1: First parameter
-+ * @param2: Second parameter
-+ * @param3: Third parameter
-+ * @param4: Fourth parameter
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+static int ally_set_dzot_ranges(struct hid_device *hdev,
-+					       struct ally_config *cfg,
-+					       u8 command, u8 param1, u8 param2,
-+					       u8 param3, u8 param4)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	u8 packet[HID_ALLY_REPORT_SIZE] = { 0 };
-+	int ret;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = command;
-+	packet[3] = 0x04; /* Length */
-+	packet[4] = param1;
-+	packet[5] = param2;
-+	packet[6] = param3;
-+	packet[7] = param4;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	return ret;
-+}
-+
-+static int ally_validate_joystick_dzot(u8 left_dz, u8 left_ot, u8 right_dz,
-+				       u8 right_ot)
-+{
-+	if (left_dz > 50 || right_dz > 50)
-+		return -EINVAL;
-+
-+	if (left_ot < 70 || left_ot > 100 || right_ot < 70 || right_ot > 100)
-+		return -EINVAL;
-+
-+	return 0;
-+}
-+
-+static int ally_set_joystick_dzot(struct hid_device *hdev,
-+				  struct ally_config *cfg, u8 left_dz,
-+				  u8 left_ot, u8 right_dz, u8 right_ot)
-+{
-+	int ret;
-+
-+	ret = ally_validate_joystick_dzot(left_dz, left_ot, right_dz, right_ot);
-+	if (ret < 0)
-+		return ret;
-+
-+	ret = ally_set_dzot_ranges(hdev, cfg,
-+				  CMD_SET_JOYSTICK_DEADZONE,
-+				  left_dz, left_ot, right_dz,
-+				  right_ot);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->left_deadzone = left_dz;
-+	cfg->left_outer_threshold = left_ot;
-+	cfg->right_deadzone = right_dz;
-+	cfg->right_outer_threshold = right_ot;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return 0;
-+}
-+
-+static ssize_t joystick_deadzone_show(struct device *dev,
-+				      struct device_attribute *attr, char *buf,
-+				      u8 deadzone, u8 outer_threshold)
-+{
-+	return sprintf(buf, "%u %u\n", deadzone, outer_threshold);
-+}
-+
-+static ssize_t joystick_deadzone_store(struct device *dev,
-+				       struct device_attribute *attr,
-+				       const char *buf, size_t count,
-+				       bool is_left, struct ally_config *cfg)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	u8 dz, ot;
-+	int ret;
-+
-+	ret = sscanf(buf, "%hhu %hhu", &dz, &ot);
-+	if (ret != 2)
-+		return -EINVAL;
-+
-+	if (is_left) {
-+		ret = ally_set_joystick_dzot(hdev, cfg, dz, ot,
-+					     cfg->right_deadzone,
-+					     cfg->right_outer_threshold);
-+	} else {
-+		ret = ally_set_joystick_dzot(hdev, cfg, cfg->left_deadzone,
-+					     cfg->left_outer_threshold, dz, ot);
-+	}
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t joystick_left_deadzone_show(struct device *dev,
-+					   struct device_attribute *attr,
-+					   char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return joystick_deadzone_show(dev, attr, buf, cfg->left_deadzone,
-+				      cfg->left_outer_threshold);
-+}
-+
-+static ssize_t joystick_left_deadzone_store(struct device *dev,
-+					    struct device_attribute *attr,
-+					    const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return joystick_deadzone_store(dev, attr, buf, count, true,
-+				       ally->config);
-+}
-+
-+static ssize_t joystick_right_deadzone_show(struct device *dev,
-+					    struct device_attribute *attr,
-+					    char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return joystick_deadzone_show(dev, attr, buf, cfg->right_deadzone,
-+				      cfg->right_outer_threshold);
-+}
-+
-+static ssize_t joystick_right_deadzone_store(struct device *dev,
-+					     struct device_attribute *attr,
-+					     const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return joystick_deadzone_store(dev, attr, buf, count, false,
-+				       ally->config);
-+}
-+
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_index, deadzone_index, "inner outer\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_inner_min, deadzone_inner_min, "0\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_inner_max, deadzone_inner_max, "50\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_outer_min, deadzone_outer_min, "70\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_deadzone_outer_max, deadzone_outer_max, "100\n");
-+
-+ALLY_DEVICE_ATTR_RW(joystick_left_deadzone, deadzone);
-+ALLY_DEVICE_ATTR_RW(joystick_right_deadzone, deadzone);
-+
-+/**
-+ * ally_set_anti_deadzone - Set anti-deadzone values for joysticks
-+ * @ally: ally handheld structure
-+ * @left_adz: Left joystick anti-deadzone value (0-100)
-+ * @right_adz: Right joystick anti-deadzone value (0-100)
-+ *
-+ * Return: 0 on success, negative on failure
-+ */
-+static int ally_set_anti_deadzone(struct ally_handheld *ally, u8 left_adz,
-+				  u8 right_adz)
-+{
-+	struct hid_device *hdev = ally->cfg_hdev;
-+	int ret;
-+
-+	if (!ally->config->anti_deadzone_support) {
-+		hid_dbg(hdev, "Anti-deadzone not supported on this device\n");
-+		return -EOPNOTSUPP;
-+	}
-+
-+	if (left_adz > 100 || right_adz > 100)
-+		return -EINVAL;
-+
-+	ret = ally_gamepad_send_two_byte_packet(
-+		ally, hdev, CMD_SET_ANTI_DEADZONE, left_adz, right_adz);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set anti-deadzone values: %d\n", ret);
-+		return ret;
-+	}
-+
-+	ally->config->left_anti_deadzone = left_adz;
-+	ally->config->right_anti_deadzone = right_adz;
-+	hid_dbg(hdev, "Set joystick anti-deadzone: left=%d, right=%d\n",
-+		left_adz, right_adz);
-+
-+	return 0;
-+}
-+
-+static ssize_t anti_deadzone_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf,
-+				 u8 anti_deadzone)
-+{
-+	return sprintf(buf, "%u\n", anti_deadzone);
-+}
-+
-+static ssize_t anti_deadzone_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count, bool is_left,
-+				  struct ally_handheld *ally)
-+{
-+	u8 adz;
-+	int ret;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	if (!ally->config->anti_deadzone_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtou8(buf, 10, &adz);
-+	if (ret)
-+		return ret;
-+
-+	if (adz > 100)
-+		return -EINVAL;
-+
-+	if (is_left)
-+		ret = ally_set_anti_deadzone(ally, adz, ally->config->right_anti_deadzone);
-+	else
-+		ret = ally_set_anti_deadzone(ally, ally->config->left_anti_deadzone, adz);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t js_left_anti_deadzone_show(struct device *dev,
-+						struct device_attribute *attr,
-+						char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	return anti_deadzone_show(dev, attr, buf,
-+				  ally->config->left_anti_deadzone);
-+}
-+
-+static ssize_t js_left_anti_deadzone_store(struct device *dev,
-+						 struct device_attribute *attr,
-+						 const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return anti_deadzone_store(dev, attr, buf, count, true, ally);
-+}
-+
-+static ssize_t js_right_anti_deadzone_show(struct device *dev,
-+						 struct device_attribute *attr,
-+						 char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	return anti_deadzone_show(dev, attr, buf,
-+				  ally->config->right_anti_deadzone);
-+}
-+
-+static ssize_t js_right_anti_deadzone_store(struct device *dev,
-+						  struct device_attribute *attr,
-+						  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return anti_deadzone_store(dev, attr, buf, count, false, ally);
-+}
-+
-+ALLY_DEVICE_ATTR_RW(js_left_anti_deadzone, anti_deadzone);
-+ALLY_DEVICE_ATTR_RW(js_right_anti_deadzone, anti_deadzone);
-+ALLY_DEVICE_CONST_ATTR_RO(js_anti_deadzone_min, js_anti_deadzone_min, "0\n");
-+ALLY_DEVICE_CONST_ATTR_RO(js_anti_deadzone_max, js_anti_deadzone_max, "100\n");
-+
-+/**
-+ * ally_set_joystick_resp_curve - Set joystick response curve parameters
-+ * @ally: ally handheld structure
-+ * @hdev: HID device
-+ * @side: Which joystick side (0=left, 1=right)
-+ * @curve: Response curve parameter structure
-+ *
-+ * Return: 0 on success, negative on failure
-+ */
-+static int ally_set_joystick_resp_curve(struct ally_handheld *ally,
-+					struct hid_device *hdev, u8 side,
-+					struct joystick_resp_curve *curve)
-+{
-+	u8 packet[HID_ALLY_REPORT_SIZE] = { 0 };
-+	int ret;
-+	struct ally_config *cfg = ally->config;
-+
-+	if (!cfg || !cfg->resp_curve_support) {
-+		hid_dbg(hdev, "Response curve not supported on this device\n");
-+		return -EOPNOTSUPP;
-+	}
-+
-+	if (side > 1) {
-+		return -EINVAL;
-+	}
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = CMD_SET_RESP_CURVE;
-+	packet[3] = 0x09; /* Length */
-+	packet[4] = side;
-+
-+	packet[5] = curve->entry_1.move;
-+	packet[6] = curve->entry_1.resp;
-+	packet[7] = curve->entry_2.move;
-+	packet[8] = curve->entry_2.resp;
-+	packet[9] = curve->entry_3.move;
-+	packet[10] = curve->entry_3.resp;
-+	packet[11] = curve->entry_4.move;
-+	packet[12] = curve->entry_4.resp;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set joystick response curve: %d\n",
-+			ret);
-+		return ret;
-+	}
-+
-+	mutex_lock(&cfg->config_mutex);
-+	if (side == 0) {
-+		memcpy(&cfg->left_curve, curve, sizeof(*curve));
-+	} else {
-+		memcpy(&cfg->right_curve, curve, sizeof(*curve));
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	hid_dbg(hdev, "Set joystick response curve for side %d\n", side);
-+	return 0;
-+}
-+
-+static int response_curve_apply(struct hid_device *hdev, struct ally_handheld *ally, bool is_left)
-+{
-+	struct ally_config *cfg = ally->config;
-+	struct joystick_resp_curve *curve = is_left ? &cfg->left_curve : &cfg->right_curve;
-+
-+	if (!(curve->entry_1.move < curve->entry_2.move &&
-+	      curve->entry_2.move < curve->entry_3.move &&
-+	      curve->entry_3.move < curve->entry_4.move)) {
-+		return -EINVAL;
-+	}
-+
-+	return ally_set_joystick_resp_curve(ally, hdev, is_left ? 0 : 1, curve);
-+}
-+
-+static ssize_t response_curve_apply_left_store(struct device *dev,
-+					      struct device_attribute *attr,
-+					      const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	int ret;
-+	bool apply;
-+
-+	if (!ally->config->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtobool(buf, &apply);
-+	if (ret)
-+		return ret;
-+
-+	if (!apply)
-+		return count;  /* Only apply on "1" or "true" value */
-+
-+	ret = response_curve_apply(hdev, ally, true);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t response_curve_apply_right_store(struct device *dev,
-+					       struct device_attribute *attr,
-+					       const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	int ret;
-+	bool apply;
-+
-+	if (!ally->config->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtobool(buf, &apply);
-+	if (ret)
-+		return ret;
-+
-+	if (!apply)
-+		return count;  /* Only apply on "1" or "true" value */
-+
-+	ret = response_curve_apply(hdev, ally, false);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t response_curve_pct_show(struct device *dev,
-+				      struct device_attribute *attr, char *buf,
-+				      struct joystick_resp_curve *curve, int idx)
-+{
-+	switch (idx) {
-+	case 1: return sprintf(buf, "%u\n", curve->entry_1.resp);
-+	case 2: return sprintf(buf, "%u\n", curve->entry_2.resp);
-+	case 3: return sprintf(buf, "%u\n", curve->entry_3.resp);
-+	case 4: return sprintf(buf, "%u\n", curve->entry_4.resp);
-+	default: return -EINVAL;
-+	}
-+}
-+
-+static ssize_t response_curve_move_show(struct device *dev,
-+				      struct device_attribute *attr, char *buf,
-+				      struct joystick_resp_curve *curve, int idx)
-+{
-+	switch (idx) {
-+	case 1: return sprintf(buf, "%u\n", curve->entry_1.move);
-+	case 2: return sprintf(buf, "%u\n", curve->entry_2.move);
-+	case 3: return sprintf(buf, "%u\n", curve->entry_3.move);
-+	case 4: return sprintf(buf, "%u\n", curve->entry_4.move);
-+	default: return -EINVAL;
-+	}
-+}
-+
-+static ssize_t response_curve_pct_store(struct device *dev,
-+				       struct device_attribute *attr,
-+				       const char *buf, size_t count,
-+				       bool is_left, struct ally_handheld *ally,
-+				       int idx)
-+{
-+	struct ally_config *cfg = ally->config;
-+	struct joystick_resp_curve *curve = is_left ? &cfg->left_curve : &cfg->right_curve;
-+	u8 value;
-+	int ret;
-+
-+	if (!cfg->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtou8(buf, 10, &value);
-+	if (ret)
-+		return ret;
-+
-+	if (value > 100)
-+		return -EINVAL;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	switch (idx) {
-+	case 1: curve->entry_1.resp = value; break;
-+	case 2: curve->entry_2.resp = value; break;
-+	case 3: curve->entry_3.resp = value; break;
-+	case 4: curve->entry_4.resp = value; break;
-+	default: ret = -EINVAL;
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t response_curve_move_store(struct device *dev,
-+				       struct device_attribute *attr,
-+				       const char *buf, size_t count,
-+				       bool is_left, struct ally_handheld *ally,
-+				       int idx)
-+{
-+	struct ally_config *cfg = ally->config;
-+	struct joystick_resp_curve *curve = is_left ? &cfg->left_curve : &cfg->right_curve;
-+	u8 value;
-+	int ret;
-+
-+	if (!cfg->resp_curve_support)
-+		return -EOPNOTSUPP;
-+
-+	ret = kstrtou8(buf, 10, &value);
-+	if (ret)
-+		return ret;
-+
-+	if (value > 100)
-+		return -EINVAL;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	switch (idx) {
-+	case 1: curve->entry_1.move = value; break;
-+	case 2: curve->entry_2.move = value; break;
-+	case 3: curve->entry_3.move = value; break;
-+	case 4: curve->entry_4.move = value; break;
-+	default: ret = -EINVAL;
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+#define DEFINE_JS_CURVE_PCT_FOPS(region, side)                             \
-+	static ssize_t response_curve_pct_##region##_##side##_show(              \
-+		struct device *dev, struct device_attribute *attr, char *buf) \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_pct_show(                               \
-+			dev, attr, buf, &ally->config->side##_curve, region);    \
-+	}                                                                     \
-+                                                                              \
-+	static ssize_t response_curve_pct_##region##_##side##_store(             \
-+		struct device *dev, struct device_attribute *attr,            \
-+		const char *buf, size_t count)                                \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_pct_store(dev, attr, buf, count,        \
-+						side##_is_left, ally, region);   \
-+	}
-+
-+#define DEFINE_JS_CURVE_MOVE_FOPS(region, side)                            \
-+	static ssize_t response_curve_move_##region##_##side##_show(             \
-+		struct device *dev, struct device_attribute *attr, char *buf) \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_move_show(                              \
-+			dev, attr, buf, &ally->config->side##_curve, region);    \
-+	}                                                                     \
-+                                                                              \
-+	static ssize_t response_curve_move_##region##_##side##_store(            \
-+		struct device *dev, struct device_attribute *attr,            \
-+		const char *buf, size_t count)                                \
-+	{                                                                     \
-+		struct hid_device *hdev = to_hid_device(dev);                 \
-+		struct ally_handheld *ally = hid_get_drvdata(hdev);           \
-+		return response_curve_move_store(dev, attr, buf, count,       \
-+						 side##_is_left, ally, region);  \
-+	}
-+
-+#define DEFINE_JS_CURVE_ATTRS(region, side)                                 \
-+	DEFINE_JS_CURVE_PCT_FOPS(region, side)                              \
-+		DEFINE_JS_CURVE_MOVE_FOPS(region, side)                     \
-+			ALLY_DEVICE_ATTR_RW(response_curve_pct_##region##_##side, \
-+					    response_curve_pct_##region);        \
-+	ALLY_DEVICE_ATTR_RW(response_curve_move_##region##_##side,                \
-+			    response_curve_move_##region)
-+
-+/* Helper defines for "is_left" parameter */
-+#define left_is_left true
-+#define right_is_left false
-+
-+DEFINE_JS_CURVE_ATTRS(1, left);
-+DEFINE_JS_CURVE_ATTRS(2, left);
-+DEFINE_JS_CURVE_ATTRS(3, left);
-+DEFINE_JS_CURVE_ATTRS(4, left);
-+
-+DEFINE_JS_CURVE_ATTRS(1, right);
-+DEFINE_JS_CURVE_ATTRS(2, right);
-+DEFINE_JS_CURVE_ATTRS(3, right);
-+DEFINE_JS_CURVE_ATTRS(4, right);
-+
-+ALLY_DEVICE_ATTR_WO(response_curve_apply_left, response_curve_apply);
-+ALLY_DEVICE_ATTR_WO(response_curve_apply_right, response_curve_apply);
-+
-+static ssize_t deadzone_left_show(struct device *dev,
-+				struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return sprintf(buf, "%u %u\n", cfg->left_deadzone, cfg->left_outer_threshold);
-+}
-+
-+static ssize_t deadzone_right_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return sprintf(buf, "%u %u\n", cfg->right_deadzone, cfg->right_outer_threshold);
-+}
-+
-+DEVICE_ATTR_RO(deadzone_left);
-+DEVICE_ATTR_RO(deadzone_right);
-+ALLY_DEVICE_CONST_ATTR_RO(deadzone_index, deadzone_index, "inner outer\n");
-+
-+static struct attribute *axis_xy_left_attrs[] = {
-+	&dev_attr_joystick_left_deadzone.attr,
-+	&dev_attr_js_deadzone_index.attr,
-+	&dev_attr_js_deadzone_inner_min.attr,
-+	&dev_attr_js_deadzone_inner_max.attr,
-+	&dev_attr_js_deadzone_outer_min.attr,
-+	&dev_attr_js_deadzone_outer_max.attr,
-+	&dev_attr_js_left_anti_deadzone.attr,
-+	&dev_attr_js_anti_deadzone_min.attr,
-+	&dev_attr_js_anti_deadzone_max.attr,
-+	&dev_attr_response_curve_pct_1_left.attr,
-+	&dev_attr_response_curve_pct_2_left.attr,
-+	&dev_attr_response_curve_pct_3_left.attr,
-+	&dev_attr_response_curve_pct_4_left.attr,
-+	&dev_attr_response_curve_move_1_left.attr,
-+	&dev_attr_response_curve_move_2_left.attr,
-+	&dev_attr_response_curve_move_3_left.attr,
-+	&dev_attr_response_curve_move_4_left.attr,
-+	&dev_attr_response_curve_apply_left.attr,
-+	NULL
-+};
-+
-+static struct attribute *axis_xy_right_attrs[] = {
-+	&dev_attr_joystick_right_deadzone.attr,
-+	&dev_attr_js_deadzone_index.attr,
-+	&dev_attr_js_deadzone_inner_min.attr,
-+	&dev_attr_js_deadzone_inner_max.attr,
-+	&dev_attr_js_deadzone_outer_min.attr,
-+	&dev_attr_js_deadzone_outer_max.attr,
-+	&dev_attr_js_right_anti_deadzone.attr,
-+	&dev_attr_js_anti_deadzone_min.attr,
-+	&dev_attr_js_anti_deadzone_max.attr,
-+	&dev_attr_response_curve_pct_1_right.attr,
-+	&dev_attr_response_curve_pct_2_right.attr,
-+	&dev_attr_response_curve_pct_3_right.attr,
-+	&dev_attr_response_curve_pct_4_right.attr,
-+	&dev_attr_response_curve_move_1_right.attr,
-+	&dev_attr_response_curve_move_2_right.attr,
-+	&dev_attr_response_curve_move_3_right.attr,
-+	&dev_attr_response_curve_move_4_right.attr,
-+	&dev_attr_response_curve_apply_right.attr,
-+	NULL
-+};
-+
-+/**
-+ * ally_set_trigger_range - Set trigger range values
-+ * @hdev: HID device
-+ * @cfg: Ally config
-+ * @left_min: Left trigger minimum (0-255)
-+ * @left_max: Left trigger maximum (0-255)
-+ * @right_min: Right trigger minimum (0-255)
-+ * @right_max: Right trigger maximum (0-255)
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+static int ally_set_trigger_range(struct hid_device *hdev,
-+				  struct ally_config *cfg, u8 left_min,
-+				  u8 left_max, u8 right_min, u8 right_max)
-+{
-+	int ret;
-+
-+	if (left_min >= left_max || right_min >= right_max)
-+		return -EINVAL;
-+
-+	ret = ally_set_dzot_ranges(hdev, cfg,
-+						  CMD_SET_TRIGGER_RANGE,
-+						  left_min, left_max, right_min,
-+						  right_max);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->left_trigger_min = left_min;
-+	cfg->left_trigger_max = left_max;
-+	cfg->right_trigger_min = right_min;
-+	cfg->right_trigger_max = right_max;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return 0;
-+}
-+
-+static ssize_t trigger_range_show(struct device *dev,
-+				  struct device_attribute *attr, char *buf,
-+				  u8 min_val, u8 max_val)
-+{
-+	return sprintf(buf, "%u %u\n", min_val, max_val);
-+}
-+
-+static ssize_t trigger_range_store(struct device *dev,
-+				   struct device_attribute *attr,
-+				   const char *buf, size_t count, bool is_left,
-+				   struct ally_config *cfg)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	u8 min_val, max_val;
-+	int ret;
-+
-+	ret = sscanf(buf, "%hhu %hhu", &min_val, &max_val);
-+	if (ret != 2)
-+		return -EINVAL;
-+
-+	if (is_left) {
-+		ret = ally_set_trigger_range(hdev, cfg, min_val, max_val,
-+					     cfg->right_trigger_min,
-+					     cfg->right_trigger_max);
-+	} else {
-+		ret = ally_set_trigger_range(hdev, cfg, cfg->left_trigger_min,
-+					     cfg->left_trigger_max, min_val,
-+					     max_val);
-+	}
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t trigger_left_deadzone_show(struct device *dev,
-+				       struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return trigger_range_show(dev, attr, buf, cfg->left_trigger_min,
-+				  cfg->left_trigger_max);
-+}
-+
-+static ssize_t trigger_left_deadzone_store(struct device *dev,
-+					struct device_attribute *attr,
-+					const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return trigger_range_store(dev, attr, buf, count, true, ally->config);
-+}
-+
-+static ssize_t trigger_right_deadzone_show(struct device *dev,
-+					struct device_attribute *attr,
-+					char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg = ally->config;
-+
-+	return trigger_range_show(dev, attr, buf, cfg->right_trigger_min,
-+				  cfg->right_trigger_max);
-+}
-+
-+static ssize_t trigger_right_deadzone_store(struct device *dev,
-+					 struct device_attribute *attr,
-+					 const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	return trigger_range_store(dev, attr, buf, count, false, ally->config);
-+}
-+
-+ALLY_DEVICE_CONST_ATTR_RO(tr_deadzone_inner_min, deadzone_inner_min, "0\n");
-+ALLY_DEVICE_CONST_ATTR_RO(tr_deadzone_inner_max, deadzone_inner_max, "255\n");
-+
-+ALLY_DEVICE_ATTR_RW(trigger_left_deadzone, deadzone);
-+ALLY_DEVICE_ATTR_RW(trigger_right_deadzone, deadzone);
-+
-+static struct attribute *axis_z_left_attrs[] = {
-+	&dev_attr_trigger_left_deadzone.attr,
-+	&dev_attr_tr_deadzone_inner_min.attr,
-+	&dev_attr_tr_deadzone_inner_max.attr,
-+	NULL
-+};
-+
-+static struct attribute *axis_z_right_attrs[] = {
-+	&dev_attr_trigger_right_deadzone.attr,
-+	&dev_attr_tr_deadzone_inner_min.attr,
-+	&dev_attr_tr_deadzone_inner_max.attr,
-+	NULL
-+};
-+
-+/* Map from string name to enum value */
-+static int get_gamepad_mode_from_name(const char *name)
-+{
-+	int i;
-+
-+	for (i = ALLY_GAMEPAD_MODE_GAMEPAD; i <= ALLY_GAMEPAD_MODE_KEYBOARD;
-+	     i++) {
-+		if (gamepad_mode_names[i] &&
-+		    strcmp(name, gamepad_mode_names[i]) == 0)
-+			return i;
-+	}
-+
-+	return -1;
-+}
-+
-+/**
-+ * ally_set_gamepad_mode - Set the gamepad operating mode
-+ * @ally: ally handheld structure
-+ * @hdev: HID device
-+ * @mode: Gamepad mode to set
-+ *
-+ * Returns: 0 on success, negative on failure
-+ */
-+static int ally_set_gamepad_mode(struct ally_handheld *ally,
-+				 struct hid_device *hdev, u8 mode)
-+{
-+	struct ally_config *cfg = ally->config;
-+	int ret;
-+
-+	if (!cfg)
-+		return -EINVAL;
-+
-+	if (mode < ALLY_GAMEPAD_MODE_GAMEPAD ||
-+	    mode > ALLY_GAMEPAD_MODE_KEYBOARD) {
-+		hid_err(hdev, "Invalid gamepad mode: %u\n", mode);
-+		return -EINVAL;
-+	}
-+
-+	ret = ally_gamepad_send_one_byte_packet(ally, hdev,
-+						CMD_SET_GAMEPAD_MODE, mode);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set gamepad mode: %d\n", ret);
-+		return ret;
-+	}
-+
-+	mutex_lock(&cfg->config_mutex);
-+	cfg->gamepad_mode = mode;
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	hid_info(hdev, "Set gamepad mode to %s\n", gamepad_mode_names[mode]);
-+	return 0;
-+}
-+
-+static ssize_t gamepad_mode_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_config *cfg;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	cfg = ally->config;
-+
-+	if (cfg->gamepad_mode >= ALLY_GAMEPAD_MODE_GAMEPAD &&
-+	    cfg->gamepad_mode <= ALLY_GAMEPAD_MODE_KEYBOARD) {
-+		return sprintf(buf, "%s\n",
-+			       gamepad_mode_names[cfg->gamepad_mode]);
-+	} else {
-+		return sprintf(buf, "unknown (%u)\n", cfg->gamepad_mode);
-+	}
-+}
-+
-+static ssize_t gamepad_mode_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	char mode_name[16];
-+	int mode;
-+	int ret;
-+
-+	if (!ally || !ally->config)
-+		return -ENODEV;
-+
-+	if (sscanf(buf, "%15s", mode_name) != 1)
-+		return -EINVAL;
-+
-+	mode = get_gamepad_mode_from_name(mode_name);
-+	if (mode < 0) {
-+		hid_err(hdev, "Unknown gamepad mode: %s\n", mode_name);
-+		return -EINVAL;
-+	}
-+
-+	ret = ally_set_gamepad_mode(ally, hdev, mode);
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+static ssize_t gamepad_modes_available_show(struct device *dev,
-+					    struct device_attribute *attr,
-+					    char *buf)
-+{
-+	int i;
-+	int len = 0;
-+
-+	for (i = ALLY_GAMEPAD_MODE_GAMEPAD; i <= ALLY_GAMEPAD_MODE_KEYBOARD;
-+	     i++) {
-+		len += sprintf(buf + len, "%s ", gamepad_mode_names[i]);
-+	}
-+
-+	/* Replace the last space with a newline */
-+	if (len > 0)
-+		buf[len - 1] = '\n';
-+
-+	return len;
-+}
-+
-+DEVICE_ATTR_RW(gamepad_mode);
-+DEVICE_ATTR_RO(gamepad_modes_available);
-+
-+static int ally_set_default_gamepad_mode(struct hid_device *hdev,
-+					 struct ally_config *cfg)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	cfg->gamepad_mode = ALLY_GAMEPAD_MODE_GAMEPAD;
-+
-+	return ally_set_gamepad_mode(ally, hdev, cfg->gamepad_mode);
-+}
-+
-+static struct attribute *ally_config_attrs[] = {
-+	&dev_attr_xbox_controller.attr,
-+	&dev_attr_vibration_intensity.attr,
-+	&dev_attr_gamepad_mode.attr,
-+	&dev_attr_gamepad_modes_available.attr,
-+	NULL
-+};
-+
-+static const struct attribute_group ally_attr_groups[] = {
-+	{
-+		.attrs = ally_config_attrs,
-+	},
-+	{
-+		.name = "axis_xy_left",
-+		.attrs = axis_xy_left_attrs,
-+	},
-+	{
-+		.name = "axis_xy_right",
-+		.attrs = axis_xy_right_attrs,
-+	},
-+	{
-+		.name = "axis_z_left",
-+		.attrs = axis_z_left_attrs,
-+	},
-+	{
-+		.name = "axis_z_right",
-+		.attrs = axis_z_right_attrs,
-+	},
-+};
-+
-+/**
-+ * ally_get_turbo_params - Get turbo parameters for a specific button
-+ * @cfg: Ally config structure
-+ * @button_id: Button identifier from ally_button_id enum
-+ *
-+ * Returns: Pointer to the button's turbo parameters, or NULL if invalid
-+ */
-+static struct button_turbo_params *ally_get_turbo_params(struct ally_config *cfg,
-+                                                       enum ally_button_id button_id)
-+{
-+	struct turbo_config *turbo;
-+
-+	if (!cfg || button_id >= ALLY_BTN_MAX)
-+		return NULL;
-+
-+	turbo = &cfg->turbo;
-+
-+	switch (button_id) {
-+	case ALLY_BTN_A:
-+		return &turbo->btn_a;
-+	case ALLY_BTN_B:
-+		return &turbo->btn_b;
-+	case ALLY_BTN_X:
-+		return &turbo->btn_x;
-+	case ALLY_BTN_Y:
-+		return &turbo->btn_y;
-+	case ALLY_BTN_LB:
-+		return &turbo->btn_lb;
-+	case ALLY_BTN_RB:
-+		return &turbo->btn_rb;
-+	case ALLY_BTN_DU:
-+		return &turbo->btn_du;
-+	case ALLY_BTN_DD:
-+		return &turbo->btn_dd;
-+	case ALLY_BTN_DL:
-+		return &turbo->btn_dl;
-+	case ALLY_BTN_DR:
-+		return &turbo->btn_dr;
-+	case ALLY_BTN_J0B:
-+		return &turbo->btn_j0b;
-+	case ALLY_BTN_J1B:
-+		return &turbo->btn_j1b;
-+	case ALLY_BTN_MENU:
-+		return &turbo->btn_menu;
-+	case ALLY_BTN_VIEW:
-+		return &turbo->btn_view;
-+	case ALLY_BTN_M1:
-+		return &turbo->btn_m1;
-+	case ALLY_BTN_M2:
-+		return &turbo->btn_m2;
-+	default:
-+		return NULL;
-+	}
-+}
-+
-+/**
-+ * ally_set_turbo_params - Set turbo parameters for all buttons
-+ * @hdev: HID device
-+ * @cfg: Ally config structure
-+ *
-+ * Returns: 0 on success, negative on failure
-+ */
-+static int ally_set_turbo_params(struct hid_device *hdev, struct ally_config *cfg)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct turbo_config *turbo = &cfg->turbo;
-+	u8 packet[HID_ALLY_REPORT_SIZE] = { 0 };
-+	int ret;
-+
-+	if (!cfg->turbo_support) {
-+		hid_dbg(hdev, "Turbo functionality not supported on this device\n");
-+		return -EOPNOTSUPP;
-+	}
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = CMD_SET_TURBO_PARAMS;
-+	packet[3] = 0x20; /* Length - 32 bytes for 16 buttons with 2 values each */
-+
-+	packet[4] = turbo->btn_du.turbo;
-+	packet[5] = turbo->btn_du.toggle;
-+	packet[6] = turbo->btn_dd.turbo;
-+	packet[7] = turbo->btn_dd.toggle;
-+	packet[8] = turbo->btn_dl.turbo;
-+	packet[9] = turbo->btn_dl.toggle;
-+	packet[10] = turbo->btn_dr.turbo;
-+	packet[11] = turbo->btn_dr.toggle;
-+	packet[12] = turbo->btn_j0b.turbo;
-+	packet[13] = turbo->btn_j0b.toggle;
-+	packet[14] = turbo->btn_j1b.turbo;
-+	packet[15] = turbo->btn_j1b.toggle;
-+	packet[16] = turbo->btn_lb.turbo;
-+	packet[17] = turbo->btn_lb.toggle;
-+	packet[18] = turbo->btn_rb.turbo;
-+	packet[19] = turbo->btn_rb.toggle;
-+	packet[20] = turbo->btn_a.turbo;
-+	packet[21] = turbo->btn_a.toggle;
-+	packet[22] = turbo->btn_b.turbo;
-+	packet[23] = turbo->btn_b.toggle;
-+	packet[24] = turbo->btn_x.turbo;
-+	packet[25] = turbo->btn_x.toggle;
-+	packet[26] = turbo->btn_y.turbo;
-+	packet[27] = turbo->btn_y.toggle;
-+	packet[28] = turbo->btn_view.turbo;
-+	packet[29] = turbo->btn_view.toggle;
-+	packet[30] = turbo->btn_menu.turbo;
-+	packet[31] = turbo->btn_menu.toggle;
-+	packet[32] = turbo->btn_m2.turbo;
-+	packet[33] = turbo->btn_m2.toggle;
-+	packet[34] = turbo->btn_m1.turbo;
-+	packet[35] = turbo->btn_m1.toggle;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet, HID_ALLY_REPORT_SIZE);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to set turbo parameters: %d\n", ret);
-+		return ret;
-+	}
-+
-+	return 0;
-+}
-+
-+struct button_turbo_attr {
-+	struct device_attribute dev_attr;
-+	int button_id;
-+};
-+
-+#define to_button_turbo_attr(x) container_of(x, struct button_turbo_attr, dev_attr)
-+
-+static ssize_t button_turbo_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_turbo_attr *btn_attr = to_button_turbo_attr(attr);
-+	struct button_turbo_params *params;
-+
-+	if (!ally->config->turbo_support)
-+		return sprintf(buf, "Unsupported\n");
-+
-+	params = ally_get_turbo_params(ally->config, btn_attr->button_id);
-+	if (!params)
-+		return -EINVAL;
-+
-+	/* Format: turbo_interval_ms[,toggle_interval_ms] */
-+	if (params->toggle)
-+		return sprintf(buf, "%d,%d\n", params->turbo * 50, params->toggle * 50);
-+	else
-+		return sprintf(buf, "%d\n", params->turbo * 50);
-+}
-+
-+static ssize_t button_turbo_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_turbo_attr *btn_attr = to_button_turbo_attr(attr);
-+	struct button_turbo_params *params;
-+	unsigned int turbo_ms, toggle_ms = 0;
-+	int ret;
-+
-+	if (!ally->config->turbo_support)
-+		return -EOPNOTSUPP;
-+
-+	params = ally_get_turbo_params(ally->config, btn_attr->button_id);
-+	if (!params)
-+		return -EINVAL;
-+
-+	/* Parse input: turbo_interval_ms[,toggle_interval_ms] */
-+	ret = sscanf(buf, "%u,%u", &turbo_ms, &toggle_ms);
-+	if (ret < 1)
-+		return -EINVAL;
-+
-+	if (turbo_ms != 0 && (turbo_ms < 50 || turbo_ms > 1000))
-+		return -EINVAL;
-+
-+	if (ret > 1 && toggle_ms > 0 && (toggle_ms < 50 || toggle_ms > 1000))
-+		return -EINVAL;
-+
-+	mutex_lock(&ally->config->config_mutex);
-+
-+	params->turbo = turbo_ms / 50;
-+	params->toggle = toggle_ms / 50;
-+
-+	ret = ally_set_turbo_params(hdev, ally->config);
-+
-+	mutex_unlock(&ally->config->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+/* Helper to create button turbo attribute */
-+static struct button_turbo_attr *button_turbo_attr_create(int button_id)
-+{
-+	struct button_turbo_attr *attr;
-+
-+	attr = kzalloc(sizeof(*attr), GFP_KERNEL);
-+	if (!attr)
-+		return NULL;
-+
-+	attr->button_id = button_id;
-+	sysfs_attr_init(&attr->dev_attr.attr);
-+	attr->dev_attr.attr.name = "turbo";
-+	attr->dev_attr.attr.mode = 0644;
-+	attr->dev_attr.show = button_turbo_show;
-+	attr->dev_attr.store = button_turbo_store;
-+
-+	return attr;
-+}
-+
-+/* Button remap attribute structure */
-+struct button_remap_attr {
-+	struct device_attribute dev_attr;
-+	enum ally_button_id button_id;
-+	bool is_macro;
-+};
-+
-+#define to_button_remap_attr(x) container_of(x, struct button_remap_attr, dev_attr)
-+
-+/* Get appropriate button pair index and position for a given button */
-+static int get_button_pair_info(enum ally_button_id button_id,
-+				enum btn_pair_index *pair_idx,
-+				bool *is_first)
-+{
-+	switch (button_id) {
-+	case ALLY_BTN_DU:
-+		*pair_idx = BTN_PAIR_DPAD_UPDOWN;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_DD:
-+		*pair_idx = BTN_PAIR_DPAD_UPDOWN;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_DL:
-+		*pair_idx = BTN_PAIR_DPAD_LEFTRIGHT;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_DR:
-+		*pair_idx = BTN_PAIR_DPAD_LEFTRIGHT;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_J0B:
-+		*pair_idx = BTN_PAIR_STICK_LR;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_J1B:
-+		*pair_idx = BTN_PAIR_STICK_LR;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_LB:
-+		*pair_idx = BTN_PAIR_BUMPER_LR;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_RB:
-+		*pair_idx = BTN_PAIR_BUMPER_LR;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_A:
-+		*pair_idx = BTN_PAIR_AB;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_B:
-+		*pair_idx = BTN_PAIR_AB;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_X:
-+		*pair_idx = BTN_PAIR_XY;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_Y:
-+		*pair_idx = BTN_PAIR_XY;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_VIEW:
-+		*pair_idx = BTN_PAIR_VIEW_MENU;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_MENU:
-+		*pair_idx = BTN_PAIR_VIEW_MENU;
-+		*is_first = false;
-+		break;
-+	case ALLY_BTN_M1:
-+		*pair_idx = BTN_PAIR_M1M2;
-+		*is_first = true;
-+		break;
-+	case ALLY_BTN_M2:
-+		*pair_idx = BTN_PAIR_M1M2;
-+		*is_first = false;
-+		break;
-+	default:
-+		return -EINVAL;
-+	}
-+
-+	return 0;
-+}
-+
-+static ssize_t button_remap_show(struct device *dev,
-+				 struct device_attribute *attr, char *buf)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_remap_attr *btn_attr = to_button_remap_attr(attr);
-+	struct ally_config *cfg = ally->config;
-+	enum ally_button_id button_id = btn_attr->button_id;
-+	enum btn_pair_index pair_idx;
-+	bool is_first;
-+	struct button_pair_map *pair;
-+	struct button_map *btn_map;
-+	int ret;
-+
-+	if (!cfg)
-+		return -ENODEV;
-+
-+	ret = get_button_pair_info(button_id, &pair_idx, &is_first);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	pair = &((struct ally_button_mapping
-+			  *)(cfg->button_mappings))[cfg->gamepad_mode]
-+			.button_pairs[pair_idx - 1];
-+	btn_map = is_first ? &pair->first : &pair->second;
-+
-+	if (btn_attr->is_macro) {
-+		if (btn_map->macro->type == BTN_TYPE_NONE)
-+			ret = sprintf(buf, "NONE\n");
-+		else
-+			ret = sprintf(buf, "%s\n", btn_map->macro->name);
-+	} else {
-+		if (btn_map->remap->type == BTN_TYPE_NONE)
-+			ret = sprintf(buf, "NONE\n");
-+		else
-+			ret = sprintf(buf, "%s\n", btn_map->remap->name);
-+	}
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	return ret;
-+}
-+
-+static ssize_t button_remap_store(struct device *dev,
-+				  struct device_attribute *attr,
-+				  const char *buf, size_t count)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct button_remap_attr *btn_attr = to_button_remap_attr(attr);
-+	struct ally_config *cfg = ally->config;
-+	enum ally_button_id button_id = btn_attr->button_id;
-+	enum btn_pair_index pair_idx;
-+	bool is_first;
-+	struct button_pair_map *pair;
-+	struct button_map *btn_map;
-+	char btn_name[32];
-+	const struct btn_code_map *code;
-+	int ret;
-+
-+	if (!cfg)
-+		return -ENODEV;
-+
-+	if (sscanf(buf, "%31s", btn_name) != 1)
-+		return -EINVAL;
-+
-+	/* Handle "NONE" specially */
-+	if (strcmp(btn_name, "NONE") == 0) {
-+		code = &ally_btn_codes[0]; /* NONE entry */
-+	} else {
-+		code = find_button_by_name(btn_name);
-+		if (!code)
-+			return -EINVAL;
-+	}
-+
-+	ret = get_button_pair_info(button_id, &pair_idx, &is_first);
-+	if (ret < 0)
-+		return ret;
-+
-+	mutex_lock(&cfg->config_mutex);
-+	/* Access the mapping for current gamepad mode */
-+	pair = &((struct ally_button_mapping
-+			  *)(cfg->button_mappings))[cfg->gamepad_mode]
-+			.button_pairs[pair_idx - 1];
-+	btn_map = is_first ? &pair->first : &pair->second;
-+
-+	if (btn_attr->is_macro) {
-+		btn_map->macro = (struct btn_code_map *)code;
-+	} else {
-+		btn_map->remap = (struct btn_code_map *)code;
-+	}
-+
-+	/* Update pair index */
-+	pair->pair_index = pair_idx;
-+
-+	/* Send mapping to device */
-+	ret = ally_set_button_mapping(hdev, ally, pair);
-+	mutex_unlock(&cfg->config_mutex);
-+
-+	if (ret < 0)
-+		return ret;
-+
-+	return count;
-+}
-+
-+/* Helper to create button remap attribute */
-+static struct button_remap_attr *button_remap_attr_create(enum ally_button_id button_id, bool is_macro)
-+{
-+	struct button_remap_attr *attr;
-+
-+	attr = kzalloc(sizeof(*attr), GFP_KERNEL);
-+	if (!attr)
-+		return NULL;
-+
-+	attr->button_id = button_id;
-+	attr->is_macro = is_macro;
-+	sysfs_attr_init(&attr->dev_attr.attr);
-+	attr->dev_attr.attr.name = is_macro ? "macro" : "remap";
-+	attr->dev_attr.attr.mode = 0644;
-+	attr->dev_attr.show = button_remap_show;
-+	attr->dev_attr.store = button_remap_store;
-+
-+	return attr;
-+}
-+
-+/* Structure to hold button sysfs information */
-+struct button_sysfs_entry {
-+	struct attribute_group group;
-+	struct attribute *attrs[4]; /* turbo + remap + macro + NULL terminator */
-+	struct button_turbo_attr *turbo_attr;
-+	struct button_remap_attr *remap_attr;
-+	struct button_remap_attr *macro_attr;
-+};
-+
-+static void ally_set_default_gamepad_mapping(struct ally_button_mapping *mappings)
-+{
-+	struct ally_button_mapping *map = &mappings[ALLY_GAMEPAD_MODE_GAMEPAD];
-+	int i;
-+
-+	/* Set all pair indexes and initialize to NONE */
-+	for (i = 0; i < 9; i++) {
-+		map->button_pairs[i].pair_index = i + 1;
-+		map->button_pairs[i].first.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].first.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+	}
-+
-+	/* Set direct mappings using array indices */
-+	map->button_pairs[BTN_PAIR_AB - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[1]; /* PAD_A */
-+	map->button_pairs[BTN_PAIR_AB - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[2]; /* PAD_B */
-+
-+	map->button_pairs[BTN_PAIR_XY - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[3]; /* PAD_X */
-+	map->button_pairs[BTN_PAIR_XY - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[4]; /* PAD_Y */
-+
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[5]; /* PAD_LB */
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[6]; /* PAD_RB */
-+
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[7]; /* PAD_LS */
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[8]; /* PAD_RS */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[9]; /* PAD_DPAD_UP */
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[10]; /* PAD_DPAD_DOWN */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[11]; /* PAD_DPAD_LEFT */
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[12]; /* PAD_DPAD_RIGHT */
-+
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[13]; /* PAD_LT */
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[14]; /* PAD_RT */
-+
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[15]; /* PAD_VIEW */
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[16]; /* PAD_MENU */
-+
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[19]; /* KB_M1 */
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[18]; /* KB_M2 */
-+}
-+
-+static void ally_set_default_keyboard_mapping(struct ally_button_mapping *mappings)
-+{
-+	struct ally_button_mapping *map = &mappings[ALLY_GAMEPAD_MODE_KEYBOARD];
-+	int i;
-+
-+	/* Set all pair indexes and initialize to NONE */
-+	for (i = 0; i < 9; i++) {
-+		map->button_pairs[i].pair_index = i + 1;
-+		map->button_pairs[i].first.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].first.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.remap =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+		map->button_pairs[i].second.macro =
-+			(struct btn_code_map *)&ally_btn_codes[0];
-+	}
-+
-+	/* Set direct mappings using array indices */
-+	map->button_pairs[BTN_PAIR_AB - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[1]; /* PAD_A */
-+	map->button_pairs[BTN_PAIR_AB - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[2]; /* PAD_B */
-+
-+	map->button_pairs[BTN_PAIR_XY - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[3]; /* PAD_X */
-+	map->button_pairs[BTN_PAIR_XY - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[4]; /* PAD_Y */
-+
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[5]; /* PAD_LB */
-+	map->button_pairs[BTN_PAIR_BUMPER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[6]; /* PAD_RB */
-+
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[7]; /* PAD_LS */
-+	map->button_pairs[BTN_PAIR_STICK_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[8]; /* PAD_RS */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[9]; /* PAD_DPAD_UP */
-+	map->button_pairs[BTN_PAIR_DPAD_UPDOWN - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[10]; /* PAD_DPAD_DOWN */
-+
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[11]; /* PAD_DPAD_LEFT */
-+	map->button_pairs[BTN_PAIR_DPAD_LEFTRIGHT - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[12]; /* PAD_DPAD_RIGHT */
-+
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[13]; /* PAD_LT */
-+	map->button_pairs[BTN_PAIR_TRIGGER_LR - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[14]; /* PAD_RT */
-+
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[15]; /* PAD_VIEW */
-+	map->button_pairs[BTN_PAIR_VIEW_MENU - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[16]; /* PAD_MENU */
-+
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].first.remap =
-+		(struct btn_code_map *)&ally_btn_codes[19]; /* KB_M1 */
-+	map->button_pairs[BTN_PAIR_M1M2 - 1].second.remap =
-+		(struct btn_code_map *)&ally_btn_codes[18]; /* KB_M2 */
-+}
-+
-+/**
-+ * ally_create_button_attributes - Create button attributes
-+ * @hdev: HID device
-+ * @cfg: Ally config structure
-+ *
-+ * Returns: 0 on success, negative on failure
-+ */
-+static int ally_create_button_attributes(struct hid_device *hdev,
-+					 struct ally_config *cfg)
-+{
-+	struct button_sysfs_entry *entries;
-+	int i, j, ret;
-+	struct ally_button_mapping *mappings;
-+
-+	entries = devm_kcalloc(&hdev->dev, ALLY_BTN_MAX, sizeof(*entries),
-+			       GFP_KERNEL);
-+	if (!entries)
-+		return -ENOMEM;
-+
-+	/* Allocate mappings for each gamepad mode (1-based indexing) */
-+	mappings = devm_kcalloc(&hdev->dev, ALLY_GAMEPAD_MODE_KEYBOARD + 1,
-+				sizeof(*mappings), GFP_KERNEL);
-+	if (!mappings) {
-+		ret = -ENOMEM;
-+		goto err_free_entries;
-+	}
-+
-+	cfg->button_entries = entries;
-+	cfg->button_mappings = mappings;
-+	ally_set_default_gamepad_mapping(mappings);
-+	ally_set_default_keyboard_mapping(mappings);
-+
-+	for (i = 0; i < ALLY_BTN_MAX; i++) {
-+		if (cfg->turbo_support) {
-+			entries[i].turbo_attr = button_turbo_attr_create(i);
-+			if (!entries[i].turbo_attr) {
-+				ret = -ENOMEM;
-+				goto err_cleanup;
-+			}
-+		}
-+
-+		entries[i].remap_attr = button_remap_attr_create(i, false);
-+		if (!entries[i].remap_attr) {
-+			ret = -ENOMEM;
-+			goto err_cleanup;
-+		}
-+
-+		entries[i].macro_attr = button_remap_attr_create(i, true);
-+		if (!entries[i].macro_attr) {
-+			ret = -ENOMEM;
-+			goto err_cleanup;
-+		}
-+
-+		/* Set up attributes array based on what's supported */
-+		if (cfg->turbo_support) {
-+			entries[i].attrs[0] =
-+				&entries[i].turbo_attr->dev_attr.attr;
-+			entries[i].attrs[1] =
-+				&entries[i].remap_attr->dev_attr.attr;
-+			entries[i].attrs[2] =
-+				&entries[i].macro_attr->dev_attr.attr;
-+			entries[i].attrs[3] = NULL;
-+		} else {
-+			entries[i].attrs[0] =
-+				&entries[i].remap_attr->dev_attr.attr;
-+			entries[i].attrs[1] =
-+				&entries[i].macro_attr->dev_attr.attr;
-+			entries[i].attrs[2] = NULL;
-+		}
-+
-+		entries[i].group.name = ally_button_names[i];
-+		entries[i].group.attrs = entries[i].attrs;
-+
-+		ret = sysfs_create_group(&hdev->dev.kobj, &entries[i].group);
-+		if (ret < 0) {
-+			hid_err(hdev,
-+				"Failed to create sysfs group for %s: %d\n",
-+				ally_button_names[i], ret);
-+			goto err_cleanup;
-+		}
-+	}
-+
-+	return 0;
-+
-+err_cleanup:
-+	while (--i >= 0) {
-+		sysfs_remove_group(&hdev->dev.kobj, &entries[i].group);
-+		if (entries[i].turbo_attr)
-+			kfree(entries[i].turbo_attr);
-+		if (entries[i].remap_attr)
-+			kfree(entries[i].remap_attr);
-+		if (entries[i].macro_attr)
-+			kfree(entries[i].macro_attr);
-+	}
-+
-+err_free_entries:
-+	if (mappings)
-+		devm_kfree(&hdev->dev, mappings);
-+	devm_kfree(&hdev->dev, entries);
-+	return ret;
-+}
-+
-+/**
-+ * ally_remove_button_attributes - Remove button attributes
-+ * @hdev: HID device
-+ * @cfg: Ally config structure
-+ */
-+static void ally_remove_button_attributes(struct hid_device *hdev,
-+					  struct ally_config *cfg)
-+{
-+	struct button_sysfs_entry *entries;
-+	int i;
-+
-+	if (!cfg || !cfg->button_entries)
-+		return;
-+
-+	entries = cfg->button_entries;
-+
-+	/* Remove all attribute groups */
-+	for (i = 0; i < ALLY_BTN_MAX; i++) {
-+		sysfs_remove_group(&hdev->dev.kobj, &entries[i].group);
-+		if (entries[i].turbo_attr)
-+			kfree(entries[i].turbo_attr);
-+		if (entries[i].remap_attr)
-+			kfree(entries[i].remap_attr);
-+		if (entries[i].macro_attr)
-+			kfree(entries[i].macro_attr);
-+	}
-+
-+	if (cfg->button_mappings)
-+		devm_kfree(&hdev->dev, cfg->button_mappings);
-+	devm_kfree(&hdev->dev, entries);
-+}
-+
-+/**
-+ * ally_config_create - Initialize configuration and create sysfs entries
-+ * @hdev: HID device
-+ * @ally: Ally device data
-+ *
-+ * Returns 0 on success, negative error code on failure
-+ */
-+int ally_config_create(struct hid_device *hdev, struct ally_handheld *ally)
-+{
-+	struct ally_config *cfg;
-+	int ret, i;
-+
-+	if (!hdev || !ally)
-+		return -EINVAL;
-+
-+	if (get_endpoint_address(hdev) != HID_ALLY_INTF_CFG_IN)
-+		return 0;
-+
-+	cfg = devm_kzalloc(&hdev->dev, sizeof(*cfg), GFP_KERNEL);
-+	if (!cfg)
-+		return -ENOMEM;
-+
-+	cfg->hdev = hdev;
-+
-+	ally->config = cfg;
-+
-+	ret = ally_detect_capabilities(hdev, cfg);
-+	if (ret < 0) {
-+		hid_err(hdev, "Failed to detect Ally capabilities: %d\n", ret);
-+		goto err_free;
-+	}
-+
-+	/* Create all attribute groups */
-+	for (i = 0; i < ARRAY_SIZE(ally_attr_groups); i++) {
-+		ret = sysfs_create_group(&hdev->dev.kobj, &ally_attr_groups[i]);
-+		if (ret < 0) {
-+			hid_err(hdev, "Failed to create sysfs group '%s': %d\n",
-+				ally_attr_groups[i].name, ret);
-+			/* Remove any groups already created */
-+			while (--i >= 0)
-+				sysfs_remove_group(&hdev->dev.kobj,
-+						   &ally_attr_groups[i]);
-+			goto err_free;
-+		}
-+	}
-+
-+	if (cfg->turbo_support) {
-+		ret = ally_create_button_attributes(hdev, cfg);
-+		if (ret < 0) {
-+			hid_err(hdev, "Failed to create button attributes: %d\n", ret);
-+			for (i = 0; i < ARRAY_SIZE(ally_attr_groups); i++)
-+				sysfs_remove_group(&hdev->dev.kobj, &ally_attr_groups[i]);
-+			goto err_free;
-+		}
-+	}
-+
-+	ret = ally_set_default_gamepad_mode(hdev, cfg);
-+		if (ret < 0)
-+			hid_warn(hdev, "Failed to set default gamepad mode: %d\n", ret);
-+
-+	cfg->gamepad_mode = 0x01;
-+	cfg->left_deadzone = 10;
-+	cfg->left_outer_threshold = 90;
-+	cfg->right_deadzone = 10;
-+	cfg->right_outer_threshold = 90;
-+
-+	cfg->vibration_intensity_left = 100;
-+	cfg->vibration_intensity_right = 100;
-+	cfg->vibration_active = false;
-+
-+	/* Initialize default response curve values (linear) */
-+	cfg->left_curve.entry_1.move = 0;
-+	cfg->left_curve.entry_1.resp = 0;
-+	cfg->left_curve.entry_2.move = 33;
-+	cfg->left_curve.entry_2.resp = 33;
-+	cfg->left_curve.entry_3.move = 66;
-+	cfg->left_curve.entry_3.resp = 66;
-+	cfg->left_curve.entry_4.move = 100;
-+	cfg->left_curve.entry_4.resp = 100;
-+
-+	cfg->right_curve.entry_1.move = 0;
-+	cfg->right_curve.entry_1.resp = 0;
-+	cfg->right_curve.entry_2.move = 33;
-+	cfg->right_curve.entry_2.resp = 33;
-+	cfg->right_curve.entry_3.move = 66;
-+	cfg->right_curve.entry_3.resp = 66;
-+	cfg->right_curve.entry_4.move = 100;
-+	cfg->right_curve.entry_4.resp = 100;
-+
-+	// ONLY FOR ALLY 1
-+	if (cfg->xbox_controller_support) {
-+		ret = ally_set_xbox_controller(hdev, cfg, true);
-+		if (ret < 0)
-+			hid_warn(
-+				hdev,
-+				"Failed to set default Xbox controller mode: %d\n",
-+				ret);
-+	}
-+
-+	cfg->initialized = true;
-+	hid_info(hdev, "Ally configuration system initialized successfully\n");
-+
-+	return 0;
-+
-+err_free:
-+	ally->config = NULL;
-+	devm_kfree(&hdev->dev, cfg);
-+	return ret;
-+}
-+
-+/**
-+ * ally_config_remove - Clean up configuration resources
-+ * @hdev: HID device
-+ * @ally: Ally device data
-+ */
-+void ally_config_remove(struct hid_device *hdev, struct ally_handheld *ally)
-+{
-+	struct ally_config *cfg;
-+	int i;
-+
-+	if (!ally)
-+		return;
-+
-+	cfg = ally->config;
-+	if (!cfg || !cfg->initialized)
-+		return;
-+
-+	if (get_endpoint_address(hdev) != HID_ALLY_INTF_CFG_IN)
-+		return;
-+
-+	if (cfg->turbo_support && cfg->button_entries)
-+			ally_remove_button_attributes(hdev, cfg);
-+
-+	/* Remove all attribute groups in reverse order */
-+	for (i = ARRAY_SIZE(ally_attr_groups) - 1; i >= 0; i--)
-+		sysfs_remove_group(&hdev->dev.kobj, &ally_attr_groups[i]);
-+
-+	ally->config = NULL;
-+
-+	hid_info(hdev, "Ally configuration system removed\n");
-+}
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-hid-core.c b/drivers/hid/asus-ally-hid/asus-ally-hid-core.c
-new file mode 100644
-index 000000000000..1e8f98b69332
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-hid-core.c
-@@ -0,0 +1,600 @@
-+// SPDX-License-Identifier: GPL-2.0-or-later
-+/*
-+ *  HID driver for Asus ROG laptops and Ally
-+ *
-+ *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
-+ */
-+
-+#include "linux/mutex.h"
-+#include "linux/stddef.h"
-+#include "linux/types.h"
 +#include <linux/usb.h>
++#include <linux/leds.h>
++#include <linux/led-class-multicolor.h>
 +
-+#include "../hid-ids.h"
-+#include "asus-ally.h"
++#include "hid-ids.h"
++#include "hid-asus.h"
++#include "hid-asus-ally.h"
++
++#define DEBUG
 +
 +#define READY_MAX_TRIES 3
++#define FEATURE_REPORT_ID 0x0d
++#define FEATURE_ROG_ALLY_REPORT_ID 0x5a
++#define FEATURE_ROG_ALLY_CODE_PAGE 0xD1
++#define FEATURE_ROG_ALLY_REPORT_SIZE 64
++#define ALLY_X_INPUT_REPORT_USB 0x0B
++#define ALLY_X_INPUT_REPORT_USB_SIZE 16
++
++#define ROG_ALLY_REPORT_SIZE 64
++#define ROG_ALLY_X_MIN_MCU 313
++#define ROG_ALLY_MIN_MCU 319
++
++#define FEATURE_KBD_LED_REPORT_ID1 0x5d
++#define FEATURE_KBD_LED_REPORT_ID2 0x5e
++
++#define BTN_DATA_LEN 11;
++#define BTN_CODE_BYTES_LEN 8
 +
 +static const u8 EC_INIT_STRING[] = { 0x5A, 'A', 'S', 'U', 'S', ' ', 'T', 'e','c', 'h', '.', 'I', 'n', 'c', '.', '\0' };
++static const u8 EC_MODE_LED_APPLY[] = { 0x5A, 0xB4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
++static const u8 EC_MODE_LED_SET[] = { 0x5A, 0xB5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 +static const u8 FORCE_FEEDBACK_OFF[] = { 0x0D, 0x0F, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0xEB };
 +
 +static const struct hid_device_id rog_ally_devices[] = {
@@ -3013,18 +668,384 @@ index 000000000000..1e8f98b69332
 +	{}
 +};
 +
-+const char * ally_keyboard_name = "ROG Ally Keyboard";
-+const char * ally_mouse_name = "ROG Ally Mouse";
-+
-+/* Changes to ally_drvdata must lock */
-+static DEFINE_MUTEX(ally_data_mutex);
-+static struct ally_handheld ally_drvdata = {
-+    .cfg_hdev = NULL,
-+    .led_rgb_dev = NULL,
-+    .ally_x_input = NULL,
++struct btn_code_map {
++	u64 code;
++	const char *name;
 +};
 +
-+static inline int asus_dev_set_report(struct hid_device *hdev, const u8 *buf, size_t len)
++static const struct btn_code_map ally_btn_codes[] = {
++	{ 0, "NONE" },
++	/* Gamepad button codes */
++	{ BTN_PAD_A, "PAD_A" },
++	{ BTN_PAD_B, "PAD_B" },
++	{ BTN_PAD_X, "PAD_X" },
++	{ BTN_PAD_Y, "PAD_Y" },
++	{ BTN_PAD_LB, "PAD_LB" },
++	{ BTN_PAD_RB, "PAD_RB" },
++	{ BTN_PAD_LS, "PAD_LS" },
++	{ BTN_PAD_RS, "PAD_RS" },
++	{ BTN_PAD_DPAD_UP, "PAD_DPAD_UP" },
++	{ BTN_PAD_DPAD_DOWN, "PAD_DPAD_DOWN" },
++	{ BTN_PAD_DPAD_LEFT, "PAD_DPAD_LEFT" },
++	{ BTN_PAD_DPAD_RIGHT, "PAD_DPAD_RIGHT" },
++	{ BTN_PAD_VIEW, "PAD_VIEW" },
++	{ BTN_PAD_MENU, "PAD_MENU" },
++	{ BTN_PAD_XBOX, "PAD_XBOX" },
++
++	/* Triggers mapped to keyboard codes */
++	{ BTN_KB_M2, "KB_M2" },
++	{ BTN_KB_M1, "KB_M1" },
++	{ BTN_KB_ESC, "KB_ESC" },
++	{ BTN_KB_F1, "KB_F1" },
++	{ BTN_KB_F2, "KB_F2" },
++	{ BTN_KB_F3, "KB_F3" },
++	{ BTN_KB_F4, "KB_F4" },
++	{ BTN_KB_F5, "KB_F5" },
++	{ BTN_KB_F6, "KB_F6" },
++	{ BTN_KB_F7, "KB_F7" },
++	{ BTN_KB_F8, "KB_F8" },
++	{ BTN_KB_F9, "KB_F9" },
++	{ BTN_KB_F10, "KB_F10" },
++	{ BTN_KB_F11, "KB_F11" },
++	{ BTN_KB_F12, "KB_F12" },
++	{ BTN_KB_F14, "KB_F14" },
++	{ BTN_KB_F15, "KB_F15" },
++	{ BTN_KB_BACKTICK, "KB_BACKTICK" },
++	{ BTN_KB_1, "KB_1" },
++	{ BTN_KB_2, "KB_2" },
++	{ BTN_KB_3, "KB_3" },
++	{ BTN_KB_4, "KB_4" },
++	{ BTN_KB_5, "KB_5" },
++	{ BTN_KB_6, "KB_6" },
++	{ BTN_KB_7, "KB_7" },
++	{ BTN_KB_8, "KB_8" },
++	{ BTN_KB_9, "KB_9" },
++	{ BTN_KB_0, "KB_0" },
++	{ BTN_KB_HYPHEN, "KB_HYPHEN" },
++	{ BTN_KB_EQUALS, "KB_EQUALS" },
++	{ BTN_KB_BACKSPACE, "KB_BACKSPACE" },
++	{ BTN_KB_TAB, "KB_TAB" },
++	{ BTN_KB_Q, "KB_Q" },
++	{ BTN_KB_W, "KB_W" },
++	{ BTN_KB_E, "KB_E" },
++	{ BTN_KB_R, "KB_R" },
++	{ BTN_KB_T, "KB_T" },
++	{ BTN_KB_Y, "KB_Y" },
++	{ BTN_KB_U, "KB_U" },
++	{ BTN_KB_O, "KB_O" },
++	{ BTN_KB_P, "KB_P" },
++	{ BTN_KB_LBRACKET, "KB_LBRACKET" },
++	{ BTN_KB_RBRACKET, "KB_RBRACKET" },
++	{ BTN_KB_BACKSLASH, "KB_BACKSLASH" },
++	{ BTN_KB_CAPS, "KB_CAPS" },
++	{ BTN_KB_A, "KB_A" },
++	{ BTN_KB_S, "KB_S" },
++	{ BTN_KB_D, "KB_D" },
++	{ BTN_KB_F, "KB_F" },
++	{ BTN_KB_G, "KB_G" },
++	{ BTN_KB_H, "KB_H" },
++	{ BTN_KB_J, "KB_J" },
++	{ BTN_KB_K, "KB_K" },
++	{ BTN_KB_L, "KB_L" },
++	{ BTN_KB_SEMI, "KB_SEMI" },
++	{ BTN_KB_QUOTE, "KB_QUOTE" },
++	{ BTN_KB_RET, "KB_RET" },
++	{ BTN_KB_LSHIFT, "KB_LSHIFT" },
++	{ BTN_KB_Z, "KB_Z" },
++	{ BTN_KB_X, "KB_X" },
++	{ BTN_KB_C, "KB_C" },
++	{ BTN_KB_V, "KB_V" },
++	{ BTN_KB_B, "KB_B" },
++	{ BTN_KB_N, "KB_N" },
++	{ BTN_KB_M, "KB_M" },
++	{ BTN_KB_COMMA, "KB_COMMA" },
++	{ BTN_KB_PERIOD, "KB_PERIOD" },
++	{ BTN_KB_RSHIFT, "KB_RSHIFT" },
++	{ BTN_KB_LCTL, "KB_LCTL" },
++	{ BTN_KB_META, "KB_META" },
++	{ BTN_KB_LALT, "KB_LALT" },
++	{ BTN_KB_SPACE, "KB_SPACE" },
++	{ BTN_KB_RALT, "KB_RALT" },
++	{ BTN_KB_MENU, "KB_MENU" },
++	{ BTN_KB_RCTL, "KB_RCTL" },
++	{ BTN_KB_PRNTSCN, "KB_PRNTSCN" },
++	{ BTN_KB_SCRLCK, "KB_SCRLCK" },
++	{ BTN_KB_PAUSE, "KB_PAUSE" },
++	{ BTN_KB_INS, "KB_INS" },
++	{ BTN_KB_HOME, "KB_HOME" },
++	{ BTN_KB_PGUP, "KB_PGUP" },
++	{ BTN_KB_DEL, "KB_DEL" },
++	{ BTN_KB_END, "KB_END" },
++	{ BTN_KB_PGDWN, "KB_PGDWN" },
++	{ BTN_KB_UP_ARROW, "KB_UP_ARROW" },
++	{ BTN_KB_DOWN_ARROW, "KB_DOWN_ARROW" },
++	{ BTN_KB_LEFT_ARROW, "KB_LEFT_ARROW" },
++	{ BTN_KB_RIGHT_ARROW, "KB_RIGHT_ARROW" },
++
++	/* Numpad mappings */
++	{ BTN_NUMPAD_LOCK, "NUMPAD_LOCK" },
++	{ BTN_NUMPAD_FWDSLASH, "NUMPAD_FWDSLASH" },
++	{ BTN_NUMPAD_ASTERISK, "NUMPAD_ASTERISK" },
++	{ BTN_NUMPAD_HYPHEN, "NUMPAD_HYPHEN" },
++	{ BTN_NUMPAD_0, "NUMPAD_0" },
++	{ BTN_NUMPAD_1, "NUMPAD_1" },
++	{ BTN_NUMPAD_2, "NUMPAD_2" },
++	{ BTN_NUMPAD_3, "NUMPAD_3" },
++	{ BTN_NUMPAD_4, "NUMPAD_4" },
++	{ BTN_NUMPAD_5, "NUMPAD_5" },
++	{ BTN_NUMPAD_6, "NUMPAD_6" },
++	{ BTN_NUMPAD_7, "NUMPAD_7" },
++	{ BTN_NUMPAD_8, "NUMPAD_8" },
++	{ BTN_NUMPAD_9, "NUMPAD_9" },
++	{ BTN_NUMPAD_PLUS, "NUMPAD_PLUS" },
++	{ BTN_NUMPAD_ENTER, "NUMPAD_ENTER" },
++	{ BTN_NUMPAD_PERIOD, "NUMPAD_PERIOD" },
++
++	/* Mouse mappings */
++	{ BTN_MOUSE_LCLICK, "MOUSE_LCLICK" },
++	{ BTN_MOUSE_RCLICK, "MOUSE_RCLICK" },
++	{ BTN_MOUSE_MCLICK, "MOUSE_MCLICK" },
++	{ BTN_MOUSE_WHEEL_UP, "MOUSE_WHEEL_UP" },
++	{ BTN_MOUSE_WHEEL_DOWN, "MOUSE_WHEEL_DOWN" },
++
++	/* Media mappings */
++	{ BTN_MEDIA_SCREENSHOT, "MEDIA_SCREENSHOT" },
++	{ BTN_MEDIA_SHOW_KEYBOARD, "MEDIA_SHOW_KEYBOARD" },
++	{ BTN_MEDIA_SHOW_DESKTOP, "MEDIA_SHOW_DESKTOP" },
++	{ BTN_MEDIA_START_RECORDING, "MEDIA_START_RECORDING" },
++	{ BTN_MEDIA_MIC_OFF, "MEDIA_MIC_OFF" },
++	{ BTN_MEDIA_VOL_DOWN, "MEDIA_VOL_DOWN" },
++	{ BTN_MEDIA_VOL_UP, "MEDIA_VOL_UP" },
++};
++static const size_t keymap_len = ARRAY_SIZE(ally_btn_codes);
++
++/* byte_array must be >= 8 in length */
++static void btn_code_to_byte_array(u64 keycode, u8 *byte_array)
++{
++	/* Convert the u64 to bytes[8] */
++	for (int i = 0; i < 8; ++i) {
++		byte_array[i] = (keycode >> (56 - 8 * i)) & 0xFF;
++	}
++}
++
++static u64 name_to_btn(const char *name)
++{
++	int len = strcspn(name, "\n");
++	for (size_t i = 0; i < keymap_len; ++i) {
++		if (strncmp(ally_btn_codes[i].name, name, len) == 0) {
++			return ally_btn_codes[i].code;
++		}
++	}
++	return -EINVAL;
++}
++
++static const char* btn_to_name(u64 key)
++{
++	for (size_t i = 0; i < keymap_len; ++i) {
++		if (ally_btn_codes[i].code == key) {
++			return ally_btn_codes[i].name;
++		}
++	}
++	return NULL;
++}
++
++struct btn_data {
++	u64 button;
++	u64 macro;
++	bool turbo;
++};
++
++struct btn_mapping {
++	struct btn_data btn_a;
++	struct btn_data btn_b;
++	struct btn_data btn_x;
++	struct btn_data btn_y;
++	struct btn_data btn_lb;
++	struct btn_data btn_rb;
++	struct btn_data btn_ls;
++	struct btn_data btn_rs;
++	struct btn_data btn_lt;
++	struct btn_data btn_rt;
++	struct btn_data dpad_up;
++	struct btn_data dpad_down;
++	struct btn_data dpad_left;
++	struct btn_data dpad_right;
++	struct btn_data btn_view;
++	struct btn_data btn_menu;
++	struct btn_data btn_m1;
++	struct btn_data btn_m2;
++};
++
++struct deadzone {
++	u8 inner;
++	u8 outer;
++};
++
++struct response_curve {
++	uint8_t move_pct_1;
++	uint8_t response_pct_1;
++	uint8_t move_pct_2;
++	uint8_t response_pct_2;
++	uint8_t move_pct_3;
++	uint8_t response_pct_3;
++	uint8_t move_pct_4;
++	uint8_t response_pct_4;
++} __packed;
++
++struct js_axis_calibrations {
++	uint16_t left_y_stable;
++	uint16_t left_y_min;
++	uint16_t left_y_max;
++	uint16_t left_x_stable;
++	uint16_t left_x_min;
++	uint16_t left_x_max;
++	uint16_t right_y_stable;
++	uint16_t right_y_min;
++	uint16_t right_y_max;
++	uint16_t right_x_stable;
++	uint16_t right_x_min;
++	uint16_t right_x_max;
++} __packed;
++
++struct tr_axis_calibrations {
++	uint16_t left_stable;
++	uint16_t left_max;
++	uint16_t right_stable;
++	uint16_t right_max;
++} __packed;
++
++/* ROG Ally has many settings related to the gamepad, all using the same n-key endpoint */
++struct ally_gamepad_cfg {
++	struct hid_device *hdev;
++	struct input_dev *input;
++
++	enum xpad_mode mode;
++	/*
++	 * index: [mode]
++	 */
++	struct btn_mapping key_mapping[xpad_mode_mouse];
++	/*
++	 * index: left, right
++	 * max: 64
++	 */
++	u8 vibration_intensity[2];
++
++	/* deadzones */
++	struct deadzone ls_dz; // left stick
++	struct deadzone rs_dz; // right stick
++	struct deadzone lt_dz; // left trigger
++	struct deadzone rt_dz; // right trigger
++	/* anti-deadzones */
++	u8 ls_adz; // left stick
++	u8 rs_adz; // right stick
++	/* joystick response curves */
++	struct response_curve ls_rc;
++	struct response_curve rs_rc;
++
++	struct js_axis_calibrations js_cal;
++	struct tr_axis_calibrations tr_cal;
++};
++
++/* The hatswitch outputs integers, we use them to index this X|Y pair */
++static const int hat_values[][2] = {
++	{ 0, 0 }, { 0, -1 }, { 1, -1 }, { 1, 0 },   { 1, 1 },
++	{ 0, 1 }, { -1, 1 }, { -1, 0 }, { -1, -1 },
++};
++
++/* rumble packet structure */
++struct ff_data {
++	u8 enable;
++	u8 magnitude_left;
++	u8 magnitude_right;
++	u8 magnitude_strong;
++	u8 magnitude_weak;
++	u8 pulse_sustain_10ms;
++	u8 pulse_release_10ms;
++	u8 loop_count;
++} __packed;
++
++struct ff_report {
++	u8 report_id;
++	struct ff_data ff;
++} __packed;
++
++struct ally_x_input_report {
++	uint16_t x, y;
++	uint16_t rx, ry;
++	uint16_t z, rz;
++	uint8_t buttons[4];
++} __packed;
++
++struct ally_x_device {
++	struct input_dev *input;
++	struct hid_device *hdev;
++	spinlock_t lock;
++
++	struct ff_report *ff_packet;
++	struct work_struct output_worker;
++	bool output_worker_initialized;
++	/* Prevent multiple queued event due to the enforced delay in worker */
++	bool update_qam_btn;
++	/* Set if the QAM and AC buttons emit Xbox and Xbox+A */
++	bool qam_btns_steam_mode;
++	bool update_ff;
++};
++
++struct ally_rgb_dev {
++	struct hid_device *hdev;
++	struct led_classdev_mc led_rgb_dev;
++	struct work_struct work;
++	bool output_worker_initialized;
++	spinlock_t lock;
++
++	bool removed;
++	bool update_rgb;
++	uint8_t red[4];
++	uint8_t green[4];
++	uint8_t blue[4];
++};
++
++struct ally_rgb_data {
++	uint8_t brightness;
++	uint8_t red[4];
++	uint8_t green[4];
++	uint8_t blue[4];
++	bool initialized;
++};
++
++static struct ally_drvdata {
++	struct hid_device *hdev;
++	struct ally_x_device *ally_x;
++	struct ally_gamepad_cfg *gamepad_cfg;
++	struct ally_rgb_dev *led_rgb_dev;
++	struct ally_rgb_data led_rgb_data;
++	uint mcu_version;
++} drvdata;
++
++static void reverse_bytes_in_pairs(u8 *buf, size_t size) {
++	uint16_t *word_ptr;
++	size_t i;
++
++	for (i = 0; i < size; i += 2) {
++		if (i + 1 < size) {
++			word_ptr = (uint16_t *)&buf[i];
++			*word_ptr = cpu_to_be16(*word_ptr);
++		}
++	}
++}
++
++/**
++ * asus_dev_set_report - send set report request to device.
++ *
++ * @hdev: hid device
++ * @buf: in/out data to transfer
++ * @len: length of buf
++ *
++ * Return: count of data transferred, negative if error
++ *
++ * Same behavior as hid_hw_raw_request. Note that the input buffer is duplicated.
++ */
++static int asus_dev_set_report(struct hid_device *hdev, const u8 *buf, size_t len)
 +{
 +	unsigned char *dmabuf;
 +	int ret;
@@ -3034,167 +1055,81 @@ index 000000000000..1e8f98b69332
 +		return -ENOMEM;
 +
 +	ret = hid_hw_raw_request(hdev, buf[0], dmabuf, len, HID_FEATURE_REPORT,
-+					HID_REQ_SET_REPORT);
++				 HID_REQ_SET_REPORT);
 +	kfree(dmabuf);
 +
 +	return ret;
 +}
 +
-+static inline int asus_dev_get_report(struct hid_device *hdev, u8 *out, size_t len)
++/**
++ * asus_dev_get_report - send get report request to device.
++ *
++ * @hdev: hid device
++ * @out: buffer to write output data in to
++ * @len: length the output buffer provided
++ *
++ * Return: count of data transferred, negative if error
++ *
++ * Same behavior as hid_hw_raw_request.
++ */
++static int asus_dev_get_report(struct hid_device *hdev, u8 *out, size_t len)
 +{
-+	return hid_hw_raw_request(hdev, HID_ALLY_GET_REPORT_ID, out, len,
++	return hid_hw_raw_request(hdev, FEATURE_REPORT_ID, out, len,
 +		HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
 +}
 +
-+/**
-+ * ally_gamepad_send_packet - Send a raw packet to the gamepad device.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @buf: Buffer containing the packet data
-+ * @len: Length of data to send
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_packet(struct ally_handheld *ally,
-+			     struct hid_device *hdev, const u8 *buf, size_t len)
++static u8 get_endpoint_address(struct hid_device *hdev)
 +{
-+	int ret;
++	struct usb_interface *intf;
++	struct usb_host_endpoint *ep;
 +
-+	mutex_lock(&ally->intf_mutex);
-+	ret = asus_dev_set_report(hdev, buf, len);
-+	mutex_unlock(&ally->intf_mutex);
++	intf = to_usb_interface(hdev->dev.parent);
 +
-+	return ret;
-+}
-+
-+/**
-+ * ally_gamepad_send_receive_packet - Send packet and receive response.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @buf: Buffer containing the packet data to send and receive response in
-+ * @len: Length of buffer
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_receive_packet(struct ally_handheld *ally,
-+				     struct hid_device *hdev, u8 *buf,
-+				     size_t len)
-+{
-+	int ret;
-+
-+	mutex_lock(&ally->intf_mutex);
-+	ret = asus_dev_set_report(hdev, buf, len);
-+	if (ret >= 0) {
-+		memset(buf, 0, len);
-+		ret = asus_dev_get_report(hdev, buf, len);
++	if (intf) {
++		ep = intf->cur_altsetting->endpoint;
++		if (ep) {
++			return ep->desc.bEndpointAddress;
++		}
 +	}
-+	mutex_unlock(&ally->intf_mutex);
 +
-+	return ret;
++	return -ENODEV;
 +}
 +
-+/**
-+ * ally_gamepad_send_one_byte_packet - Send a one-byte payload packet.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @command: Command code
-+ * @param: Parameter byte
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_one_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command, u8 param)
-+{
-+	u8 *packet;
-+	int ret;
++/**************************************************************************************************/
++/* ROG Ally gamepad configuration                                                                 */
++/**************************************************************************************************/
 +
-+	packet = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
-+	if (!packet)
-+		return -ENOMEM;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = command;
-+	packet[3] = 0x01; /* Length */
-+	packet[4] = param;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	kfree(packet);
-+	return ret;
-+}
-+
-+/**
-+ * ally_gamepad_send_two_byte_packet - Send a two-byte payload packet.
-+ *
-+ * @ally: ally handheld structure
-+ * @hdev: hid device
-+ * @command: Command code
-+ * @param1: First parameter byte
-+ * @param2: Second parameter byte
-+ *
-+ * Return: count of data transferred, negative if error
-+ */
-+int ally_gamepad_send_two_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command,
-+				      u8 param1, u8 param2)
-+{
-+	u8 *packet;
-+	int ret;
-+
-+	packet = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
-+	if (!packet)
-+		return -ENOMEM;
-+
-+	packet[0] = HID_ALLY_SET_REPORT_ID;
-+	packet[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+	packet[2] = command;
-+	packet[3] = 0x02; /* Length */
-+	packet[4] = param1;
-+	packet[5] = param2;
-+
-+	ret = ally_gamepad_send_packet(ally, hdev, packet,
-+				       HID_ALLY_REPORT_SIZE);
-+	kfree(packet);
-+	return ret;
-+}
-+
-+/*
-+ * This should be called before any remapping attempts, and on driver init/resume.
-+ */
-+int ally_gamepad_check_ready(struct hid_device *hdev)
++/* This should be called before any attempts to set device functions */
++static int ally_gamepad_check_ready(struct hid_device *hdev)
 +{
 +	int ret, count;
 +	u8 *hidbuf;
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
 +
-+	hidbuf = kzalloc(HID_ALLY_REPORT_SIZE, GFP_KERNEL);
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
 +	if (!hidbuf)
 +		return -ENOMEM;
 +
 +	ret = 0;
 +	for (count = 0; count < READY_MAX_TRIES; count++) {
-+		hidbuf[0] = HID_ALLY_SET_REPORT_ID;
-+		hidbuf[1] = HID_ALLY_FEATURE_CODE_PAGE;
-+		hidbuf[2] = CMD_CHECK_READY;
++		hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++		hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++		hidbuf[2] = xpad_cmd_check_ready;
 +		hidbuf[3] = 01;
++		ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0)
++			hid_dbg(hdev, "ROG Ally check failed set report: %d\n", ret);
 +
-+		ret = ally_gamepad_send_receive_packet(ally, hdev, hidbuf,
-+						       HID_ALLY_REPORT_SIZE);
-+		if (ret < 0) {
-+			hid_err(hdev, "ROG Ally check failed: %d\n", ret);
-+			continue;
-+		}
++		hidbuf[0] = hidbuf[1] = hidbuf[2] = hidbuf[3] = 0;
++		ret = asus_dev_get_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0)
++			hid_dbg(hdev, "ROG Ally check failed get report: %d\n", ret);
 +
-+		ret = hidbuf[2] == CMD_CHECK_READY;
++		ret = hidbuf[2] == xpad_cmd_check_ready;
 +		if (ret)
 +			break;
-+		usleep_range(1000, 2000);
++		usleep_range(
++			1000,
++			2000); /* don't spam the entire loop in less than USB response time */
 +	}
 +
 +	if (count == READY_MAX_TRIES)
@@ -3204,492 +1139,899 @@ index 000000000000..1e8f98b69332
 +	return ret;
 +}
 +
-+u8 get_endpoint_address(struct hid_device *hdev)
++/* VIBRATION INTENSITY ****************************************************************************/
++static ssize_t gamepad_vibration_intensity_index_show(struct device *dev,
++						      struct device_attribute *attr, char *buf)
 +{
-+	struct usb_host_endpoint *ep;
-+	struct usb_interface *intf;
-+
-+	intf = to_usb_interface(hdev->dev.parent);
-+	if (!intf || !intf->cur_altsetting)
-+		return -ENODEV;
-+
-+	ep = intf->cur_altsetting->endpoint;
-+	if (!ep)
-+		return -ENODEV;
-+
-+	return ep->desc.bEndpointAddress;
++	return sysfs_emit(buf, "left right\n");
 +}
 +
-+/**************************************************************************************************/
-+/* ROG Ally driver init                                                                           */
-+/**************************************************************************************************/
++ALLY_DEVICE_ATTR_RO(gamepad_vibration_intensity_index, vibration_intensity_index);
 +
-+static int cad_sequence_state = 0;
-+static unsigned long cad_last_event_time = 0;
-+
-+/* Ally left buton emits a sequence of events: ctrl+alt+del. Capture this and emit only a single code */
-+static bool handle_ctrl_alt_del(struct hid_device *hdev, u8 *data, int size)
++static ssize_t _gamepad_apply_intensity(struct hid_device *hdev,
++					struct ally_gamepad_cfg *ally_cfg)
 +{
-+	if (size < 16 || data[0] != 0x01)
-+		return false;
-+
-+	if (cad_sequence_state > 0 && time_after(jiffies, cad_last_event_time + msecs_to_jiffies(100)))
-+		cad_sequence_state = 0;
-+
-+	cad_last_event_time = jiffies;
-+
-+	switch (cad_sequence_state) {
-+	case 0:
-+		if (data[1] == 0x01 && data[2] == 0x00 && data[3] == 0x00) {
-+			cad_sequence_state = 1;
-+			data[1] = 0x00;
-+			return true;
-+		}
-+		break;
-+	case 1:
-+		if (data[1] == 0x05 && data[2] == 0x00 && data[3] == 0x00) {
-+			cad_sequence_state = 2;
-+			data[1] = 0x00;
-+			return true;
-+		}
-+		break;
-+	case 2:
-+		if (data[1] == 0x05 && data[2] == 0x00 && data[3] == 0x4c) {
-+			cad_sequence_state = 3;
-+			data[1] = 0x00;
-+			data[3] = 0x6F; // F20;
-+			return true;
-+		}
-+		break;
-+	case 3:
-+		if (data[1] == 0x04 && data[2] == 0x00 && data[3] == 0x4c) {
-+			cad_sequence_state = 4;
-+			data[1] = 0x00;
-+			data[1] = data[3] = 0x00;
-+			return true;
-+		}
-+		break;
-+	case 4:
-+		if (data[1] == 0x00 && data[2] == 0x00 && data[3] == 0x4c) {
-+			cad_sequence_state = 5;
-+			data[3] = 0x00;
-+			return true;
-+		}
-+		break;
-+	}
-+	cad_sequence_state = 0;
-+	return false;
-+}
-+
-+static bool handle_ally_event(struct hid_device *hdev, u8 *data, int size)
-+{
-+	struct input_dev *keyboard_input;
-+	int keycode = 0;
-+
-+	if (data[0] == 0x5A) {
-+		switch (data[1]) {
-+		case 0x38:
-+			keycode = KEY_F19;
-+			break;
-+		case 0xA6:
-+			keycode = KEY_F16;
-+			break;
-+		case 0xA7:
-+			keycode = KEY_F17;
-+			break;
-+		case 0xA8:
-+			keycode = KEY_F18;
-+			break;
-+		default:
-+			return false;
-+		}
-+
-+		keyboard_input = ally_drvdata.keyboard_input;
-+		if (keyboard_input) {
-+			input_report_key(keyboard_input, keycode, 1);
-+			input_sync(keyboard_input);
-+			input_report_key(keyboard_input, keycode, 0);
-+			input_sync(keyboard_input);
-+			return true;
-+		}
-+
-+		memset(data, 0, size);
-+	}
-+	return false;
-+}
-+
-+static int ally_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data,
-+					int size)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x;
-+	int ep;
-+
-+	if (!ally)
-+		return -ENODEV;
-+
-+	ep = get_endpoint_address(hdev);
-+	if (ep != HID_ALLY_INTF_CFG_IN && ep != HID_ALLY_X_INTF_IN && ep != HID_ALLY_KEYBOARD_INTF_IN)
-+		return 0;
-+
-+	ally_x = ally->ally_x_input;
-+	if (ally_x) {
-+		if ((hdev->bus == BUS_USB && report->id == HID_ALLY_X_INPUT_REPORT &&
-+		   size == HID_ALLY_X_INPUT_REPORT_SIZE) ||
-+		   (data[0] == 0x5A)) {
-+			if (ally_x_raw_event(ally_x, report, data, size))
-+				return 0;
-+		}
-+	}
-+
-+	switch (ep) {
-+	case HID_ALLY_INTF_CFG_IN:
-+		if (handle_ally_event(hdev, data, size))
-+			return 0;
-+		break;
-+	case HID_ALLY_KEYBOARD_INTF_IN:
-+		if (handle_ctrl_alt_del(hdev, data, size))
-+			return 0;
-+		break;
-+	}
-+
-+	return 0;
-+}
-+
-+static int ally_hid_init(struct hid_device *hdev)
-+{
++	u8 *hidbuf;
 +	int ret;
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, EC_INIT_STRING, sizeof(EC_INIT_STRING));
-+	if (ret < 0) {
-+		hid_err(hdev, "Ally failed to send init command: %d\n", ret);
-+		goto cleanup;
-+	}
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
 +
-+	/* All gamepad configuration commands must go after the ally_gamepad_check_ready() */
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_vibe_intensity;
++	hidbuf[3] = xpad_cmd_len_vibe_intensity;
++	hidbuf[4] = ally_cfg->vibration_intensity[0];
++	hidbuf[5] = ally_cfg->vibration_intensity[1];
++
 +	ret = ally_gamepad_check_ready(hdev);
 +	if (ret < 0)
-+		goto cleanup;
++		goto report_fail;
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, FORCE_FEEDBACK_OFF, sizeof(FORCE_FEEDBACK_OFF));
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
 +	if (ret < 0)
-+		hid_err(hdev, "Ally failed to init force-feedback off: %d\n", ret);
++		goto report_fail;
 +
-+cleanup:
++report_fail:
++	kfree(hidbuf);
 +	return ret;
 +}
 +
-+static int ally_input_configured(struct hid_device *hdev, struct hid_input *hi)
++static ssize_t gamepad_vibration_intensity_show(struct device *dev,
++						struct device_attribute *attr, char *buf)
 +{
-+	int ep = get_endpoint_address(hdev);
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
 +
-+	hid_info(hdev, "Input configured: endpoint 0x%02x, name: %s\n", ep, hi->input->name);
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
 +
-+	if (ep == HID_ALLY_KEYBOARD_INTF_IN)
-+		hi->input->name = ally_keyboard_name;
-+
-+	if (ep == HID_ALLY_MOUSE_INTF_IN)
-+		hi->input->name = ally_mouse_name;
-+
-+	return 0;
++	return sysfs_emit(
++		buf, "%d %d\n",
++		ally_cfg->vibration_intensity[0],
++		ally_cfg->vibration_intensity[1]);
 +}
 +
-+static int ally_hid_probe(struct hid_device *hdev, const struct hid_device_id *_id)
++static ssize_t gamepad_vibration_intensity_store(struct device *dev,
++						 struct device_attribute *attr, const char *buf,
++						 size_t count)
 +{
-+	int ret, ep;
-+
-+	ep = get_endpoint_address(hdev);
-+	if (ep < 0)
-+		return ep;
-+
-+	/*** CRITICAL START ***/
-+	mutex_lock(&ally_data_mutex);
-+	if (ep == HID_ALLY_INTF_CFG_IN)
-+		ally_drvdata.cfg_hdev = hdev;
-+	if (ep == HID_ALLY_KEYBOARD_INTF_IN)
-+		ally_drvdata.keyboard_hdev = hdev;
-+	mutex_unlock(&ally_data_mutex);
-+	/*** CRITICAL END ***/
-+
-+	hid_set_drvdata(hdev, &ally_drvdata);
-+
-+	ret = hid_parse(hdev);
-+	if (ret) {
-+		hid_err(hdev, "Parse failed\n");
-+		return ret;
-+	}
-+
-+	if (ep == HID_ALLY_INTF_CFG_IN || ep == HID_ALLY_X_INTF_IN) {
-+		ret = hid_hw_start(hdev, HID_CONNECT_HIDRAW);
-+	} else if (ep == HID_ALLY_KEYBOARD_INTF_IN) {
-+		ret = hid_hw_start(hdev, HID_CONNECT_HIDINPUT | HID_CONNECT_HIDRAW);
-+		if (!list_empty(&hdev->inputs)) {
-+			struct hid_input *hidinput = list_first_entry(&hdev->inputs, struct hid_input, list);
-+			ally_drvdata.keyboard_input = hidinput->input;
-+		}
-+		hid_info(hdev, "Connected keyboard interface with input events\n");
-+	} else {
-+		ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
-+		hid_info(hdev, "Passing through HID events for endpoint: 0x%02x\n", ep);
-+		return 0;
-+	}
-+
-+	ret = hid_hw_open(hdev);
-+	if (ret) {
-+		hid_err(hdev, "Failed to open HID device\n");
-+		goto err_stop;
-+	}
-+
-+	/* Initialize MCU even before alloc */
-+	ret = ally_hid_init(hdev);
-+	if (ret < 0)
-+		goto err_close;
-+
-+	if (ep == HID_ALLY_INTF_CFG_IN) {
-+		ret = ally_config_create(hdev, &ally_drvdata);
-+		if (ret < 0)
-+			hid_err(hdev, "Failed to create Ally configuration interface.\n");
-+		else
-+			hid_info(hdev, "Created Ally configuration interface.\n");
-+
-+		ret = ally_rgb_create(hdev, &ally_drvdata);
-+		if (ret < 0)
-+			hid_err(hdev, "Failed to create Ally gamepad LEDs.\n");
-+		else
-+			hid_info(hdev, "Created Ally RGB LED controls.\n");
-+	}
-+
-+	if (ep == HID_ALLY_X_INTF_IN) {
-+		ret = ally_x_create(hdev, &ally_drvdata);
-+		if (ret < 0) {
-+			hid_err(hdev, "Failed to create Ally X gamepad device.\n");
-+			ally_drvdata.ally_x_input = NULL;
-+			goto err_close;
-+		} else {
-+			hid_info(hdev, "Created Ally X gamepad device.\n");
-+		}
-+		// Not required since we send this inputs ep through the gamepad input dev
-+		// if (drvdata.gamepad_cfg && drvdata.gamepad_cfg->input) {
-+		// 	input_unregister_device(drvdata.gamepad_cfg->input);
-+		// 	hid_info(hdev, "Ally X removed unrequired input dev.\n");
-+		// }
-+	}
-+
-+	return 0;
-+
-+err_close:
-+	hid_hw_close(hdev);
-+err_stop:
-+	hid_hw_stop(hdev);
-+	return ret;
-+}
-+
-+static void ally_hid_remove(struct hid_device *hdev)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+
-+	if (!ally)
-+		goto out;
-+
-+	if (ally->led_rgb_dev)
-+		ally_rgb_remove(hdev, ally);
-+
-+	if (ally->config)
-+		ally_config_remove(hdev, ally);
-+
-+	if (ally->ally_x_input)
-+		ally_x_remove(hdev, ally);
-+
-+out:
-+	hid_hw_close(hdev);
-+	hid_hw_stop(hdev);
-+}
-+
-+static int ally_hid_reset_resume(struct hid_device *hdev)
-+{
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
++	struct hid_device *hdev = to_hid_device(dev);
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	u32 left, right;
 +	int ret;
 +
-+	if (!ally)
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	if (sscanf(buf, "%d %d", &left, &right) != 2)
 +		return -EINVAL;
 +
-+	int ep = get_endpoint_address(hdev);
-+	if (ep != HID_ALLY_INTF_CFG_IN)
-+		return 0;
++	if (left > 64 || right > 64)
++		return -EINVAL;
 +
-+	ret = ally_hid_init(hdev);
++	ally_cfg->vibration_intensity[0] = left;
++	ally_cfg->vibration_intensity[1] = right;
++
++	ret = _gamepad_apply_intensity(hdev, ally_cfg);
 +	if (ret < 0)
 +		return ret;
 +
-+	ally_rgb_resume(ally);
-+
-+	return 0;
++	return count;
 +}
 +
-+static int ally_pm_thaw(struct device *dev)
-+{
-+	struct hid_device *hdev = to_hid_device(dev);
++ALLY_DEVICE_ATTR_RW(gamepad_vibration_intensity, vibration_intensity);
 +
-+	if (!hdev)
++/* ANALOGUE DEADZONES *****************************************************************************/
++static ssize_t _gamepad_apply_deadzones(struct hid_device *hdev,
++				       struct ally_gamepad_cfg *ally_cfg)
++{
++	u8 *hidbuf;
++	int ret;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		return ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_js_dz;
++	hidbuf[3] = xpad_cmd_len_deadzone;
++	hidbuf[4] = ally_cfg->ls_dz.inner;
++	hidbuf[5] = ally_cfg->ls_dz.outer;
++	hidbuf[6] = ally_cfg->rs_dz.inner;
++	hidbuf[7] = ally_cfg->rs_dz.outer;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto end;
++
++	hidbuf[2] = xpad_cmd_set_tr_dz;
++	hidbuf[4] = ally_cfg->lt_dz.inner;
++	hidbuf[5] = ally_cfg->lt_dz.outer;
++	hidbuf[6] = ally_cfg->rt_dz.inner;
++	hidbuf[7] = ally_cfg->rt_dz.outer;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto end;
++
++end:
++	kfree(hidbuf);
++	return ret;
++}
++
++static void _gamepad_set_deadzones_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	ally_cfg->ls_dz.inner = 0x00;
++	ally_cfg->ls_dz.outer = 0x64;
++	ally_cfg->rs_dz.inner = 0x00;
++	ally_cfg->rs_dz.outer = 0x64;
++	ally_cfg->lt_dz.inner = 0x00;
++	ally_cfg->lt_dz.outer = 0x64;
++	ally_cfg->rt_dz.inner = 0x00;
++	ally_cfg->rt_dz.outer = 0x64;
++}
++
++static ssize_t axis_xyz_deadzone_index_show(struct device *dev, struct device_attribute *attr,
++					    char *buf)
++{
++	return sysfs_emit(buf, "inner outer\n");
++}
++
++ALLY_DEVICE_ATTR_RO(axis_xyz_deadzone_index, deadzone_index);
++
++ALLY_DEADZONES(axis_xy_left, ls_dz);
++ALLY_DEADZONES(axis_xy_right, rs_dz);
++ALLY_DEADZONES(axis_z_left, lt_dz);
++ALLY_DEADZONES(axis_z_right, rt_dz);
++
++/* ANTI-DEADZONES *********************************************************************************/
++static ssize_t _gamepad_apply_js_ADZ(struct hid_device *hdev,
++					     struct ally_gamepad_cfg *ally_cfg)
++{
++	u8 *hidbuf;
++	int ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_adz;
++	hidbuf[3] = xpad_cmd_len_adz;
++	hidbuf[4] = ally_cfg->ls_adz;
++	hidbuf[5] = ally_cfg->rs_adz;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto report_fail;
++
++report_fail:
++	kfree(hidbuf);
++	return ret;
++}
++
++static void _gamepad_set_anti_deadzones_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	ally_cfg->ls_adz = 0x00;
++	ally_cfg->rs_adz = 0x00;
++}
++
++static ssize_t _gamepad_js_ADZ_store(struct device *dev, const char *buf, u8 *adz)
++{
++	int ret, val;
++
++	ret = kstrtoint(buf, 0, &val);
++	if (ret)
++		return ret;
++
++	if (val < 0 || val > 32)
 +		return -EINVAL;
 +
-+	return ally_hid_reset_resume(hdev);
++	*adz = val;
++
++	return ret;
 +}
 +
-+static int ally_pm_prepare(struct device *dev)
++static ssize_t axis_xy_left_anti_deadzone_show(struct device *dev,
++						struct device_attribute *attr,
++						char *buf)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	return sysfs_emit(buf, "%d\n", ally_cfg->ls_adz);
++}
++
++static ssize_t axis_xy_left_anti_deadzone_store(struct device *dev,
++						struct device_attribute *attr,
++						const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int ret;
++
++	ret = _gamepad_js_ADZ_store(dev, buf, &ally_cfg->ls_adz);
++	if (ret)
++		return ret;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_RW(axis_xy_left_anti_deadzone, anti_deadzone);
++
++static ssize_t axis_xy_right_anti_deadzone_show(struct device *dev,
++						struct device_attribute *attr,
++						char *buf)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	return sysfs_emit(buf, "%d\n", ally_cfg->rs_adz);
++}
++
++static ssize_t axis_xy_right_anti_deadzone_store(struct device *dev,
++						struct device_attribute *attr,
++						const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int ret;
++
++	ret = _gamepad_js_ADZ_store(dev, buf, &ally_cfg->rs_adz);
++	if (ret)
++		return ret;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_RW(axis_xy_right_anti_deadzone, anti_deadzone);
++
++/* JS RESPONSE CURVES *****************************************************************************/
++static void _gamepad_set_js_response_curves_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	struct response_curve *js1_rc = &ally_cfg->ls_rc;
++	struct response_curve *js2_rc = &ally_cfg->rs_rc;
++	js1_rc->move_pct_1 = js2_rc->move_pct_1 = 0x16; // 25%
++	js1_rc->move_pct_2 = js2_rc->move_pct_2 = 0x32; // 50%
++	js1_rc->move_pct_3 = js2_rc->move_pct_3 = 0x48; // 75%
++	js1_rc->move_pct_4 = js2_rc->move_pct_4 = 0x64; // 100%
++	js1_rc->response_pct_1 = js2_rc->response_pct_1 = 0x16;
++	js1_rc->response_pct_2 = js2_rc->response_pct_2 = 0x32;
++	js1_rc->response_pct_3 = js2_rc->response_pct_3 = 0x48;
++	js1_rc->response_pct_4 = js2_rc->response_pct_4 = 0x64;
++}
++
++static ssize_t _gamepad_apply_response_curves(struct hid_device *hdev,
++					      struct ally_gamepad_cfg *ally_cfg)
++{
++	u8 *hidbuf;
++	int ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	memcpy(&hidbuf[2], &ally_cfg->ls_rc, sizeof(ally_cfg->ls_rc));
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	hidbuf[4] = 0x02;
++	memcpy(&hidbuf[5], &ally_cfg->rs_rc, sizeof(ally_cfg->rs_rc));
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto report_fail;
++
++report_fail:
++	kfree(hidbuf);
++	return ret;
++}
++
++ALLY_JS_RC_POINT(axis_xy_left, move, 1);
++ALLY_JS_RC_POINT(axis_xy_left, move, 2);
++ALLY_JS_RC_POINT(axis_xy_left, move, 3);
++ALLY_JS_RC_POINT(axis_xy_left, move, 4);
++ALLY_JS_RC_POINT(axis_xy_left, response, 1);
++ALLY_JS_RC_POINT(axis_xy_left, response, 2);
++ALLY_JS_RC_POINT(axis_xy_left, response, 3);
++ALLY_JS_RC_POINT(axis_xy_left, response, 4);
++
++ALLY_JS_RC_POINT(axis_xy_right, move, 1);
++ALLY_JS_RC_POINT(axis_xy_right, move, 2);
++ALLY_JS_RC_POINT(axis_xy_right, move, 3);
++ALLY_JS_RC_POINT(axis_xy_right, move, 4);
++ALLY_JS_RC_POINT(axis_xy_right, response, 1);
++ALLY_JS_RC_POINT(axis_xy_right, response, 2);
++ALLY_JS_RC_POINT(axis_xy_right, response, 3);
++ALLY_JS_RC_POINT(axis_xy_right, response, 4);
++
++/* CALIBRATIONS ***********************************************************************************/
++static int gamepad_get_calibration(struct hid_device *hdev)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	u8 *hidbuf;
++	int ret, i;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	for (i = 0; i < 2; i++) {
++		hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++		hidbuf[1] = 0xD0;
++		hidbuf[2] = 0x03;
++		hidbuf[3] = i + 1; // 0x01 JS, 0x02 TR
++		hidbuf[4] = 0x20;
++
++		ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0) {
++			hid_warn(hdev, "ROG Ally check failed set report: %d\n", ret);
++			goto cleanup;
++		}
++
++		memset(hidbuf, 0, FEATURE_ROG_ALLY_REPORT_SIZE);
++		ret = asus_dev_get_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++		if (ret < 0 || hidbuf[5] != 1) {
++			hid_warn(hdev, "ROG Ally check failed get report: %d\n", ret);
++			goto cleanup;
++		}
++
++		if (i == 0) {
++			/* Joystick calibration */
++			reverse_bytes_in_pairs(&hidbuf[6], sizeof(struct js_axis_calibrations));
++			ally_cfg->js_cal = *(struct js_axis_calibrations *)&hidbuf[6];
++			print_hex_dump(KERN_INFO, "HID Buffer JS: ", DUMP_PREFIX_OFFSET, 16, 1, hidbuf, 32, true);
++			struct js_axis_calibrations *cal = &drvdata.gamepad_cfg->js_cal;
++			pr_err("LS_CAL: X: %d, Min: %d, Max: %d", cal->left_x_stable, cal->left_x_min, cal->left_x_max);
++			pr_err("LS_CAL: Y: %d, Min: %d, Max: %d", cal->left_y_stable, cal->left_y_min, cal->left_y_max);
++			pr_err("RS_CAL: X: %d, Min: %d, Max: %d", cal->right_x_stable, cal->right_x_min, cal->right_x_max);
++			pr_err("RS_CAL: Y: %d, Min: %d, Max: %d", cal->right_y_stable, cal->right_y_min, cal->right_y_max);
++		} else {
++			/* Trigger calibration */
++			reverse_bytes_in_pairs(&hidbuf[6], sizeof(struct tr_axis_calibrations));
++			ally_cfg->tr_cal = *(struct tr_axis_calibrations *)&hidbuf[6];
++			print_hex_dump(KERN_INFO, "HID Buffer TR: ", DUMP_PREFIX_OFFSET, 16, 1, hidbuf, 32, true);
++		}
++	}
++
++cleanup:
++	kfree(hidbuf);
++	return ret;
++}
++
++static struct attribute *axis_xy_left_attrs[] = {
++	&dev_attr_axis_xy_left_anti_deadzone.attr,
++	&dev_attr_axis_xy_left_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	&dev_attr_axis_xy_left_move_1.attr,
++	&dev_attr_axis_xy_left_move_2.attr,
++	&dev_attr_axis_xy_left_move_3.attr,
++	&dev_attr_axis_xy_left_move_4.attr,
++	&dev_attr_axis_xy_left_response_1.attr,
++	&dev_attr_axis_xy_left_response_2.attr,
++	&dev_attr_axis_xy_left_response_3.attr,
++	&dev_attr_axis_xy_left_response_4.attr,
++	NULL
++};
++static const struct attribute_group axis_xy_left_attr_group = {
++	.name = "axis_xy_left",
++	.attrs = axis_xy_left_attrs,
++};
++
++static struct attribute *axis_xy_right_attrs[] = {
++	&dev_attr_axis_xy_right_anti_deadzone.attr,
++	&dev_attr_axis_xy_right_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	&dev_attr_axis_xy_right_move_1.attr,
++	&dev_attr_axis_xy_right_move_2.attr,
++	&dev_attr_axis_xy_right_move_3.attr,
++	&dev_attr_axis_xy_right_move_4.attr,
++	&dev_attr_axis_xy_right_response_1.attr,
++	&dev_attr_axis_xy_right_response_2.attr,
++	&dev_attr_axis_xy_right_response_3.attr,
++	&dev_attr_axis_xy_right_response_4.attr,
++	NULL
++};
++static const struct attribute_group axis_xy_right_attr_group = {
++	.name = "axis_xy_right",
++	.attrs = axis_xy_right_attrs,
++};
++
++static struct attribute *axis_z_left_attrs[] = {
++	&dev_attr_axis_z_left_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	NULL,
++};
++static const struct attribute_group axis_z_left_attr_group = {
++	.name = "axis_z_left",
++	.attrs = axis_z_left_attrs,
++};
++
++static struct attribute *axis_z_right_attrs[] = {
++	&dev_attr_axis_z_right_deadzone.attr,
++	&dev_attr_axis_xyz_deadzone_index.attr,
++	NULL,
++};
++static const struct attribute_group axis_z_right_attr_group = {
++	.name = "axis_z_right",
++	.attrs = axis_z_right_attrs,
++};
++
++/* A HID packet conatins mappings for two buttons: btn1, btn1_macro, btn2, btn2_macro */
++static void _btn_pair_to_hid_pkt(struct ally_gamepad_cfg *ally_cfg,
++				enum btn_pair_index pair,
++				struct btn_data *btn1, struct btn_data *btn2,
++				u8 *out, int out_len)
++{
++	int start = 5;
++
++	out[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	out[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	out[2] = xpad_cmd_set_mapping;
++	out[3] = pair;
++	out[4] = xpad_cmd_len_mapping;
++
++	btn_code_to_byte_array(btn1->button, &out[start]);
++	start += BTN_DATA_LEN;
++	btn_code_to_byte_array(btn1->macro, &out[start]);
++	start += BTN_DATA_LEN;
++	btn_code_to_byte_array(btn2->button, &out[start]);
++	start += BTN_DATA_LEN;
++	btn_code_to_byte_array(btn2->macro, &out[start]);
++	//print_hex_dump(KERN_DEBUG, "byte_array: ", DUMP_PREFIX_OFFSET, 64, 1, out, 64, false);
++}
++
++/* Apply the mapping pair to the device */
++static int _gamepad_apply_btn_pair(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg,
++				 enum btn_pair_index btn_pair)
++{
++	u8 mode = ally_cfg->mode - 1;
++	struct btn_data *btn1, *btn2;
++	u8 *hidbuf;
++	int ret;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		return ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	switch (btn_pair) {
++	case btn_pair_dpad_u_d:
++		btn1 = &ally_cfg->key_mapping[mode].dpad_up;
++		btn2 = &ally_cfg->key_mapping[mode].dpad_down;
++		break;
++	case btn_pair_dpad_l_r:
++		btn1 = &ally_cfg->key_mapping[mode].dpad_left;
++		btn2 = &ally_cfg->key_mapping[mode].dpad_right;
++		break;
++	case btn_pair_ls_rs:
++		btn1 = &ally_cfg->key_mapping[mode].btn_ls;
++		btn2 = &ally_cfg->key_mapping[mode].btn_rs;
++		break;
++	case btn_pair_lb_rb:
++		btn1 = &ally_cfg->key_mapping[mode].btn_lb;
++		btn2 = &ally_cfg->key_mapping[mode].btn_rb;
++		break;
++	case btn_pair_lt_rt:
++		btn1 = &ally_cfg->key_mapping[mode].btn_lt;
++		btn2 = &ally_cfg->key_mapping[mode].btn_rt;
++		break;
++	case btn_pair_a_b:
++		btn1 = &ally_cfg->key_mapping[mode].btn_a;
++		btn2 = &ally_cfg->key_mapping[mode].btn_b;
++		break;
++	case btn_pair_x_y:
++		btn1 = &ally_cfg->key_mapping[mode].btn_x;
++		btn2 = &ally_cfg->key_mapping[mode].btn_y;
++		break;
++	case btn_pair_view_menu:
++		btn1 = &ally_cfg->key_mapping[mode].btn_view;
++		btn2 = &ally_cfg->key_mapping[mode].btn_menu;
++		break;
++	case btn_pair_m1_m2:
++		btn1 = &ally_cfg->key_mapping[mode].btn_m1;
++		btn2 = &ally_cfg->key_mapping[mode].btn_m2;
++		break;
++	default:
++		break;
++	}
++
++	_btn_pair_to_hid_pkt(ally_cfg, btn_pair, btn1, btn2, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++
++	kfree(hidbuf);
++
++	return ret;
++}
++
++static int _gamepad_apply_turbo(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg)
++{
++	struct btn_mapping *map = &ally_cfg->key_mapping[ally_cfg->mode - 1];
++	u8 *hidbuf;
++	int ret;
++
++	/* set turbo */
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_turbo;
++	hidbuf[3] = xpad_cmd_len_turbo;
++
++	hidbuf[4] = map->dpad_up.turbo;
++	hidbuf[6] = map->dpad_down.turbo;
++	hidbuf[8] = map->dpad_left.turbo;
++	hidbuf[10] = map->dpad_right.turbo;
++
++	hidbuf[12] = map->btn_ls.turbo;
++	hidbuf[14] = map->btn_rs.turbo;
++	hidbuf[16] = map->btn_lb.turbo;
++	hidbuf[18] = map->btn_rb.turbo;
++
++	hidbuf[20] = map->btn_a.turbo;
++	hidbuf[22] = map->btn_b.turbo;
++	hidbuf[24] = map->btn_x.turbo;
++	hidbuf[26] = map->btn_y.turbo;
++
++	hidbuf[28] = map->btn_lt.turbo;
++	hidbuf[30] = map->btn_rt.turbo;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++
++	kfree(hidbuf);
++
++	return ret;
++}
++
++static ssize_t _gamepad_apply_all(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg)
++{
++	int ret;
++
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_dpad_u_d);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_dpad_l_r);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_ls_rs);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_lb_rb);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_a_b);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_x_y);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_view_menu);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_m1_m2);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_lt_rt);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_turbo(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_deadzones(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++	ret = _gamepad_apply_js_ADZ(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++	ret =_gamepad_apply_response_curves(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++
++	return 0;
++}
++
++static ssize_t gamepad_apply_all_store(struct device *dev, struct device_attribute *attr,
++				       const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	struct hid_device *hdev = to_hid_device(dev);
++	int ret;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	ret = _gamepad_apply_all(hdev, ally_cfg);
++	if (ret < 0)
++		return ret;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_WO(gamepad_apply_all, apply_all);
++
++/* button map attributes, regular and macro*/
++ALLY_BTN_MAPPING(m1, btn_m1);
++ALLY_BTN_MAPPING(m2, btn_m2);
++ALLY_BTN_MAPPING(view, btn_view);
++ALLY_BTN_MAPPING(menu, btn_menu);
++ALLY_TURBO_BTN_MAPPING(a, btn_a);
++ALLY_TURBO_BTN_MAPPING(b, btn_b);
++ALLY_TURBO_BTN_MAPPING(x, btn_x);
++ALLY_TURBO_BTN_MAPPING(y, btn_y);
++ALLY_TURBO_BTN_MAPPING(lb, btn_lb);
++ALLY_TURBO_BTN_MAPPING(rb, btn_rb);
++ALLY_TURBO_BTN_MAPPING(ls, btn_ls);
++ALLY_TURBO_BTN_MAPPING(rs, btn_rs);
++ALLY_TURBO_BTN_MAPPING(lt, btn_lt);
++ALLY_TURBO_BTN_MAPPING(rt, btn_rt);
++ALLY_TURBO_BTN_MAPPING(dpad_u, dpad_up);
++ALLY_TURBO_BTN_MAPPING(dpad_d, dpad_down);
++ALLY_TURBO_BTN_MAPPING(dpad_l, dpad_left);
++ALLY_TURBO_BTN_MAPPING(dpad_r, dpad_right);
++
++static void _gamepad_set_xpad_default(struct ally_gamepad_cfg *ally_cfg)
++{
++	struct btn_mapping *map = &ally_cfg->key_mapping[ally_cfg->mode - 1];
++	map->btn_m1.button = BTN_KB_M1;
++	map->btn_m2.button = BTN_KB_M2;
++	map->btn_a.button = BTN_PAD_A;
++	map->btn_b.button = BTN_PAD_B;
++	map->btn_x.button = BTN_PAD_X;
++	map->btn_y.button = BTN_PAD_Y;
++	map->btn_lb.button = BTN_PAD_LB;
++	map->btn_rb.button = BTN_PAD_RB;
++	map->btn_lt.button = BTN_PAD_LT;
++	map->btn_rt.button = BTN_PAD_RT;
++	map->btn_ls.button = BTN_PAD_LS;
++	map->btn_rs.button = BTN_PAD_RS;
++	map->dpad_up.button = BTN_PAD_DPAD_UP;
++	map->dpad_down.button = BTN_PAD_DPAD_DOWN;
++	map->dpad_left.button = BTN_PAD_DPAD_LEFT;
++	map->dpad_right.button = BTN_PAD_DPAD_RIGHT;
++	map->btn_view.button = BTN_PAD_VIEW;
++	map->btn_menu.button = BTN_PAD_MENU;
++}
++
++static ssize_t btn_mapping_reset_store(struct device *dev, struct device_attribute *attr,
++				       const char *buf, size_t count)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	switch (ally_cfg->mode) {
++	case xpad_mode_game:
++		_gamepad_set_xpad_default(ally_cfg);
++		break;
++	default:
++		_gamepad_set_xpad_default(ally_cfg);
++		break;
++	}
++
++	return count;
++}
++ALLY_DEVICE_ATTR_WO(btn_mapping_reset, reset_btn_mapping);
++
++/* GAMEPAD MODE */
++static ssize_t _gamepad_set_mode(struct hid_device *hdev, struct ally_gamepad_cfg *ally_cfg,
++				  int val)
++{
++	u8 *hidbuf;
++	int ret;
++
++	hidbuf = kzalloc(FEATURE_ROG_ALLY_REPORT_SIZE, GFP_KERNEL);
++	if (!hidbuf)
++		return -ENOMEM;
++
++	hidbuf[0] = FEATURE_ROG_ALLY_REPORT_ID;
++	hidbuf[1] = FEATURE_ROG_ALLY_CODE_PAGE;
++	hidbuf[2] = xpad_cmd_set_mode;
++	hidbuf[3] = xpad_cmd_len_mode;
++	hidbuf[4] = val;
++
++	ret = ally_gamepad_check_ready(hdev);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = asus_dev_set_report(hdev, hidbuf, FEATURE_ROG_ALLY_REPORT_SIZE);
++	if (ret < 0)
++		goto report_fail;
++
++	ret = _gamepad_apply_all(hdev, ally_cfg);
++	if (ret < 0)
++		goto report_fail;
++
++report_fail:
++	kfree(hidbuf);
++	return ret;
++}
++
++static ssize_t gamepad_mode_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
++
++	return sysfs_emit(buf, "%d\n", ally_cfg->mode);
++}
++
++static ssize_t gamepad_mode_store(struct device *dev, struct device_attribute *attr,
++				  const char *buf, size_t count)
 +{
 +	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int ret, val;
 +
-+	if (ally->led_rgb_dev) {
-+		ally_rgb_store_settings(ally);
-+	}
++	if (!drvdata.gamepad_cfg)
++		return -ENODEV;
 +
-+	return 0;
++	ret = kstrtoint(buf, 0, &val);
++	if (ret)
++		return ret;
++
++	if (val < xpad_mode_game || val > xpad_mode_mouse)
++		return -EINVAL;
++
++	ally_cfg->mode = val;
++
++	ret = _gamepad_set_mode(hdev, ally_cfg, val);
++	if (ret < 0)
++		return ret;
++
++	return count;
 +}
 +
-+static const struct dev_pm_ops ally_pm_ops = {
-+	.thaw = ally_pm_thaw,
-+	.prepare = ally_pm_prepare,
++DEVICE_ATTR_RW(gamepad_mode);
++
++static ssize_t mcu_version_show(struct device *dev, struct device_attribute *attr, char *buf)
++{
++	return sysfs_emit(buf, "%d\n", drvdata.mcu_version);
++}
++
++DEVICE_ATTR_RO(mcu_version);
++
++/* ROOT LEVEL ATTRS *******************************************************************************/
++static struct attribute *gamepad_device_attrs[] = {
++	&dev_attr_btn_mapping_reset.attr,
++	&dev_attr_gamepad_mode.attr,
++	&dev_attr_gamepad_apply_all.attr,
++	&dev_attr_gamepad_vibration_intensity.attr,
++	&dev_attr_gamepad_vibration_intensity_index.attr,
++	&dev_attr_mcu_version.attr,
++	NULL
 +};
 +
-+MODULE_DEVICE_TABLE(hid, rog_ally_devices);
-+
-+static struct hid_driver rog_ally_cfg = { .name = "asus_rog_ally",
-+		.id_table = rog_ally_devices,
-+		.probe = ally_hid_probe,
-+		.remove = ally_hid_remove,
-+		.raw_event = ally_raw_event,
-+		.input_configured = ally_input_configured,
-+		/* ALLy 1 requires this to reset device state correctly */
-+		.reset_resume = ally_hid_reset_resume,
-+		.driver = {
-+			.pm = &ally_pm_ops,
-+		}
++static const struct attribute_group ally_controller_attr_group = {
++	.attrs = gamepad_device_attrs,
 +};
 +
-+static int __init rog_ally_init(void)
-+{
-+	mutex_init(&ally_drvdata.intf_mutex);
-+	return hid_register_driver(&rog_ally_cfg);
-+}
-+
-+static void __exit rog_ally_exit(void)
-+{
-+	mutex_destroy(&ally_drvdata.intf_mutex);
-+	hid_unregister_driver(&rog_ally_cfg);
-+}
-+
-+module_init(rog_ally_init);
-+module_exit(rog_ally_exit);
-+
-+MODULE_AUTHOR("Luke D. Jones");
-+MODULE_DESCRIPTION("HID Driver for ASUS ROG Ally handeheld.");
-+MODULE_LICENSE("GPL");
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-hid-input.c b/drivers/hid/asus-ally-hid/asus-ally-hid-input.c
-new file mode 100644
-index 000000000000..4fc848d67c23
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-hid-input.c
-@@ -0,0 +1,345 @@
-+// SPDX-License-Identifier: GPL-2.0-or-later
-+/*
-+ *  HID driver for Asus ROG laptops and Ally
-+ *
-+ *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
-+ */
-+
-+#include "linux/delay.h"
-+#include "linux/input-event-codes.h"
-+#include <linux/hid.h>
-+#include <linux/types.h>
-+
-+#include "asus-ally.h"
-+
-+struct ally_x_input_report {
-+	uint16_t x, y;
-+	uint16_t rx, ry;
-+	uint16_t z, rz;
-+	uint8_t buttons[4];
-+} __packed;
-+
-+/* The hatswitch outputs integers, we use them to index this X|Y pair */
-+static const int hat_values[][2] = {
-+	{ 0, 0 }, { 0, -1 }, { 1, -1 }, { 1, 0 },   { 1, 1 },
-+	{ 0, 1 }, { -1, 1 }, { -1, 0 }, { -1, -1 },
++static const struct attribute_group *gamepad_device_attr_groups[] = {
++	&ally_controller_attr_group,
++	&axis_xy_left_attr_group,
++	&axis_xy_right_attr_group,
++	&axis_z_left_attr_group,
++	&axis_z_right_attr_group,
++	&btn_mapping_m1_attr_group,
++	&btn_mapping_m2_attr_group,
++	&btn_mapping_a_attr_group,
++	&btn_mapping_b_attr_group,
++	&btn_mapping_x_attr_group,
++	&btn_mapping_y_attr_group,
++	&btn_mapping_lb_attr_group,
++	&btn_mapping_rb_attr_group,
++	&btn_mapping_ls_attr_group,
++	&btn_mapping_rs_attr_group,
++	&btn_mapping_lt_attr_group,
++	&btn_mapping_rt_attr_group,
++	&btn_mapping_dpad_u_attr_group,
++	&btn_mapping_dpad_d_attr_group,
++	&btn_mapping_dpad_l_attr_group,
++	&btn_mapping_dpad_r_attr_group,
++	&btn_mapping_view_attr_group,
++	&btn_mapping_menu_attr_group,
++	NULL,
 +};
 +
-+static void ally_x_work(struct work_struct *work)
++static struct ally_gamepad_cfg *ally_gamepad_cfg_create(struct hid_device *hdev)
 +{
-+	struct ally_x_input *ally_x = container_of(work, struct ally_x_input, output_worker);
-+	struct ff_report *ff_report = NULL;
-+	bool update_qam_chord = false;
-+	bool update_ff = false;
-+	unsigned long flags;
++	struct ally_gamepad_cfg *ally_cfg;
++	struct input_dev *input_dev;
++	int err;
 +
-+	spin_lock_irqsave(&ally_x->lock, flags);
-+	update_qam_chord = ally_x->update_qam_chord;
++	ally_cfg = devm_kzalloc(&hdev->dev, sizeof(*ally_cfg), GFP_KERNEL);
++	if (!ally_cfg)
++		return ERR_PTR(-ENOMEM);
++	ally_cfg->hdev = hdev;
++	// Allocate memory for each mode's `btn_mapping`
++	ally_cfg->mode = xpad_mode_game;
 +
-+	update_ff = ally_x->update_ff;
-+	if (ally_x->update_ff) {
-+		ff_report = kmemdup(ally_x->ff_packet, sizeof(*ally_x->ff_packet), GFP_KERNEL);
-+		ally_x->update_ff = false;
++	input_dev = devm_input_allocate_device(&hdev->dev);
++	if (!input_dev) {
++		err = -ENOMEM;
++		goto free_ally_cfg;
 +	}
-+	spin_unlock_irqrestore(&ally_x->lock, flags);
 +
-+	if (update_ff && ff_report) {
-+		ff_report->ff.magnitude_left = ff_report->ff.magnitude_strong;
-+		ff_report->ff.magnitude_right = ff_report->ff.magnitude_weak;
-+		ally_gamepad_send_packet(ally_x->ally, ally_x->hdev,
-+					 (u8 *)ff_report, sizeof(*ff_report));
++	input_dev->id.bustype = hdev->bus;
++	input_dev->id.vendor = hdev->vendor;
++	input_dev->id.product = hdev->product;
++	input_dev->id.version = hdev->version;
++	input_dev->uniq = hdev->uniq;
++	input_dev->name = "ASUS ROG Ally Config";
++	input_set_capability(input_dev, EV_KEY, KEY_PROG1);
++	input_set_capability(input_dev, EV_KEY, KEY_F16);
++	input_set_capability(input_dev, EV_KEY, KEY_F17);
++	input_set_capability(input_dev, EV_KEY, KEY_F18);
++	input_set_drvdata(input_dev, hdev);
++
++	err = input_register_device(input_dev);
++	if (err)
++		goto free_input_dev;
++	ally_cfg->input = input_dev;
++
++	/* ignore all errors for this as they are related to USB HID I/O */
++	_gamepad_set_xpad_default(ally_cfg);
++	ally_cfg->key_mapping[ally_cfg->mode - 1].btn_m1.button = BTN_KB_M1;
++	ally_cfg->key_mapping[ally_cfg->mode - 1].btn_m2.button = BTN_KB_M2;
++	_gamepad_apply_btn_pair(hdev, ally_cfg, btn_pair_m1_m2);
++	gamepad_get_calibration(hdev);
++
++	ally_cfg->vibration_intensity[0] = 0x64;
++	ally_cfg->vibration_intensity[1] = 0x64;
++	_gamepad_set_deadzones_default(ally_cfg);
++	_gamepad_set_anti_deadzones_default(ally_cfg);
++	_gamepad_set_js_response_curves_default(ally_cfg);
++
++	drvdata.gamepad_cfg = ally_cfg; // Must asign before attr group setup
++	if (sysfs_create_groups(&hdev->dev.kobj, gamepad_device_attr_groups)) {
++		err = -ENODEV;
++		goto unregister_input_dev;
 +	}
-+	kfree(ff_report);
 +
-+	if (update_qam_chord) {
-+		/*
-+		 * The sleeps here are required to allow steam to register the button combo.
-+		 */
-+		input_report_key(ally_x->input, BTN_MODE, 1);
-+		input_sync(ally_x->input);
-+		msleep(150);
-+		input_report_key(ally_x->input, BTN_A, 1);
-+		input_sync(ally_x->input);
-+		input_report_key(ally_x->input, BTN_A, 0);
-+		input_sync(ally_x->input);
-+		input_report_key(ally_x->input, BTN_MODE, 0);
-+		input_sync(ally_x->input);
++	return ally_cfg;
 +
-+		spin_lock_irqsave(&ally_x->lock, flags);
-+		ally_x->update_qam_chord = false;
-+		spin_unlock_irqrestore(&ally_x->lock, flags);
-+	}
++unregister_input_dev:
++	input_unregister_device(input_dev);
++	ally_cfg->input = NULL; // Prevent double free when kfree(ally_cfg) happens
++
++free_input_dev:
++	devm_kfree(&hdev->dev, input_dev);
++
++free_ally_cfg:
++	devm_kfree(&hdev->dev, ally_cfg);
++	return ERR_PTR(err);
 +}
 +
-+static int ally_x_play_effect(struct input_dev *idev, void *data, struct ff_effect *effect)
++static void ally_cfg_remove(struct hid_device *hdev)
 +{
-+	struct hid_device *hdev = input_get_drvdata(idev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x = ally->ally_x_input;
-+	unsigned long flags;
-+
-+	if (effect->type != FF_RUMBLE)
-+		return 0;
-+
-+	spin_lock_irqsave(&ally_x->lock, flags);
-+	ally_x->ff_packet->ff.magnitude_strong = effect->u.rumble.strong_magnitude / 512;
-+	ally_x->ff_packet->ff.magnitude_weak = effect->u.rumble.weak_magnitude / 512;
-+	ally_x->update_ff = true;
-+	spin_unlock_irqrestore(&ally_x->lock, flags);
-+
-+	if (ally_x->output_worker_initialized)
-+		schedule_work(&ally_x->output_worker);
-+
-+	return 0;
++	// __gamepad_set_mode(hdev, drvdata.gamepad_cfg, xpad_mode_mouse);
++	sysfs_remove_groups(&hdev->dev.kobj, gamepad_device_attr_groups);
 +}
 +
-+/* Return true if event was handled, otherwise false */
-+bool ally_x_raw_event(struct ally_x_input *ally_x, struct hid_report *report, u8 *data,
++/**************************************************************************************************/
++/* ROG Ally gamepad i/o and force-feedback                                                        */
++/**************************************************************************************************/
++static int ally_x_raw_event(struct ally_x_device *ally_x, struct hid_report *report, u8 *data,
 +			    int size)
 +{
 +	struct ally_x_input_report *in_report;
@@ -3699,10 +2041,10 @@ index 000000000000..4fc848d67c23
 +	if (data[0] == 0x0B) {
 +		in_report = (struct ally_x_input_report *)&data[1];
 +
-+		input_report_abs(ally_x->input, ABS_X, in_report->x - 32768);
-+		input_report_abs(ally_x->input, ABS_Y, in_report->y - 32768);
-+		input_report_abs(ally_x->input, ABS_RX, in_report->rx - 32768);
-+		input_report_abs(ally_x->input, ABS_RY, in_report->ry - 32768);
++		input_report_abs(ally_x->input, ABS_X, in_report->x);
++		input_report_abs(ally_x->input, ABS_Y, in_report->y);
++		input_report_abs(ally_x->input, ABS_RX, in_report->rx);
++		input_report_abs(ally_x->input, ABS_RY, in_report->ry);
 +		input_report_abs(ally_x->input, ABS_Z, in_report->z);
 +		input_report_abs(ally_x->input, ABS_RZ, in_report->rz);
 +
@@ -3724,9 +2066,6 @@ index 000000000000..4fc848d67c23
 +		byte = in_report->buttons[2];
 +		input_report_abs(ally_x->input, ABS_HAT0X, hat_values[byte][0]);
 +		input_report_abs(ally_x->input, ABS_HAT0Y, hat_values[byte][1]);
-+		input_sync(ally_x->input);
-+
-+		return true;
 +	}
 +	/*
 +	 * The MCU used on Ally provides many devices: gamepad, keyboord, mouse, other.
@@ -3734,33 +2073,29 @@ index 000000000000..4fc848d67c23
 +	 * use the events unless we grab those and use them here. Only works for Ally X.
 +	 */
 +	else if (data[0] == 0x5A) {
-+		if (ally_x->qam_mode) {
++		if (ally_x->qam_btns_steam_mode) {
 +			spin_lock_irqsave(&ally_x->lock, flags);
-+			/* Right Armoury Crate button */
-+			if (data[1] == 0x38 && !ally_x->update_qam_chord) {
-+				ally_x->update_qam_chord = true;
++			if (data[1] == 0x38 && !ally_x->update_qam_btn) {
++				ally_x->update_qam_btn = true;
 +				if (ally_x->output_worker_initialized)
 +					schedule_work(&ally_x->output_worker);
 +			}
 +			spin_unlock_irqrestore(&ally_x->lock, flags);
-+			/* Left/XBox button */
++			/* Left/XBox button. Long press does ctrl+alt+del which we can't catch */
 +			input_report_key(ally_x->input, BTN_MODE, data[1] == 0xA6);
 +		} else {
-+			/* Right Armoury Crate button */
-+			input_report_key(ally_x->input, KEY_PROG1, data[1] == 0x38);
-+			/* Left/XBox button */
 +			input_report_key(ally_x->input, KEY_F16, data[1] == 0xA6);
++			input_report_key(ally_x->input, KEY_PROG1, data[1] == 0x38);
 +		}
 +		/* QAM long press */
 +		input_report_key(ally_x->input, KEY_F17, data[1] == 0xA7);
 +		/* QAM long press released */
 +		input_report_key(ally_x->input, KEY_F18, data[1] == 0xA8);
-+		input_sync(ally_x->input);
-+
-+		return data[1] == 0xA6 || data[1] == 0xA7 || data[1] == 0xA8 || data[1] == 0x38;
 +	}
 +
-+	return false;
++	input_sync(ally_x->input);
++
++	return 0;
 +}
 +
 +static struct input_dev *ally_x_alloc_input_dev(struct hid_device *hdev,
@@ -3784,56 +2119,91 @@ index 000000000000..4fc848d67c23
 +	return input_dev;
 +}
 +
-+static ssize_t ally_x_qam_mode_show(struct device *dev, struct device_attribute *attr,
-+								char *buf)
++static int ally_x_play_effect(struct input_dev *idev, void *data, struct ff_effect *effect)
 +{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x = ally->ally_x_input;
++	struct ally_x_device *ally_x = drvdata.ally_x;
++	unsigned long flags;
 +
-+	if (!ally_x)
-+		return -ENODEV;
++	if (effect->type != FF_RUMBLE)
++		return 0;
 +
-+	return sysfs_emit(buf, "%d\n", ally_x->qam_mode);
++	spin_lock_irqsave(&ally_x->lock, flags);
++	ally_x->ff_packet->ff.magnitude_strong = effect->u.rumble.strong_magnitude / 512;
++	ally_x->ff_packet->ff.magnitude_weak = effect->u.rumble.weak_magnitude / 512;
++	ally_x->update_ff = true;
++	spin_unlock_irqrestore(&ally_x->lock, flags);
++
++	if (ally_x->output_worker_initialized)
++		schedule_work(&ally_x->output_worker);
++
++	return 0;
 +}
 +
-+static ssize_t ally_x_qam_mode_store(struct device *dev, struct device_attribute *attr,
-+				     const char *buf, size_t count)
++static void ally_x_work(struct work_struct *work)
 +{
-+	struct hid_device *hdev = to_hid_device(dev);
-+	struct ally_handheld *ally = hid_get_drvdata(hdev);
-+	struct ally_x_input *ally_x = ally->ally_x_input;
-+	bool val;
-+	int ret;
++	struct ally_x_device *ally_x = container_of(work, struct ally_x_device, output_worker);
++	struct ff_report *ff_report = NULL;
++	bool update_qam = false;
++	bool update_ff = false;
++	unsigned long flags;
 +
-+	if (!ally_x)
-+		return -ENODEV;
++	spin_lock_irqsave(&ally_x->lock, flags);
++	update_ff = ally_x->update_ff;
++	if (ally_x->update_ff) {
++		ff_report = kmemdup(ally_x->ff_packet, sizeof(*ally_x->ff_packet), GFP_KERNEL);
++		ally_x->update_ff = false;
++	}
++	update_qam = ally_x->update_qam_btn;
++	spin_unlock_irqrestore(&ally_x->lock, flags);
 +
-+	ret = kstrtobool(buf, &val);
-+	if (ret < 0)
-+		return ret;
++	if (update_ff && ff_report) {
++		ff_report->ff.magnitude_left = ff_report->ff.magnitude_strong;
++		ff_report->ff.magnitude_right = ff_report->ff.magnitude_weak;
++		asus_dev_set_report(ally_x->hdev, (u8 *)ff_report, sizeof(*ff_report));
++	}
++	kfree(ff_report);
 +
-+	ally_x->qam_mode = val;
++	if (update_qam) {
++		/*
++		 * The sleeps here are required to allow steam to register the button combo.
++		 */
++		usleep_range(1000, 2000);
++		input_report_key(ally_x->input, BTN_MODE, 1);
++		input_sync(ally_x->input);
 +
-+	return count;
++		msleep(80);
++		input_report_key(ally_x->input, BTN_A, 1);
++		input_sync(ally_x->input);
++
++		msleep(80);
++		input_report_key(ally_x->input, BTN_A, 0);
++		input_sync(ally_x->input);
++
++		msleep(80);
++		input_report_key(ally_x->input, BTN_MODE, 0);
++		input_sync(ally_x->input);
++
++		spin_lock_irqsave(&ally_x->lock, flags);
++		ally_x->update_qam_btn = false;
++		spin_unlock_irqrestore(&ally_x->lock, flags);
++	}
 +}
-+ALLY_DEVICE_ATTR_RW(ally_x_qam_mode, qam_mode);
 +
-+static int ally_x_setup_input(struct hid_device *hdev, struct ally_x_input *ally_x)
++static struct input_dev *ally_x_setup_input(struct hid_device *hdev)
 +{
++	int ret, abs_min = 0, js_abs_max = 65535, tr_abs_max = 1023;
 +	struct input_dev *input;
-+	int ret;
 +
 +	input = ally_x_alloc_input_dev(hdev, NULL);
 +	if (IS_ERR(input))
-+		return PTR_ERR(input);
++		return ERR_CAST(input);
 +
-+	input_set_abs_params(input, ABS_X, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_Y, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_RX, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_RY, -32768, 32767, 0, 0);
-+	input_set_abs_params(input, ABS_Z, 0, 1023, 0, 0);
-+	input_set_abs_params(input, ABS_RZ, 0, 1023, 0, 0);
++	input_set_abs_params(input, ABS_X, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_Y, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_RX, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_RY, abs_min, js_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_Z, abs_min, tr_abs_max, 0, 0);
++	input_set_abs_params(input, ABS_RZ, abs_min, tr_abs_max, 0, 0);
 +	input_set_abs_params(input, ABS_HAT0X, -1, 1, 0, 0);
 +	input_set_abs_params(input, ABS_HAT0Y, -1, 1, 0, 0);
 +	input_set_capability(input, EV_KEY, BTN_A);
@@ -3852,121 +2222,121 @@ index 000000000000..4fc848d67c23
 +	input_set_capability(input, EV_KEY, KEY_F16);
 +	input_set_capability(input, EV_KEY, KEY_F17);
 +	input_set_capability(input, EV_KEY, KEY_F18);
-+	input_set_capability(input, EV_KEY, BTN_TRIGGER_HAPPY);
-+	input_set_capability(input, EV_KEY, BTN_TRIGGER_HAPPY1);
 +
 +	input_set_capability(input, EV_FF, FF_RUMBLE);
 +	input_ff_create_memless(input, NULL, ally_x_play_effect);
 +
 +	ret = input_register_device(input);
-+	if (ret) {
-+		input_unregister_device(input);
-+		return ret;
-+	}
++	if (ret)
++		return ERR_PTR(ret);
 +
-+	ally_x->input = input;
-+
-+	return 0;
++	return input;
 +}
 +
-+int ally_x_create(struct hid_device *hdev, struct ally_handheld *ally)
++static ssize_t ally_x_qam_mode_show(struct device *dev, struct device_attribute *attr,
++				    char *buf)
++{
++	struct ally_x_device *ally_x = drvdata.ally_x;
++
++	return sysfs_emit(buf, "%d\n", ally_x->qam_btns_steam_mode);
++}
++
++static ssize_t ally_x_qam_mode_store(struct device *dev, struct device_attribute *attr,
++				     const char *buf, size_t count)
++{
++	struct ally_x_device *ally_x = drvdata.ally_x;
++	bool val;
++	int ret;
++
++	ret = kstrtobool(buf, &val);
++	if (ret < 0)
++		return ret;
++
++	ally_x->qam_btns_steam_mode = val;
++
++	return count;
++}
++ALLY_DEVICE_ATTR_RW(ally_x_qam_mode, qam_mode);
++
++static struct ally_x_device *ally_x_create(struct hid_device *hdev)
 +{
 +	uint8_t max_output_report_size;
-+	struct ally_x_input *ally_x;
-+	struct ff_report *ff_report;
++	struct ally_x_device *ally_x;
++	struct ff_report *report;
 +	int ret;
 +
 +	ally_x = devm_kzalloc(&hdev->dev, sizeof(*ally_x), GFP_KERNEL);
 +	if (!ally_x)
-+		return -ENOMEM;
++		return ERR_PTR(-ENOMEM);
 +
 +	ally_x->hdev = hdev;
-+	ally_x->ally = ally;
-+	ally->ally_x_input = ally_x;
-+
-+	max_output_report_size = sizeof(struct ally_x_input_report);
-+
-+	ret = ally_x_setup_input(hdev, ally_x);
-+	if (ret)
-+		goto free_ally_x;
-+
 +	INIT_WORK(&ally_x->output_worker, ally_x_work);
 +	spin_lock_init(&ally_x->lock);
 +	ally_x->output_worker_initialized = true;
-+	ally_x->qam_mode =
-+		true;
++	ally_x->qam_btns_steam_mode =
++		true; /* Always default to steam mode, it can be changed by userspace attr */
 +
-+	ff_report = devm_kzalloc(&hdev->dev, sizeof(*ff_report), GFP_KERNEL);
-+	if (!ff_report) {
++	max_output_report_size = sizeof(struct ally_x_input_report);
++	report = devm_kzalloc(&hdev->dev, sizeof(*report), GFP_KERNEL);
++	if (!report) {
 +		ret = -ENOMEM;
 +		goto free_ally_x;
 +	}
 +
 +	/* None of these bytes will change for the FF command for now */
-+	ff_report->report_id = 0x0D;
-+	ff_report->ff.enable = 0x0F; /* Enable all by default */
-+	ff_report->ff.pulse_sustain_10ms = 0xFF; /* Duration */
-+	ff_report->ff.pulse_release_10ms = 0x00; /* Start Delay */
-+	ff_report->ff.loop_count = 0xEB; /* Loop Count */
-+	ally_x->ff_packet = ff_report;
++	report->report_id = 0x0D;
++	report->ff.enable = 0x0F; /* Enable all by default */
++	report->ff.pulse_sustain_10ms = 0xFF; /* Duration */
++	report->ff.pulse_release_10ms = 0x00; /* Start Delay */
++	report->ff.loop_count = 0xEB; /* Loop Count */
++	ally_x->ff_packet = report;
++
++	ally_x->input = ally_x_setup_input(hdev);
++	if (IS_ERR(ally_x->input)) {
++		ret = PTR_ERR(ally_x->input);
++		goto free_ff_packet;
++	}
 +
 +	if (sysfs_create_file(&hdev->dev.kobj, &dev_attr_ally_x_qam_mode.attr)) {
 +		ret = -ENODEV;
 +		goto unregister_input;
 +	}
 +
-+	hid_info(hdev, "Registered Ally X controller using %s\n",
-+			dev_name(&ally_x->input->dev));
++	ally_x->update_ff = true;
++	if (ally_x->output_worker_initialized)
++		schedule_work(&ally_x->output_worker);
 +
-+	return 0;
++	hid_info(hdev, "Registered Ally X controller using %s\n",
++		 dev_name(&ally_x->input->dev));
++	return ally_x;
 +
 +unregister_input:
 +	input_unregister_device(ally_x->input);
++free_ff_packet:
++	kfree(ally_x->ff_packet);
 +free_ally_x:
-+	devm_kfree(&hdev->dev, ally_x);
-+	return ret;
++	kfree(ally_x);
++	return ERR_PTR(ret);
 +}
 +
-+void ally_x_remove(struct hid_device *hdev, struct ally_handheld *ally)
++static void ally_x_remove(struct hid_device *hdev)
 +{
-+	if (ally->ally_x_input) {
-+		sysfs_remove_file(&hdev->dev.kobj, &dev_attr_ally_x_qam_mode.attr);
++	struct ally_x_device *ally_x = drvdata.ally_x;
++	unsigned long flags;
 +
-+		if (ally->ally_x_input->output_worker_initialized)
-+			cancel_work_sync(&ally->ally_x_input->output_worker);
-+
-+		ally->ally_x_input = NULL;
-+	}
++	spin_lock_irqsave(&ally_x->lock, flags);
++	ally_x->output_worker_initialized = false;
++	spin_unlock_irqrestore(&ally_x->lock, flags);
++	cancel_work_sync(&ally_x->output_worker);
++	sysfs_remove_file(&hdev->dev.kobj, &dev_attr_ally_x_qam_mode.attr);
 +}
-diff --git a/drivers/hid/asus-ally-hid/asus-ally-rgb.c b/drivers/hid/asus-ally-hid/asus-ally-rgb.c
-new file mode 100644
-index 000000000000..22aec39a7634
---- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally-rgb.c
-@@ -0,0 +1,356 @@
-+// SPDX-License-Identifier: GPL-2.0-or-later
-+/*
-+ *  HID driver for Asus ROG laptops and Ally
-+ *
-+ *  Copyright (c) 2025 Luke Jones <luke@ljones.dev>
-+ */
 +
-+#include "asus-ally.h"
-+#include "linux/delay.h"
-+
-+static const u8 EC_MODE_LED_APPLY[] = { 0x5A, 0xB4, 0, 0, 0, 0, 0, 0, 0,
-+					0,    0,    0, 0, 0, 0, 0, 0 };
-+static const u8 EC_MODE_LED_SET[] = { 0x5A, 0xB5, 0, 0, 0, 0, 0, 0, 0,
-+				      0,    0,	  0, 0, 0, 0, 0, 0 };
-+
-+static struct ally_rgb_resume_data resume_data;
-+
++/**************************************************************************************************/
++/* ROG Ally LED control                                                                           */
++/**************************************************************************************************/
 +static void ally_rgb_schedule_work(struct ally_rgb_dev *led)
 +{
 +	unsigned long flags;
-+
-+	if (!led)
-+		return;
 +
 +	spin_lock_irqsave(&led->lock, flags);
 +	if (!led->removed)
@@ -3978,231 +2348,160 @@ index 000000000000..22aec39a7634
 + * The RGB still has the basic 0-3 level brightness. Since the multicolour
 + * brightness is being used in place, set this to max
 + */
-+static int ally_rgb_set_bright_base_max(struct hid_device *hdev, struct ally_handheld *ally)
++static int ally_rgb_set_bright_base_max(struct hid_device *hdev)
 +{
-+	u8 buf[] = { HID_ALLY_SET_RGB_REPORT_ID, 0xba, 0xc5, 0xc4, 0x02 };
++	u8 buf[] = { FEATURE_KBD_LED_REPORT_ID1, 0xba, 0xc5, 0xc4, 0x02 };
 +
-+	return ally_gamepad_send_packet(ally, hdev, buf, sizeof(buf));
++	return asus_dev_set_report(hdev, buf, sizeof(buf));
 +}
 +
 +static void ally_rgb_do_work(struct work_struct *work)
 +{
 +	struct ally_rgb_dev *led = container_of(work, struct ally_rgb_dev, work);
-+	unsigned long flags;
 +	int ret;
++	unsigned long flags;
 +
-+	bool update_needed = false;
-+	u8 red[4], green[4], blue[4];
-+	const int data_size = 12; /* 4 RGB zones × 3 colors */
-+
-+	u8 buf[16] = { [0] = HID_ALLY_SET_REPORT_ID,
-+		       [1] = HID_ALLY_FEATURE_CODE_PAGE,
-+		       [2] = CMD_LED_CONTROL,
-+		       [3] = data_size };
-+
-+	if (!led || !led->hdev)
-+		return;
++	u8 buf[16] = { [0] = FEATURE_ROG_ALLY_REPORT_ID,
++		       [1] = FEATURE_ROG_ALLY_CODE_PAGE,
++		       [2] = xpad_cmd_set_leds,
++		       [3] = xpad_cmd_len_leds };
 +
 +	spin_lock_irqsave(&led->lock, flags);
-+	if (led->removed) {
++	if (!led->update_rgb) {
 +		spin_unlock_irqrestore(&led->lock, flags);
 +		return;
 +	}
 +
-+	if (led->update_rgb) {
-+		memcpy(red, led->red, sizeof(red));
-+		memcpy(green, led->green, sizeof(green));
-+		memcpy(blue, led->blue, sizeof(blue));
-+		led->update_rgb = false;
-+		update_needed = true;
++	for (int i = 0; i < 4; i++) {
++		buf[5 + i * 3] = drvdata.led_rgb_dev->green[i];
++		buf[6 + i * 3] = drvdata.led_rgb_dev->blue[i];
++		buf[4 + i * 3] = drvdata.led_rgb_dev->red[i];
 +	}
++	led->update_rgb = false;
++
 +	spin_unlock_irqrestore(&led->lock, flags);
 +
-+	if (!update_needed)
-+		return;
-+
-+	for (int i = 0; i < 4; i++) {
-+		buf[5 + i * 3] = green[i];
-+		buf[6 + i * 3] = blue[i];
-+		buf[4 + i * 3] = red[i];
-+	}
-+
-+	ret = ally_gamepad_send_packet(led->ally, led->hdev, buf, sizeof(buf));
++	ret = asus_dev_set_report(led->hdev, buf, sizeof(buf));
 +	if (ret < 0)
-+		hid_err(led->hdev, "Ally failed to set gamepad backlight: %d\n",
-+			ret);
++		hid_err(led->hdev, "Ally failed to set gamepad backlight: %d\n", ret);
 +}
 +
-+static void ally_rgb_set(struct led_classdev *cdev,
-+			 enum led_brightness brightness)
++static void ally_rgb_set(struct led_classdev *cdev, enum led_brightness brightness)
 +{
-+	struct led_classdev_mc *mc_cdev;
-+	struct ally_rgb_dev *led;
++	struct led_classdev_mc *mc_cdev = lcdev_to_mccdev(cdev);
++	struct ally_rgb_dev *led = container_of(mc_cdev, struct ally_rgb_dev, led_rgb_dev);
 +	int intensity, bright;
 +	unsigned long flags;
 +
-+	mc_cdev = lcdev_to_mccdev(cdev);
-+	if (!mc_cdev)
-+		return;
-+
-+	led = container_of(mc_cdev, struct ally_rgb_dev, led_rgb_dev);
-+	if (!led)
-+		return;
-+
 +	led_mc_calc_color_components(mc_cdev, brightness);
-+
 +	spin_lock_irqsave(&led->lock, flags);
-+
 +	led->update_rgb = true;
 +	bright = mc_cdev->led_cdev.brightness;
-+
 +	for (int i = 0; i < 4; i++) {
 +		intensity = mc_cdev->subled_info[i].intensity;
-+		led->red[i] = (((intensity >> 16) & 0xFF) * bright) / 255;
-+		led->green[i] = (((intensity >> 8) & 0xFF) * bright) / 255;
-+		led->blue[i] = ((intensity & 0xFF) * bright) / 255;
++		drvdata.led_rgb_dev->red[i] = (((intensity >> 16) & 0xFF) * bright) / 255;
++		drvdata.led_rgb_dev->green[i] = (((intensity >> 8) & 0xFF) * bright) / 255;
++		drvdata.led_rgb_dev->blue[i] = ((intensity & 0xFF) * bright) / 255;
 +	}
-+
-+	resume_data.initialized = true;
-+
 +	spin_unlock_irqrestore(&led->lock, flags);
++	drvdata.led_rgb_data.initialized = true;
 +
 +	ally_rgb_schedule_work(led);
 +}
 +
-+static int ally_rgb_set_static_from_multi(struct hid_device *hdev,
-+					  struct ally_handheld *ally, u8 r,
-+					  u8 g, u8 b)
++static int ally_rgb_set_static_from_multi(struct hid_device *hdev)
 +{
-+	u8 buf[17] = { HID_ALLY_SET_RGB_REPORT_ID, 0xb3 };
++	u8 buf[17] = {FEATURE_KBD_LED_REPORT_ID1, 0xb3};
 +	int ret;
 +
 +	/*
 +	 * Set single zone single colour based on the first LED of EC software mode.
 +	 * buf[2] = zone, buf[3] = mode
 +	 */
-+	buf[4] = r;
-+	buf[5] = g;
-+	buf[6] = b;
++	buf[4] = drvdata.led_rgb_data.red[0];
++	buf[5] = drvdata.led_rgb_data.green[0];
++	buf[6] = drvdata.led_rgb_data.blue[0];
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, buf, sizeof(buf));
++	ret = asus_dev_set_report(hdev, buf, sizeof(buf));
 +	if (ret < 0)
 +		return ret;
 +
-+	ret = ally_gamepad_send_packet(ally, hdev, EC_MODE_LED_APPLY,
-+				       sizeof(EC_MODE_LED_APPLY));
++	ret = asus_dev_set_report(hdev, EC_MODE_LED_APPLY, sizeof(EC_MODE_LED_APPLY));
 +	if (ret < 0)
 +		return ret;
 +
-+	return ally_gamepad_send_packet(ally, hdev, EC_MODE_LED_SET,
-+					sizeof(EC_MODE_LED_SET));
++	return asus_dev_set_report(hdev, EC_MODE_LED_SET, sizeof(EC_MODE_LED_SET));
 +}
 +
 +/*
 + * Store the RGB values for restoring on resume, and set the static mode to the first LED colour
 +*/
-+void ally_rgb_store_settings(struct ally_handheld *ally)
++static void ally_rgb_store_settings(void)
 +{
-+	struct ally_rgb_dev *led_rgb;
-+	int arr_size;
-+	u8 r = 0, g = 0, b = 0;
++	int arr_size = sizeof(drvdata.led_rgb_data.red);
 +
-+	led_rgb = ally->led_rgb_dev;
-+	if (!led_rgb || !led_rgb->hdev)
-+		return;
++	struct ally_rgb_dev *led_rgb = drvdata.led_rgb_dev;
 +
-+	arr_size = sizeof(resume_data.red);
++	drvdata.led_rgb_data.brightness = led_rgb->led_rgb_dev.led_cdev.brightness;
 +
-+	/* Take a snapshot of current settings with locking */
-+	spin_lock_irq(&led_rgb->lock);
-+	resume_data.brightness = led_rgb->led_rgb_dev.led_cdev.brightness;
-+	memcpy(resume_data.red, led_rgb->red, arr_size);
-+	memcpy(resume_data.green, led_rgb->green, arr_size);
-+	memcpy(resume_data.blue, led_rgb->blue, arr_size);
-+	r = resume_data.red[0];
-+	g = resume_data.green[0];
-+	b = resume_data.blue[0];
-+	spin_unlock_irq(&led_rgb->lock);
++	memcpy(drvdata.led_rgb_data.red, led_rgb->red, arr_size);
++	memcpy(drvdata.led_rgb_data.green, led_rgb->green, arr_size);
++	memcpy(drvdata.led_rgb_data.blue, led_rgb->blue, arr_size);
 +
-+	ally_rgb_set_static_from_multi(led_rgb->hdev, ally, r, g, b);
++	ally_rgb_set_static_from_multi(led_rgb->hdev);
 +}
 +
-+static void ally_rgb_restore_settings(struct ally_handheld *ally,
-+				      struct led_classdev *led_cdev,
++static void ally_rgb_restore_settings(struct ally_rgb_dev *led_rgb, struct led_classdev *led_cdev,
 +				      struct mc_subled *mc_led_info)
 +{
-+	struct ally_rgb_dev *led_rgb_dev;
-+	unsigned long flags;
-+	int arr_size;
++	int arr_size = sizeof(drvdata.led_rgb_data.red);
 +
-+	led_rgb_dev = ally->led_rgb_dev;
-+	if (!led_rgb_dev)
-+		return;
-+
-+	arr_size = sizeof(resume_data.red);
-+
-+	spin_lock_irqsave(&led_rgb_dev->lock, flags);
-+
-+	memcpy(led_rgb_dev->red, resume_data.red, arr_size);
-+	memcpy(led_rgb_dev->green, resume_data.green, arr_size);
-+	memcpy(led_rgb_dev->blue, resume_data.blue, arr_size);
-+
++	memcpy(led_rgb->red, drvdata.led_rgb_data.red, arr_size);
++	memcpy(led_rgb->green, drvdata.led_rgb_data.green, arr_size);
++	memcpy(led_rgb->blue, drvdata.led_rgb_data.blue, arr_size);
 +	for (int i = 0; i < 4; i++) {
-+		mc_led_info[i].intensity = (resume_data.red[i] << 16) |
-+					   (resume_data.green[i] << 8) |
-+					   resume_data.blue[i];
++		mc_led_info[i].intensity = (drvdata.led_rgb_data.red[i] << 16) |
++					   (drvdata.led_rgb_data.green[i] << 8) |
++					   drvdata.led_rgb_data.blue[i];
 +	}
-+	led_cdev->brightness = resume_data.brightness;
-+
-+	spin_unlock_irqrestore(&led_rgb_dev->lock, flags);
++	led_cdev->brightness = drvdata.led_rgb_data.brightness;
 +}
 +
 +/* Set LEDs. Call after any setup. */
-+void ally_rgb_resume(struct ally_handheld *ally)
++static void ally_rgb_resume(void)
 +{
-+	struct ally_rgb_dev *led_rgb;
++	struct ally_rgb_dev *led_rgb = drvdata.led_rgb_dev;
 +	struct led_classdev *led_cdev;
 +	struct mc_subled *mc_led_info;
 +
-+	led_rgb = ally->led_rgb_dev;
 +	if (!led_rgb)
 +		return;
 +
 +	led_cdev = &led_rgb->led_rgb_dev.led_cdev;
 +	mc_led_info = led_rgb->led_rgb_dev.subled_info;
-+	if (!led_cdev || !mc_led_info)
-+		return;
 +
-+	if (resume_data.initialized) {
-+		ally_rgb_restore_settings(ally, led_cdev, mc_led_info);
-+
-+		spin_lock_irq(&led_rgb->lock);
++	if (drvdata.led_rgb_data.initialized) {
++		ally_rgb_restore_settings(led_rgb, led_cdev, mc_led_info);
 +		led_rgb->update_rgb = true;
-+		spin_unlock_irq(&led_rgb->lock);
-+
 +		ally_rgb_schedule_work(led_rgb);
-+		ally_rgb_set_bright_base_max(led_rgb->hdev, ally);
++		ally_rgb_set_bright_base_max(led_rgb->hdev);
 +	}
 +}
 +
-+static int ally_rgb_register(struct hid_device *hdev,
-+			     struct ally_rgb_dev *led_rgb)
++static int ally_rgb_register(struct hid_device *hdev, struct ally_rgb_dev *led_rgb)
 +{
 +	struct mc_subled *mc_led_info;
 +	struct led_classdev *led_cdev;
-+	int ret;
 +
-+	if (!hdev || !led_rgb)
-+		return -EINVAL;
-+
-+	mc_led_info = devm_kmalloc_array(&hdev->dev, 4, sizeof(*mc_led_info),
-+					 GFP_KERNEL | __GFP_ZERO);
++	mc_led_info =
++		devm_kmalloc_array(&hdev->dev, 12, sizeof(*mc_led_info), GFP_KERNEL | __GFP_ZERO);
 +	if (!mc_led_info)
 +		return -ENOMEM;
 +
-+	for (int i = 0; i < 4; i++) {
-+		mc_led_info[i].color_index = LED_COLOR_ID_RGB;
-+	}
++	mc_led_info[0].color_index = LED_COLOR_ID_RGB;
++	mc_led_info[1].color_index = LED_COLOR_ID_RGB;
++	mc_led_info[2].color_index = LED_COLOR_ID_RGB;
++	mc_led_info[3].color_index = LED_COLOR_ID_RGB;
 +
 +	led_rgb->led_rgb_dev.subled_info = mc_led_info;
 +	led_rgb->led_rgb_dev.num_colors = 4;
@@ -4213,99 +2512,310 @@ index 000000000000..22aec39a7634
 +	led_cdev->max_brightness = 255;
 +	led_cdev->brightness_set = ally_rgb_set;
 +
-+	ret = devm_led_classdev_multicolor_register(&hdev->dev,
-+						    &led_rgb->led_rgb_dev);
-+	if (ret < 0)
-+		hid_err(hdev, "Failed to register RGB LED device: %d\n", ret);
++	if (drvdata.led_rgb_data.initialized) {
++		ally_rgb_restore_settings(led_rgb, led_cdev, mc_led_info);
++	}
 +
-+	return ret;
++	return devm_led_classdev_multicolor_register(&hdev->dev, &led_rgb->led_rgb_dev);
 +}
 +
-+int ally_rgb_create(struct hid_device *hdev, struct ally_handheld *ally)
++static struct ally_rgb_dev *ally_rgb_create(struct hid_device *hdev)
 +{
 +	struct ally_rgb_dev *led_rgb;
 +	int ret;
 +
-+	led_rgb = devm_kzalloc(&hdev->dev, sizeof(struct ally_rgb_dev),
-+			       GFP_KERNEL);
++	led_rgb = devm_kzalloc(&hdev->dev, sizeof(struct ally_rgb_dev), GFP_KERNEL);
 +	if (!led_rgb)
-+		return -ENOMEM;
-+
-+	led_rgb->ally = ally;
-+	led_rgb->hdev = hdev;
-+	led_rgb->removed = false;
-+	INIT_WORK(&led_rgb->work, ally_rgb_do_work);
-+	spin_lock_init(&led_rgb->lock);
-+
-+	/* Set the pointer in ally structure BEFORE doing any operations that might use it */
-+	ally->led_rgb_dev = led_rgb;
++		return ERR_PTR(-ENOMEM);
 +
 +	ret = ally_rgb_register(hdev, led_rgb);
 +	if (ret < 0) {
-+		hid_err(hdev, "Failed to register RGB LED device: %d\n", ret);
 +		cancel_work_sync(&led_rgb->work);
-+		ally->led_rgb_dev = NULL; /* Reset pointer on failure */
 +		devm_kfree(&hdev->dev, led_rgb);
-+		return ret;
++		return ERR_PTR(ret);
 +	}
 +
++	led_rgb->hdev = hdev;
++	led_rgb->removed = false;
++
++	INIT_WORK(&led_rgb->work, ally_rgb_do_work);
 +	led_rgb->output_worker_initialized = true;
++	spin_lock_init(&led_rgb->lock);
 +
-+	ret = ally_rgb_set_bright_base_max(hdev, ally);
-+	if (ret < 0)
-+		hid_warn(hdev, "Failed to set maximum base brightness: %d\n",
-+			 ret);
++	ally_rgb_set_bright_base_max(hdev);
 +
-+	if (resume_data.initialized) {
++	/* Not marked as initialized unless ally_rgb_set() is called */
++	if (drvdata.led_rgb_data.initialized) {
 +		msleep(1500);
-+		spin_lock_irq(&led_rgb->lock);
 +		led_rgb->update_rgb = true;
-+		spin_unlock_irq(&led_rgb->lock);
 +		ally_rgb_schedule_work(led_rgb);
++	}
++
++	return led_rgb;
++}
++
++static void ally_rgb_remove(struct hid_device *hdev)
++{
++	struct ally_rgb_dev *led_rgb = drvdata.led_rgb_dev;
++	unsigned long flags;
++	int ep;
++
++	ep = get_endpoint_address(hdev);
++	if (ep != ROG_ALLY_CFG_INTF_IN)
++		return;
++
++	if (!drvdata.led_rgb_dev || led_rgb->removed)
++		return;
++
++	spin_lock_irqsave(&led_rgb->lock, flags);
++	led_rgb->removed = true;
++	led_rgb->output_worker_initialized = false;
++	spin_unlock_irqrestore(&led_rgb->lock, flags);
++	cancel_work_sync(&led_rgb->work);
++	devm_led_classdev_multicolor_unregister(&hdev->dev, &led_rgb->led_rgb_dev);
++
++	hid_info(hdev, "Removed Ally RGB interface");
++}
++
++/**************************************************************************************************/
++/* ROG Ally driver init                                                                           */
++/**************************************************************************************************/
++
++static int ally_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data,
++			  int size)
++{
++	struct ally_gamepad_cfg *cfg = drvdata.gamepad_cfg;
++	struct ally_x_device *ally_x = drvdata.ally_x;
++
++	if (ally_x) {
++		if ((hdev->bus == BUS_USB && report->id == ALLY_X_INPUT_REPORT_USB &&
++		     size == ALLY_X_INPUT_REPORT_USB_SIZE) ||
++		    (data[0] == 0x5A)) {
++			ally_x_raw_event(ally_x, report, data, size);
++		} else {
++			return -1;
++		}
++	}
++
++	if (cfg && !ally_x) {
++		input_report_key(cfg->input, KEY_PROG1, data[1] == 0x38);
++		input_report_key(cfg->input, KEY_F16, data[1] == 0xA6);
++		input_report_key(cfg->input, KEY_F17, data[1] == 0xA7);
++		input_report_key(cfg->input, KEY_F18, data[1] == 0xA8);
++		input_sync(cfg->input);
 +	}
 +
 +	return 0;
 +}
 +
-+void ally_rgb_remove(struct hid_device *hdev, struct ally_handheld *ally)
++static int ally_hid_init(struct hid_device *hdev)
 +{
-+	struct ally_rgb_dev *led_rgb;
-+	unsigned long flags;
-+	int ep;
++	int ret;
++
++	ret = asus_dev_set_report(hdev, EC_INIT_STRING, sizeof(EC_INIT_STRING));
++	if (ret < 0) {
++		hid_err(hdev, "Ally failed to send init command: %d\n", ret);
++		return ret;
++	}
++
++	ret = asus_dev_set_report(hdev, FORCE_FEEDBACK_OFF, sizeof(FORCE_FEEDBACK_OFF));
++	if (ret < 0)
++		hid_err(hdev, "Ally failed to send init command: %d\n", ret);
++
++	return ret;
++}
++
++static int ally_hid_probe(struct hid_device *hdev, const struct hid_device_id *_id)
++{
++	struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
++	struct usb_device *udev = interface_to_usbdev(intf);
++	u16 idProduct = le16_to_cpu(udev->descriptor.idProduct);
++	int ret, ep;
 +
 +	ep = get_endpoint_address(hdev);
-+	if (ep != HID_ALLY_INTF_CFG_IN)
-+		return;
++	if (ep < 0)
++		return ep;
 +
-+	led_rgb = ally->led_rgb_dev;
-+	if (!led_rgb)
-+		return;
++	if (ep != ROG_ALLY_CFG_INTF_IN &&
++	    ep != ROG_ALLY_X_INTF_IN)
++		return -ENODEV;
 +
-+	/* Mark as removed to prevent new work from being scheduled */
-+	spin_lock_irqsave(&led_rgb->lock, flags);
-+	if (led_rgb->removed) {
-+		spin_unlock_irqrestore(&led_rgb->lock, flags);
-+		return;
++	ret = hid_parse(hdev);
++	if (ret) {
++		hid_err(hdev, "Parse failed\n");
++		return ret;
 +	}
-+	led_rgb->removed = true;
-+	led_rgb->output_worker_initialized = false;
-+	spin_unlock_irqrestore(&led_rgb->lock, flags);
 +
-+	cancel_work_sync(&led_rgb->work);
++	ret = hid_hw_start(hdev, HID_CONNECT_HIDRAW);
++	if (ret) {
++		hid_err(hdev, "Failed to start HID device\n");
++		return ret;
++	}
 +
-+	devm_led_classdev_multicolor_unregister(&hdev->dev,
-+						&led_rgb->led_rgb_dev);
++	ret = hid_hw_open(hdev);
++	if (ret) {
++		hid_err(hdev, "Failed to open HID device\n");
++		goto err_stop;
++	}
 +
-+	ally->led_rgb_dev = NULL;
++	/* Initialize MCU even before alloc */
++	ret = ally_hid_init(hdev);
++	if (ret < 0)
++		return ret;
 +
-+	hid_info(hdev, "Removed Ally RGB interface");
++	drvdata.hdev = hdev;
++	hid_set_drvdata(hdev, &drvdata);
++
++	/* This should almost always exist */
++	if (ep == ROG_ALLY_CFG_INTF_IN) {
++		validate_mcu_fw_version(hdev, idProduct);
++
++		drvdata.led_rgb_dev = ally_rgb_create(hdev);
++		if (IS_ERR(drvdata.led_rgb_dev))
++			hid_err(hdev, "Failed to create Ally gamepad LEDs.\n");
++		else
++			hid_info(hdev, "Created Ally RGB LED controls.\n");
++
++		drvdata.gamepad_cfg = ally_gamepad_cfg_create(hdev);
++		if (IS_ERR(drvdata.gamepad_cfg))
++			hid_err(hdev, "Failed to create Ally gamepad attributes.\n");
++		else
++			hid_info(hdev, "Created Ally gamepad attributes.\n");
++
++		if (IS_ERR(drvdata.led_rgb_dev) && IS_ERR(drvdata.gamepad_cfg))
++			goto err_close;
++	}
++
++	/* May or may not exist */
++	if (ep == ROG_ALLY_X_INTF_IN) {
++		drvdata.ally_x = ally_x_create(hdev);
++		if (IS_ERR(drvdata.ally_x)) {
++			hid_err(hdev, "Failed to create Ally X gamepad.\n");
++			drvdata.ally_x = NULL;
++			goto err_close;
++		}
++		hid_info(hdev, "Created Ally X controller.\n");
++
++		// Not required since we send this inputs ep through the gamepad input dev
++		if (drvdata.gamepad_cfg && drvdata.gamepad_cfg->input) {
++			input_unregister_device(drvdata.gamepad_cfg->input);
++			hid_info(hdev, "Ally X removed unrequired input dev.\n");
++		}
++	}
++
++	return 0;
++
++err_close:
++	hid_hw_close(hdev);
++err_stop:
++	hid_hw_stop(hdev);
++	return ret;
 +}
-diff --git a/drivers/hid/asus-ally-hid/asus-ally.h b/drivers/hid/asus-ally-hid/asus-ally.h
++
++static void ally_hid_remove(struct hid_device *hdev)
++{
++	if (drvdata.led_rgb_dev)
++		ally_rgb_remove(hdev);
++
++	if (drvdata.ally_x)
++		ally_x_remove(hdev);
++
++	if (drvdata.gamepad_cfg)
++		ally_cfg_remove(hdev);
++
++	hid_hw_close(hdev);
++	hid_hw_stop(hdev);
++}
++
++static int ally_hid_resume(struct hid_device *hdev)
++{
++	struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;
++	int err;
++
++	if (!ally_cfg)
++		return 0;
++
++	err = _gamepad_apply_all(hdev, ally_cfg);
++	if (err)
++		return err;
++
++	return 0;
++}
++
++static int ally_hid_reset_resume(struct hid_device *hdev)
++{
++	int ep = get_endpoint_address(hdev);
++	if (ep != ROG_ALLY_CFG_INTF_IN)
++		return 0;
++
++	ally_hid_init(hdev);
++	ally_rgb_resume();
++
++	return ally_hid_resume(hdev);
++}
++
++static int ally_pm_thaw(struct device *dev)
++{
++	struct hid_device *hdev = to_hid_device(dev);
++
++	return ally_hid_reset_resume(hdev);
++}
++
++static int ally_pm_suspend(struct device *dev)
++{
++	if (drvdata.led_rgb_dev) {
++		ally_rgb_store_settings();
++	}
++
++	return 0;
++}
++
++static const struct dev_pm_ops ally_pm_ops = {
++	.thaw = ally_pm_thaw,
++	.suspend = ally_pm_suspend,
++	.poweroff = ally_pm_suspend,
++};
++
++MODULE_DEVICE_TABLE(hid, rog_ally_devices);
++
++static struct hid_driver rog_ally_cfg = { .name = "asus_rog_ally",
++		.id_table = rog_ally_devices,
++		.probe = ally_hid_probe,
++		.remove = ally_hid_remove,
++		.raw_event = ally_raw_event,
++		/* HID is the better place for resume functions, not pm_ops */
++		.resume = ally_hid_resume,
++		/* ALLy 1 requires this to reset device state correctly */
++		.reset_resume = ally_hid_reset_resume,
++		.driver = {
++			.pm = &ally_pm_ops,
++		}
++};
++
++static int __init rog_ally_init(void)
++{
++	return hid_register_driver(&rog_ally_cfg);
++}
++
++static void __exit rog_ally_exit(void)
++{
++	hid_unregister_driver(&rog_ally_cfg);
++}
++
++module_init(rog_ally_init);
++module_exit(rog_ally_exit);
++
++MODULE_IMPORT_NS("ASUS_WMI");
++MODULE_IMPORT_NS("HID_ASUS");
++MODULE_AUTHOR("Luke D. Jones");
++MODULE_DESCRIPTION("HID Driver for ASUS ROG Ally gamepad configuration.");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/hid/hid-asus-ally.h b/drivers/hid/hid-asus-ally.h
 new file mode 100644
-index 000000000000..fd9c788a4a42
+index 000000000..c83817589
 --- /dev/null
-+++ b/drivers/hid/asus-ally-hid/asus-ally.h
-@@ -0,0 +1,314 @@
++++ b/drivers/hid/hid-asus-ally.h
+@@ -0,0 +1,398 @@
 +/* SPDX-License-Identifier: GPL-2.0-or-later
 + *
 + *  HID driver for Asus ROG laptops and Ally
@@ -4313,291 +2823,202 @@ index 000000000000..fd9c788a4a42
 + *  Copyright (c) 2023 Luke Jones <luke@ljones.dev>
 + */
 +
-+ #ifndef __ASUS_ALLY_H
-+ #define __ASUS_ALLY_H
-+
 +#include <linux/hid.h>
-+#include <linux/led-class-multicolor.h>
 +#include <linux/types.h>
 +
-+#define HID_ALLY_KEYBOARD_INTF_IN 0x81
-+#define HID_ALLY_MOUSE_INTF_IN 0x82
-+#define HID_ALLY_INTF_CFG_IN 0x83
-+#define HID_ALLY_X_INTF_IN 0x87
-+
-+#define HID_ALLY_REPORT_SIZE 64
-+#define HID_ALLY_GET_REPORT_ID 0x0D
-+#define HID_ALLY_SET_REPORT_ID 0x5A
-+#define HID_ALLY_SET_RGB_REPORT_ID 0x5D
-+#define HID_ALLY_FEATURE_CODE_PAGE 0xD1
-+
-+#define HID_ALLY_X_INPUT_REPORT 0x0B
-+#define HID_ALLY_X_INPUT_REPORT_SIZE 16
-+
-+enum ally_command_codes {
-+    CMD_SET_GAMEPAD_MODE            = 0x01,
-+    CMD_SET_MAPPING                 = 0x02,
-+    CMD_SET_JOYSTICK_MAPPING        = 0x03,
-+    CMD_SET_JOYSTICK_DEADZONE       = 0x04,
-+    CMD_SET_TRIGGER_RANGE           = 0x05,
-+    CMD_SET_VIBRATION_INTENSITY     = 0x06,
-+    CMD_LED_CONTROL                 = 0x08,
-+    CMD_CHECK_READY                 = 0x0A,
-+    CMD_SET_XBOX_CONTROLLER         = 0x0B,
-+    CMD_CHECK_XBOX_SUPPORT          = 0x0C,
-+    CMD_USER_CAL_DATA               = 0x0D,
-+    CMD_CHECK_USER_CAL_SUPPORT      = 0x0E,
-+    CMD_SET_TURBO_PARAMS            = 0x0F,
-+    CMD_CHECK_TURBO_SUPPORT         = 0x10,
-+    CMD_CHECK_RESP_CURVE_SUPPORT    = 0x12,
-+    CMD_SET_RESP_CURVE              = 0x13,
-+    CMD_CHECK_DIR_TO_BTN_SUPPORT    = 0x14,
-+    CMD_SET_GYRO_PARAMS             = 0x15,
-+    CMD_CHECK_GYRO_TO_JOYSTICK      = 0x16,
-+    CMD_CHECK_ANTI_DEADZONE         = 0x17,
-+    CMD_SET_ANTI_DEADZONE           = 0x18,
-+};
-+
-+enum ally_gamepad_mode {
-+	ALLY_GAMEPAD_MODE_GAMEPAD = 0x01,
-+	ALLY_GAMEPAD_MODE_KEYBOARD = 0x02,
-+};
-+
-+static const char *const gamepad_mode_names[] = {
-+	[ALLY_GAMEPAD_MODE_GAMEPAD] = "gamepad",
-+	[ALLY_GAMEPAD_MODE_KEYBOARD] = "keyboard"
-+};
-+
-+/* Button identifiers for the attribute system */
-+enum ally_button_id {
-+	ALLY_BTN_A,
-+	ALLY_BTN_B,
-+	ALLY_BTN_X,
-+	ALLY_BTN_Y,
-+	ALLY_BTN_LB,
-+	ALLY_BTN_RB,
-+	ALLY_BTN_DU,
-+	ALLY_BTN_DD,
-+	ALLY_BTN_DL,
-+	ALLY_BTN_DR,
-+	ALLY_BTN_J0B,
-+	ALLY_BTN_J1B,
-+	ALLY_BTN_MENU,
-+	ALLY_BTN_VIEW,
-+	ALLY_BTN_M1,
-+	ALLY_BTN_M2,
-+	ALLY_BTN_MAX
-+};
-+
-+/* Names for the button directories in sysfs */
-+static const char *const ally_button_names[ALLY_BTN_MAX] = {
-+	[ALLY_BTN_A] = "btn_a",
-+	[ALLY_BTN_B] = "btn_b",
-+	[ALLY_BTN_X] = "btn_x",
-+	[ALLY_BTN_Y] = "btn_y",
-+	[ALLY_BTN_LB] = "btn_lb",
-+	[ALLY_BTN_RB] = "btn_rb",
-+	[ALLY_BTN_DU] = "dpad_up",
-+	[ALLY_BTN_DD] = "dpad_down",
-+	[ALLY_BTN_DL] = "dpad_left",
-+	[ALLY_BTN_DR] = "dpad_right",
-+	[ALLY_BTN_J0B] = "btn_l3",
-+	[ALLY_BTN_J1B] = "btn_r3",
-+	[ALLY_BTN_MENU] = "btn_menu",
-+	[ALLY_BTN_VIEW] = "btn_view",
-+	[ALLY_BTN_M1] = "btn_m1",
-+	[ALLY_BTN_M2] = "btn_m2",
-+};
-+
-+struct ally_rgb_resume_data {
-+	uint8_t brightness;
-+	uint8_t red[4];
-+	uint8_t green[4];
-+	uint8_t blue[4];
-+	bool initialized;
-+};
-+
-+struct ally_rgb_dev {
-+	struct ally_handheld *ally;
-+	struct hid_device *hdev;
-+	struct led_classdev_mc led_rgb_dev;
-+	struct work_struct work;
-+	bool output_worker_initialized;
-+	spinlock_t lock;
-+
-+	bool removed;
-+	bool update_rgb;
-+	uint8_t red[4];
-+	uint8_t green[4];
-+	uint8_t blue[4];
-+};
-+
-+/* rumble packet structure */
-+struct ff_data {
-+	u8 enable;
-+	u8 magnitude_left;
-+	u8 magnitude_right;
-+	u8 magnitude_strong;
-+	u8 magnitude_weak;
-+	u8 pulse_sustain_10ms;
-+	u8 pulse_release_10ms;
-+	u8 loop_count;
-+} __packed;
-+
-+struct ff_report {
-+	u8 report_id;
-+	struct ff_data ff;
-+} __packed;
-+
-+struct ally_x_input {
-+	struct ally_handheld *ally;
-+	struct input_dev *input;
-+	struct hid_device *hdev;
-+	spinlock_t lock;
-+
-+	struct work_struct output_worker;
-+	bool output_worker_initialized;
-+
-+	/* Set if the left QAM emits Guide/Mode and right QAM emits Home + A chord */
-+	bool qam_mode;
-+	/* Prevent multiple queued event due to the enforced delay in worker */
-+	bool update_qam_chord;
-+
-+	struct ff_report *ff_packet;
-+	bool update_ff;
-+};
-+
-+struct resp_curve_param {
-+	u8 move;
-+	u8 resp;
-+} __packed;
-+
-+struct joystick_resp_curve {
-+	struct resp_curve_param entry_1;
-+	struct resp_curve_param entry_2;
-+	struct resp_curve_param entry_3;
-+	struct resp_curve_param entry_4;
-+} __packed;
-+
 +/*
-+ * Button turbo parameters structure
-+ * Each button can have:
-+ * - turbo: Turbo press interval in multiple of 50ms (0 = disabled, 1-20 = 50ms-1000ms)
-+ * - toggle: Toggle interval (0 = disabled)
++ * the xpad_mode is used inside the mode setting packet and is used
++ * for indexing (xpad_mode - 1)
 + */
-+struct button_turbo_params {
-+	u8 turbo;
-+	u8 toggle;
-+} __packed;
-+
-+/* Collection of all button turbo settings */
-+struct turbo_config {
-+	struct button_turbo_params btn_du;   /* D-pad Up */
-+	struct button_turbo_params btn_dd;   /* D-pad Down */
-+	struct button_turbo_params btn_dl;   /* D-pad Left */
-+	struct button_turbo_params btn_dr;   /* D-pad Right */
-+	struct button_turbo_params btn_j0b;  /* Left joystick button */
-+	struct button_turbo_params btn_j1b;  /* Right joystick button */
-+	struct button_turbo_params btn_lb;   /* Left bumper */
-+	struct button_turbo_params btn_rb;   /* Right bumper */
-+	struct button_turbo_params btn_a;    /* A button */
-+	struct button_turbo_params btn_b;    /* B button */
-+	struct button_turbo_params btn_x;    /* X button */
-+	struct button_turbo_params btn_y;    /* Y button */
-+	struct button_turbo_params btn_view; /* View button */
-+	struct button_turbo_params btn_menu; /* Menu button */
-+	struct button_turbo_params btn_m2;   /* M2 button */
-+	struct button_turbo_params btn_m1;   /* M1 button */
++enum xpad_mode {
++	xpad_mode_game = 0x01,
++	xpad_mode_wasd = 0x02,
++	xpad_mode_mouse = 0x03,
 +};
 +
-+struct ally_config {
-+	struct hid_device *hdev;
-+	/* Must be locked if the data is being changed */
-+	struct mutex config_mutex;
-+	bool initialized;
-+
-+	/* Device capabilities flags */
-+	bool is_ally_x;
-+	bool xbox_controller_support;
-+	bool user_cal_support;
-+	bool turbo_support;
-+	bool resp_curve_support;
-+	bool dir_to_btn_support;
-+	bool gyro_support;
-+	bool anti_deadzone_support;
-+
-+	/* Current settings */
-+	bool xbox_controller_enabled;
-+	u8 gamepad_mode;
-+	u8 left_deadzone;
-+	u8 left_outer_threshold;
-+	u8 right_deadzone;
-+	u8 right_outer_threshold;
-+	u8 left_anti_deadzone;
-+	u8 right_anti_deadzone;
-+	u8 left_trigger_min;
-+	u8 left_trigger_max;
-+	u8 right_trigger_min;
-+	u8 right_trigger_max;
-+
-+	/* Vibration settings */
-+	u8 vibration_intensity_left;
-+	u8 vibration_intensity_right;
-+	bool vibration_active;
-+
-+	struct turbo_config turbo;
-+	struct button_sysfs_entry *button_entries;
-+	void *button_mappings; /* ally_button_mapping array indexed by gamepad_mode */
-+
-+	struct joystick_resp_curve left_curve;
-+	struct joystick_resp_curve right_curve;
++/* the xpad_cmd determines which feature is set or queried */
++enum xpad_cmd {
++	xpad_cmd_set_mode = 0x01,
++	xpad_cmd_set_mapping = 0x02,
++	xpad_cmd_set_js_dz = 0x04, /* deadzones */
++	xpad_cmd_set_tr_dz = 0x05, /* deadzones */
++	xpad_cmd_set_vibe_intensity = 0x06,
++	xpad_cmd_set_leds = 0x08,
++	xpad_cmd_check_ready = 0x0A,
++	xpad_cmd_set_turbo = 0x0F,
++	xpad_cmd_set_response_curve = 0x13,
++	xpad_cmd_set_adz = 0x18,
 +};
 +
-+struct ally_handheld {
-+	/* All read/write to IN interfaces must lock */
-+	struct mutex intf_mutex;
-+	struct hid_device *cfg_hdev;
-+
-+	struct ally_rgb_dev *led_rgb_dev;
-+
-+	struct ally_x_input *ally_x_input;
-+
-+	struct hid_device *keyboard_hdev;
-+	struct input_dev *keyboard_input;
-+
-+	struct ally_config *config;
++/* the xpad_cmd determines which feature is set or queried */
++enum xpad_cmd_len {
++	xpad_cmd_len_mode = 0x01,
++	xpad_cmd_len_mapping = 0x2c,
++	xpad_cmd_len_deadzone = 0x04,
++	xpad_cmd_len_vibe_intensity = 0x02,
++	xpad_cmd_len_leds = 0x0C,
++	xpad_cmd_len_turbo = 0x20,
++	xpad_cmd_len_response_curve = 0x09,
++	xpad_cmd_len_adz = 0x02,
 +};
 +
-+int ally_gamepad_send_packet(struct ally_handheld *ally,
-+			     struct hid_device *hdev, const u8 *buf,
-+			     size_t len);
-+int ally_gamepad_send_receive_packet(struct ally_handheld *ally,
-+				     struct hid_device *hdev, u8 *buf,
-+				     size_t len);
-+int ally_gamepad_send_one_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command,
-+				      u8 param);
-+int ally_gamepad_send_two_byte_packet(struct ally_handheld *ally,
-+				      struct hid_device *hdev,
-+				      enum ally_command_codes command,
-+				      u8 param1, u8 param2);
-+int ally_gamepad_check_ready(struct hid_device *hdev);
-+u8 get_endpoint_address(struct hid_device *hdev);
++/* Values correspond to the actual HID byte value required */
++enum btn_pair_index {
++	btn_pair_dpad_u_d = 0x01,
++	btn_pair_dpad_l_r = 0x02,
++	btn_pair_ls_rs = 0x03,
++	btn_pair_lb_rb = 0x04,
++	btn_pair_a_b = 0x05,
++	btn_pair_x_y = 0x06,
++	btn_pair_view_menu = 0x07,
++	btn_pair_m1_m2 = 0x08,
++	btn_pair_lt_rt = 0x09,
++};
 +
-+int ally_rgb_create(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_rgb_remove(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_rgb_store_settings(struct ally_handheld *ally);
-+void ally_rgb_resume(struct ally_handheld *ally);
++#define BTN_PAD_A             0x0101000000000000
++#define BTN_PAD_B             0x0102000000000000
++#define BTN_PAD_X             0x0103000000000000
++#define BTN_PAD_Y             0x0104000000000000
++#define BTN_PAD_LB            0x0105000000000000
++#define BTN_PAD_RB            0x0106000000000000
++#define BTN_PAD_LS            0x0107000000000000
++#define BTN_PAD_RS            0x0108000000000000
++#define BTN_PAD_DPAD_UP       0x0109000000000000
++#define BTN_PAD_DPAD_DOWN     0x010A000000000000
++#define BTN_PAD_DPAD_LEFT     0x010B000000000000
++#define BTN_PAD_DPAD_RIGHT    0x010C000000000000
++#define BTN_PAD_LT            0x010D000000000000
++#define BTN_PAD_RT            0x010E000000000000
++#define BTN_PAD_VIEW          0x0111000000000000
++#define BTN_PAD_MENU          0x0112000000000000
++#define BTN_PAD_XBOX          0x0113000000000000
 +
-+int ally_x_create(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_x_remove(struct hid_device *hdev, struct ally_handheld *ally);
-+bool ally_x_raw_event(struct ally_x_input *ally_x, struct hid_report *report, u8 *data,
-+			    int size);
++#define BTN_KB_M2             0x02008E0000000000
++#define BTN_KB_M1             0x02008F0000000000
++#define BTN_KB_ESC            0x0200760000000000
++#define BTN_KB_F1             0x0200500000000000
++#define BTN_KB_F2             0x0200600000000000
++#define BTN_KB_F3             0x0200400000000000
++#define BTN_KB_F4             0x02000C0000000000
++#define BTN_KB_F5             0x0200030000000000
++#define BTN_KB_F6             0x02000B0000000000
++#define BTN_KB_F7             0x0200800000000000
++#define BTN_KB_F8             0x02000A0000000000
++#define BTN_KB_F9             0x0200010000000000
++#define BTN_KB_F10            0x0200090000000000
++#define BTN_KB_F11            0x0200780000000000
++#define BTN_KB_F12            0x0200070000000000
++#define BTN_KB_F14            0x0200180000000000
++#define BTN_KB_F15            0x0200100000000000
++#define BTN_KB_BACKTICK       0x02000E0000000000
++#define BTN_KB_1              0x0200160000000000
++#define BTN_KB_2              0x02001E0000000000
++#define BTN_KB_3              0x0200260000000000
++#define BTN_KB_4              0x0200250000000000
++#define BTN_KB_5              0x02002E0000000000
++#define BTN_KB_6              0x0200360000000000
++#define BTN_KB_7              0x02003D0000000000
++#define BTN_KB_8              0x02003E0000000000
++#define BTN_KB_9              0x0200460000000000
++#define BTN_KB_0              0x0200450000000000
++#define BTN_KB_HYPHEN         0x02004E0000000000
++#define BTN_KB_EQUALS         0x0200550000000000
++#define BTN_KB_BACKSPACE      0x0200660000000000
++#define BTN_KB_TAB            0x02000D0000000000
++#define BTN_KB_Q              0x0200150000000000
++#define BTN_KB_W              0x02001D0000000000
++#define BTN_KB_E              0x0200240000000000
++#define BTN_KB_R              0x02002D0000000000
++#define BTN_KB_T              0x02002C0000000000
++#define BTN_KB_Y              0x0200350000000000
++#define BTN_KB_U              0x02003C0000000000
++#define BTN_KB_O              0x0200440000000000
++#define BTN_KB_P              0x02004D0000000000
++#define BTN_KB_LBRACKET       0x0200540000000000
++#define BTN_KB_RBRACKET       0x02005B0000000000
++#define BTN_KB_BACKSLASH      0x02005D0000000000
++#define BTN_KB_CAPS           0x0200580000000000
++#define BTN_KB_A              0x02001C0000000000
++#define BTN_KB_S              0x02001B0000000000
++#define BTN_KB_D              0x0200230000000000
++#define BTN_KB_F              0x02002B0000000000
++#define BTN_KB_G              0x0200340000000000
++#define BTN_KB_H              0x0200330000000000
++#define BTN_KB_J              0x02003B0000000000
++#define BTN_KB_K              0x0200420000000000
++#define BTN_KB_L              0x02004B0000000000
++#define BTN_KB_SEMI           0x02004C0000000000
++#define BTN_KB_QUOTE          0x0200520000000000
++#define BTN_KB_RET            0x02005A0000000000
++#define BTN_KB_LSHIFT         0x0200880000000000
++#define BTN_KB_Z              0x02001A0000000000
++#define BTN_KB_X              0x0200220000000000
++#define BTN_KB_C              0x0200210000000000
++#define BTN_KB_V              0x02002A0000000000
++#define BTN_KB_B              0x0200320000000000
++#define BTN_KB_N              0x0200310000000000
++#define BTN_KB_M              0x02003A0000000000
++#define BTN_KB_COMMA          0x0200410000000000
++#define BTN_KB_PERIOD         0x0200490000000000
++#define BTN_KB_RSHIFT         0x0200890000000000
++#define BTN_KB_LCTL           0x02008C0000000000
++#define BTN_KB_META           0x0200820000000000
++#define BTN_KB_LALT           0x02008A0000000000
++#define BTN_KB_SPACE          0x0200290000000000
++#define BTN_KB_RALT           0x02008B0000000000
++#define BTN_KB_MENU           0x0200840000000000
++#define BTN_KB_RCTL           0x02008D0000000000
++#define BTN_KB_PRNTSCN        0x0200C30000000000
++#define BTN_KB_SCRLCK         0x02007E0000000000
++#define BTN_KB_PAUSE          0x0200910000000000
++#define BTN_KB_INS            0x0200C20000000000
++#define BTN_KB_HOME           0x0200940000000000
++#define BTN_KB_PGUP           0x0200960000000000
++#define BTN_KB_DEL            0x0200C00000000000
++#define BTN_KB_END            0x0200950000000000
++#define BTN_KB_PGDWN          0x0200970000000000
++#define BTN_KB_UP_ARROW       0x0200980000000000
++#define BTN_KB_DOWN_ARROW     0x0200990000000000
++#define BTN_KB_LEFT_ARROW     0x0200910000000000
++#define BTN_KB_RIGHT_ARROW    0x02009B0000000000
 +
-+int ally_config_create(struct hid_device *hdev, struct ally_handheld *ally);
-+void ally_config_remove(struct hid_device *hdev, struct ally_handheld *ally);
++#define BTN_NUMPAD_LOCK       0x0200770000000000
++#define BTN_NUMPAD_FWDSLASH   0x0200900000000000
++#define BTN_NUMPAD_ASTERISK   0x02007C0000000000
++#define BTN_NUMPAD_HYPHEN     0x02007B0000000000
++#define BTN_NUMPAD_0          0x0200700000000000
++#define BTN_NUMPAD_1          0x0200690000000000
++#define BTN_NUMPAD_2          0x0200720000000000
++#define BTN_NUMPAD_3          0x02007A0000000000
++#define BTN_NUMPAD_4          0x02006B0000000000
++#define BTN_NUMPAD_5          0x0200730000000000
++#define BTN_NUMPAD_6          0x0200740000000000
++#define BTN_NUMPAD_7          0x02006C0000000000
++#define BTN_NUMPAD_8          0x0200750000000000
++#define BTN_NUMPAD_9          0x02007D0000000000
++#define BTN_NUMPAD_PLUS       0x0200790000000000
++#define BTN_NUMPAD_ENTER      0x0200810000000000
++#define BTN_NUMPAD_PERIOD     0x0200710000000000
 +
++#define BTN_MOUSE_LCLICK      0x0300000001000000
++#define BTN_MOUSE_RCLICK      0x0300000002000000
++#define BTN_MOUSE_MCLICK      0x0300000003000000
++#define BTN_MOUSE_WHEEL_UP    0x0300000004000000
++#define BTN_MOUSE_WHEEL_DOWN  0x0300000005000000
++
++#define BTN_MEDIA_SCREENSHOT      0x0500001600000000
++#define BTN_MEDIA_SHOW_KEYBOARD   0x0500001900000000
++#define BTN_MEDIA_SHOW_DESKTOP    0x0500001C00000000
++#define BTN_MEDIA_START_RECORDING 0x0500001E00000000
++#define BTN_MEDIA_MIC_OFF         0x0500000100000000
++#define BTN_MEDIA_VOL_DOWN        0x0500000200000000
++#define BTN_MEDIA_VOL_UP          0x0500000300000000
++
++#define ALLY_DEVICE_ATTR_WO(_name, _sysfs_name)    \
++	struct device_attribute dev_attr_##_name = \
++		__ATTR(_sysfs_name, 0200, NULL, _name##_store)
++
++/* required so we can have nested attributes with same name but different functions */
 +#define ALLY_DEVICE_ATTR_RW(_name, _sysfs_name)    \
 +	struct device_attribute dev_attr_##_name = \
 +		__ATTR(_sysfs_name, 0644, _name##_show, _name##_store)
@@ -4606,72 +3027,913 @@ index 000000000000..fd9c788a4a42
 +	struct device_attribute dev_attr_##_name = \
 +		__ATTR(_sysfs_name, 0444, _name##_show, NULL)
 +
-+#define ALLY_DEVICE_ATTR_WO(_name, _sysfs_name)    \
-+	struct device_attribute dev_attr_##_name = \
-+		__ATTR(_sysfs_name, 0200, NULL, _name##_store)
++/* button specific macros */
++#define ALLY_BTN_SHOW(_fname, _btn_name, _secondary)                           \
++	static ssize_t _fname##_show(struct device *dev,                       \
++				     struct device_attribute *attr, char *buf) \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		const char* name;                                              \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		name = btn_to_name(_secondary ? btn->macro : btn->button);     \
++		return sysfs_emit(buf, "%s\n", name);                          \
++	}
 +
-+#define ALLY_DEVICE_CONST_ATTR_RO(fname, sysfs_name, value)			\
-+	static ssize_t fname##_show(struct device *dev,				\
-+				   struct device_attribute *attr, char *buf)	\
-+	{									\
-+		return sprintf(buf, value);					\
-+	}									\
-+	struct device_attribute dev_attr_##fname =				\
-+		__ATTR(sysfs_name, 0444, fname##_show, NULL)
++#define ALLY_BTN_STORE(_fname, _btn_name, _secondary)                          \
++	static ssize_t _fname##_store(struct device *dev,                      \
++				      struct device_attribute *attr,           \
++				      const char *buf, size_t count)           \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		u64 code;                                                      \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		code = name_to_btn(buf);                                       \
++		if (_secondary)                                                \
++			btn->macro = code;                                     \
++		else                                                           \
++			btn->button = code;                                    \
++		return count;                                                  \
++	}
 +
-+#endif /* __ASUS_ALLY_H */
++#define ALLY_TURBO_SHOW(_fname, _btn_name)                                     \
++	static ssize_t _fname##_show(struct device *dev,                       \
++				     struct device_attribute *attr, char *buf) \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		return sysfs_emit(buf, "%d\n", btn->turbo);                    \
++	}
++
++#define ALLY_TURBO_STORE(_fname, _btn_name)                                    \
++	static ssize_t _fname##_store(struct device *dev,                      \
++				      struct device_attribute *attr,           \
++				      const char *buf, size_t count)           \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct btn_data *btn;                                          \
++		bool turbo;                                                    \
++		int ret; \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		btn = &ally_cfg->key_mapping[ally_cfg->mode - 1]._btn_name;   \
++		ret = kstrtobool(buf, &turbo);                                 \
++		if (ret)                                                       \
++			return ret;                                            \
++		btn->turbo = turbo;                                            \
++		return count;                                                  \
++	}
++
++#define ALLY_DEADZONE_SHOW(_fname, _axis_name)                                 \
++	static ssize_t _fname##_show(struct device *dev,                       \
++				     struct device_attribute *attr, char *buf) \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct deadzone *dz;                                           \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		dz = &ally_cfg->_axis_name;                                    \
++		return sysfs_emit(buf, "%d %d\n", dz->inner, dz->outer);       \
++	}
++
++#define ALLY_DEADZONE_STORE(_fname, _axis_name)                                \
++	static ssize_t _fname##_store(struct device *dev,                      \
++				      struct device_attribute *attr,           \
++				      const char *buf, size_t count)           \
++	{                                                                      \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg;       \
++		struct hid_device *hdev = to_hid_device(dev);                  \
++		u32 inner, outer;                                              \
++		if (!drvdata.gamepad_cfg)                                      \
++			return -ENODEV;                                        \
++		if (sscanf(buf, "%d %d", &inner, &outer) != 2)                 \
++			return -EINVAL;                                        \
++		if (inner > 64 || outer > 64 || inner > outer)                 \
++			return -EINVAL;                                        \
++		ally_cfg->_axis_name.inner = inner;                            \
++		ally_cfg->_axis_name.outer = outer;                            \
++		_gamepad_apply_deadzones(hdev, ally_cfg);                      \
++		return count;                                                  \
++	}
++
++#define ALLY_DEADZONES(_fname, _mname)                                    \
++	ALLY_DEADZONE_SHOW(_fname##_deadzone, _mname);                    \
++	ALLY_DEADZONE_STORE(_fname##_deadzone, _mname);                   \
++	ALLY_DEVICE_ATTR_RW(_fname##_deadzone, deadzone)
++
++/* response curve macros */
++#define ALLY_RESP_CURVE_SHOW(_fname, _mname)                             \
++static ssize_t _fname##_show(struct device *dev,                         \
++			struct device_attribute *attr,                   \
++			char *buf)                                       \
++	{                                                                \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg; \
++		if (!drvdata.gamepad_cfg)                                \
++			return -ENODEV;                                  \
++		return sysfs_emit(buf, "%d\n", ally_cfg->ls_rc._mname);  \
++	}
++
++#define ALLY_RESP_CURVE_STORE(_fname, _mname)                            \
++static ssize_t _fname##_store(struct device *dev,                        \
++			struct device_attribute *attr,                   \
++			const char *buf, size_t count)                   \
++	{                                                                \
++		struct ally_gamepad_cfg *ally_cfg = drvdata.gamepad_cfg; \
++		int ret, val;                                            \
++		if (!drvdata.gamepad_cfg)                                \
++			return -ENODEV;                                  \
++		ret = kstrtoint(buf, 0, &val);                           \
++		if (ret)                                                 \
++			return ret;                                      \
++		if (val < 0 || val > 100)                                \
++			return -EINVAL;                                  \
++		ally_cfg->ls_rc._mname = val;                            \
++		return count;                                            \
++	}
++
++/* _point_n must start at 1 */
++#define ALLY_JS_RC_POINT(_fname, _mname, _num)                                 \
++	ALLY_RESP_CURVE_SHOW(_fname##_##_mname##_##_num, _mname##_pct_##_num); \
++	ALLY_RESP_CURVE_STORE(_fname##_##_mname##_##_num, _mname##_pct_##_num); \
++	ALLY_DEVICE_ATTR_RW(_fname##_##_mname##_##_num, curve_##_mname##_pct_##_num)
++
++#define ALLY_BTN_ATTRS_GROUP(_name, _fname)                               \
++	static struct attribute *_fname##_attrs[] = {                     \
++		&dev_attr_##_fname.attr,                                  \
++		&dev_attr_##_fname##_macro.attr,                          \
++	};                                                                \
++	static const struct attribute_group _fname##_attr_group = {       \
++		.name = __stringify(_name),                               \
++		.attrs = _fname##_attrs,                                  \
++	}
++
++#define _ALLY_BTN_REMAP(_fname, _btn_name)                              \
++	ALLY_BTN_SHOW(btn_mapping_##_fname##_remap, _btn_name, false);  \
++	ALLY_BTN_STORE(btn_mapping_##_fname##_remap, _btn_name, false); \
++	ALLY_DEVICE_ATTR_RW(btn_mapping_##_fname##_remap, remap);
++
++#define _ALLY_BTN_MACRO(_fname, _btn_name)                             \
++	ALLY_BTN_SHOW(btn_mapping_##_fname##_macro, _btn_name, true);  \
++	ALLY_BTN_STORE(btn_mapping_##_fname##_macro, _btn_name, true); \
++	ALLY_DEVICE_ATTR_RW(btn_mapping_##_fname##_macro, macro_remap);
++
++#define ALLY_BTN_MAPPING(_fname, _btn_name)                                       \
++	_ALLY_BTN_REMAP(_fname, _btn_name)                                        \
++	_ALLY_BTN_MACRO(_fname, _btn_name)                                        \
++	static struct attribute *_fname##_attrs[] = {                             \
++		&dev_attr_btn_mapping_##_fname##_remap.attr,                      \
++		&dev_attr_btn_mapping_##_fname##_macro.attr,                      \
++		NULL,                                                             \
++	};                                                                        \
++	static const struct attribute_group btn_mapping_##_fname##_attr_group = { \
++		.name = __stringify(btn_##_fname),                                \
++		.attrs = _fname##_attrs,                                          \
++	}
++
++#define ALLY_TURBO_BTN_MAPPING(_fname, _btn_name)                                 \
++	_ALLY_BTN_REMAP(_fname, _btn_name)                                        \
++	_ALLY_BTN_MACRO(_fname, _btn_name)                                        \
++	ALLY_TURBO_SHOW(btn_mapping_##_fname##_turbo, _btn_name);                 \
++	ALLY_TURBO_STORE(btn_mapping_##_fname##_turbo, _btn_name);                \
++	ALLY_DEVICE_ATTR_RW(btn_mapping_##_fname##_turbo, turbo);                 \
++	static struct attribute *_fname##_turbo_attrs[] = {                       \
++		&dev_attr_btn_mapping_##_fname##_remap.attr,                      \
++		&dev_attr_btn_mapping_##_fname##_macro.attr,                      \
++		&dev_attr_btn_mapping_##_fname##_turbo.attr,                      \
++		NULL,                                                             \
++	};                                                                        \
++	static const struct attribute_group btn_mapping_##_fname##_attr_group = { \
++		.name = __stringify(btn_##_fname),                                \
++		.attrs = _fname##_turbo_attrs,                                    \
++	}
 diff --git a/drivers/hid/hid-asus.c b/drivers/hid/hid-asus.c
-index 599c836507ff..52882d6589e1 100644
+index 599c83650..4805d1505 100644
 --- a/drivers/hid/hid-asus.c
 +++ b/drivers/hid/hid-asus.c
-@@ -624,6 +624,9 @@ static void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
- 		hid_warn(hdev,
- 			"The MCU firmware version must be %d or greater to avoid issues with suspend.\n",
- 			min_version);
-+	} else {
-+		set_ally_mcu_hack(ASUS_WMI_ALLY_MCU_HACK_DISABLED);
-+		set_ally_mcu_powersave(true);
+@@ -23,6 +23,8 @@
+ /*
+  */
+ 
++#include <linux/array_size.h>
++#include "linux/export.h"
+ #include <linux/dmi.h>
+ #include <linux/hid.h>
+ #include <linux/module.h>
+@@ -30,9 +32,11 @@
+ #include <linux/input/mt.h>
+ #include <linux/usb.h> /* For to_usb_interface for T100 touchpad intf check */
+ #include <linux/power_supply.h>
++#include <linux/led-class-multicolor.h>
+ #include <linux/leds.h>
+ 
+ #include "hid-ids.h"
++#include "hid-asus.h"
+ 
+ MODULE_AUTHOR("Yusuke Fujimaki <usk.fujimaki@gmail.com>");
+ MODULE_AUTHOR("Brendan McGrath <redmcg@redmandi.dyndns.org>");
+@@ -47,10 +51,12 @@ MODULE_DESCRIPTION("Asus HID Keyboard and TouchPad");
+ #define T100CHI_MOUSE_REPORT_ID 0x06
+ #define FEATURE_REPORT_ID 0x0d
+ #define INPUT_REPORT_ID 0x5d
++#define HID_USAGE_PAGE_VENDOR 0xff310000
+ #define FEATURE_KBD_REPORT_ID 0x5a
+-#define FEATURE_KBD_REPORT_SIZE 16
++#define FEATURE_KBD_REPORT_SIZE 64
+ #define FEATURE_KBD_LED_REPORT_ID1 0x5d
+ #define FEATURE_KBD_LED_REPORT_ID2 0x5e
++#define FEATURE_KBD_LED_REPORT_SIZE 7
+ 
+ #define ROG_ALLY_REPORT_SIZE 64
+ #define ROG_ALLY_X_MIN_MCU 313
+@@ -89,6 +95,9 @@ MODULE_DESCRIPTION("Asus HID Keyboard and TouchPad");
+ #define QUIRK_ROG_NKEY_KEYBOARD		BIT(11)
+ #define QUIRK_ROG_CLAYMORE_II_KEYBOARD BIT(12)
+ #define QUIRK_ROG_ALLY_XPAD		BIT(13)
++#define QUIRK_HANDLE_GENERIC		BIT(14)
++#define QUIRK_ROG_NKEY_RGB		BIT(15)
++#define QUIRK_ROG_NKEY_LEGACY		BIT(16)
+ 
+ #define I2C_KEYBOARD_QUIRKS			(QUIRK_FIX_NOTEBOOK_REPORT | \
+ 						 QUIRK_NO_INIT_REPORTS | \
+@@ -100,10 +109,16 @@ MODULE_DESCRIPTION("Asus HID Keyboard and TouchPad");
+ #define TRKID_SGN       ((TRKID_MAX + 1) >> 1)
+ 
+ struct asus_kbd_leds {
+-	struct led_classdev cdev;
++	struct asus_hid_listener listener;
++	struct led_classdev_mc mc_led;
++	struct mc_subled subled_info[3];
+ 	struct hid_device *hdev;
+ 	struct work_struct work;
+ 	unsigned int brightness;
++	u8 rgb_colors[3];
++	bool rgb_init;
++	bool rgb_set;
++	bool rgb_registered;
+ 	spinlock_t lock;
+ 	bool removed;
+ };
+@@ -125,7 +140,6 @@ struct asus_drvdata {
+ 	struct input_dev *tp_kbd_input;
+ 	struct asus_kbd_leds *kbd_backlight;
+ 	const struct asus_touchpad_info *tp;
+-	bool enable_backlight;
+ 	struct power_supply *battery;
+ 	struct power_supply_desc battery_desc;
+ 	int battery_capacity;
+@@ -316,13 +330,24 @@ static int asus_e1239t_event(struct asus_drvdata *drvdat, u8 *data, int size)
+ static int asus_event(struct hid_device *hdev, struct hid_field *field,
+ 		      struct hid_usage *usage, __s32 value)
+ {
+-	if ((usage->hid & HID_USAGE_PAGE) == 0xff310000 &&
++	if ((usage->hid & HID_USAGE_PAGE) == HID_USAGE_PAGE_VENDOR &&
+ 	    (usage->hid & HID_USAGE) != 0x00 &&
+ 	    (usage->hid & HID_USAGE) != 0xff && !usage->type) {
+ 		hid_warn(hdev, "Unmapped Asus vendor usagepage code 0x%02x\n",
+ 			 usage->hid & HID_USAGE);
  	}
+ 
++	if (usage->type == EV_KEY && value) {
++		switch (usage->code) {
++		case KEY_KBDILLUMUP:
++			return !asus_hid_event(ASUS_EV_BRTUP);
++		case KEY_KBDILLUMDOWN:
++			return !asus_hid_event(ASUS_EV_BRTDOWN);
++		case KEY_KBDILLUMTOGGLE:
++			return !asus_hid_event(ASUS_EV_BRTTOGGLE);
++		}
++	}
++
+ 	return 0;
  }
  
-@@ -1381,12 +1384,17 @@ static const struct hid_device_id asus_devices[] = {
+@@ -331,6 +356,10 @@ static int asus_raw_event(struct hid_device *hdev,
+ {
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return 0;
++
+ 	if (drvdata->battery && data[0] == BATTERY_REPORT_ID)
+ 		return asus_report_battery(drvdata, data, size);
+ 
+@@ -393,14 +422,37 @@ static int asus_kbd_set_report(struct hid_device *hdev, const u8 *buf, size_t bu
+ 
+ static int asus_kbd_init(struct hid_device *hdev, u8 report_id)
+ {
+-	const u8 buf[] = { report_id, 0x41, 0x53, 0x55, 0x53, 0x20, 0x54,
+-		     0x65, 0x63, 0x68, 0x2e, 0x49, 0x6e, 0x63, 0x2e, 0x00 };
++	/*
++	 * The handshake is first sent as a set_report, then retrieved
++	 * from a get_report. They should be equal.
++	 */
++	const u8 buf[] = { report_id, 0x41, 0x53, 0x55, 0x53, 0x20,
++		0x54, 0x65, 0x63, 0x68, 0x2e, 0x49, 0x6e, 0x63, 0x2e, 0x00 };
++	u8 *readbuf;
+ 	int ret;
+ 
+ 	ret = asus_kbd_set_report(hdev, buf, sizeof(buf));
+-	if (ret < 0)
+-		hid_err(hdev, "Asus failed to send init command: %d\n", ret);
++	if (ret < 0) {
++		hid_err(hdev, "Asus failed to send handshake: %d\n", ret);
++		return ret;
++	}
++
++	readbuf = kzalloc(FEATURE_KBD_REPORT_SIZE, GFP_KERNEL);
++	if (!readbuf)
++		return -ENOMEM;
++
++	ret = hid_hw_raw_request(hdev, report_id, readbuf,
++				 FEATURE_KBD_REPORT_SIZE, HID_FEATURE_REPORT,
++				 HID_REQ_GET_REPORT);
++	if (ret < 0) {
++		hid_err(hdev, "Asus failed to receive handshake ack: %d\n", ret);
++	} else if (memcmp(readbuf, buf, sizeof(buf)) != 0) {
++		hid_warn(hdev, "Asus handshake returned invalid response: %*ph\n",
++			FEATURE_KBD_REPORT_SIZE, readbuf);
++		// Do not return error if handshake is wrong to avoid regressions
++	}
+ 
++	kfree(readbuf);
+ 	return ret;
+ }
+ 
+@@ -422,7 +474,7 @@ static int asus_kbd_get_functions(struct hid_device *hdev,
+ 	if (!readbuf)
+ 		return -ENOMEM;
+ 
+-	ret = hid_hw_raw_request(hdev, FEATURE_KBD_REPORT_ID, readbuf,
++	ret = hid_hw_raw_request(hdev, report_id, readbuf,
+ 				 FEATURE_KBD_REPORT_SIZE, HID_FEATURE_REPORT,
+ 				 HID_REQ_GET_REPORT);
+ 	if (ret < 0) {
+@@ -467,11 +519,8 @@ static void asus_schedule_work(struct asus_kbd_leds *led)
+ 	spin_unlock_irqrestore(&led->lock, flags);
+ }
+ 
+-static void asus_kbd_backlight_set(struct led_classdev *led_cdev,
+-				   enum led_brightness brightness)
++static void do_asus_kbd_backlight_set(struct asus_kbd_leds *led, int brightness)
+ {
+-	struct asus_kbd_leds *led = container_of(led_cdev, struct asus_kbd_leds,
+-						 cdev);
+ 	unsigned long flags;
+ 
+ 	spin_lock_irqsave(&led->lock, flags);
+@@ -481,13 +530,47 @@ static void asus_kbd_backlight_set(struct led_classdev *led_cdev,
+ 	asus_schedule_work(led);
+ }
+ 
+-static enum led_brightness asus_kbd_backlight_get(struct led_classdev *led_cdev)
++static void asus_kbd_listener_set(struct asus_hid_listener *listener,
++				   int brightness)
++{
++	struct asus_kbd_leds *led = container_of(listener, struct asus_kbd_leds,
++						 listener);
++	do_asus_kbd_backlight_set(led, brightness);
++	if (led->rgb_registered) {
++		led->mc_led.led_cdev.brightness = brightness;
++		led_classdev_notify_brightness_hw_changed(&led->mc_led.led_cdev,
++							  brightness);
++	}
++}
++
++static void asus_kbd_brightness_set(struct led_classdev *led_cdev,
++				    enum led_brightness brightness)
++{
++	struct led_classdev_mc *mc_cdev = lcdev_to_mccdev(led_cdev);
++	struct asus_kbd_leds *led = container_of(mc_cdev, struct asus_kbd_leds,
++						 mc_led);
++	unsigned long flags;
++
++	spin_lock_irqsave(&led->lock, flags);
++	led->rgb_colors[0] = mc_cdev->subled_info[0].intensity;
++	led->rgb_colors[1] = mc_cdev->subled_info[1].intensity;
++	led->rgb_colors[2] = mc_cdev->subled_info[2].intensity;
++	led->rgb_set = true;
++	spin_unlock_irqrestore(&led->lock, flags);
++
++	do_asus_kbd_backlight_set(led, brightness);
++}
++
++static enum led_brightness asus_kbd_brightness_get(struct led_classdev *led_cdev)
+ {
+-	struct asus_kbd_leds *led = container_of(led_cdev, struct asus_kbd_leds,
+-						 cdev);
++	struct led_classdev_mc *mc_led;
++	struct asus_kbd_leds *led;
+ 	enum led_brightness brightness;
+ 	unsigned long flags;
+ 
++	mc_led = lcdev_to_mccdev(led_cdev);
++	led = container_of(mc_led, struct asus_kbd_leds, mc_led);
++
+ 	spin_lock_irqsave(&led->lock, flags);
+ 	brightness = led->brightness;
+ 	spin_unlock_irqrestore(&led->lock, flags);
+@@ -495,9 +578,8 @@ static enum led_brightness asus_kbd_backlight_get(struct led_classdev *led_cdev)
+ 	return brightness;
+ }
+ 
+-static void asus_kbd_backlight_work(struct work_struct *work)
++static void asus_kbd_backlight_work(struct asus_kbd_leds *led)
+ {
+-	struct asus_kbd_leds *led = container_of(work, struct asus_kbd_leds, work);
+ 	u8 buf[] = { FEATURE_KBD_REPORT_ID, 0xba, 0xc5, 0xc4, 0x00 };
+ 	int ret;
+ 	unsigned long flags;
+@@ -511,34 +593,6 @@ static void asus_kbd_backlight_work(struct work_struct *work)
+ 		hid_err(led->hdev, "Asus failed to set keyboard backlight: %d\n", ret);
+ }
+ 
+-/* WMI-based keyboard backlight LED control (via asus-wmi driver) takes
+- * precedence. We only activate HID-based backlight control when the
+- * WMI control is not available.
+- */
+-static bool asus_kbd_wmi_led_control_present(struct hid_device *hdev)
+-{
+-	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+-	u32 value;
+-	int ret;
+-
+-	if (!IS_ENABLED(CONFIG_ASUS_WMI))
+-		return false;
+-
+-	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD &&
+-			dmi_check_system(asus_use_hid_led_dmi_ids)) {
+-		hid_info(hdev, "using HID for asus::kbd_backlight\n");
+-		return false;
+-	}
+-
+-	ret = asus_wmi_evaluate_method(ASUS_WMI_METHODID_DSTS,
+-				       ASUS_WMI_DEVID_KBD_BACKLIGHT, 0, &value);
+-	hid_dbg(hdev, "WMI backlight check: rc %d value %x", ret, value);
+-	if (ret)
+-		return false;
+-
+-	return !!(value & ASUS_WMI_DSTS_PRESENCE_BIT);
+-}
+-
+ /*
+  * We don't care about any other part of the string except the version section.
+  * Example strings: FGA80100.RC72LA.312_T01, FGA80100.RC71LS.318_T01
+@@ -601,7 +655,7 @@ static int mcu_request_version(struct hid_device *hdev)
+ 	return ret;
+ }
+ 
+-static void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
++void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
+ {
+ 	int min_version, version;
+ 
+@@ -626,58 +680,112 @@ static void validate_mcu_fw_version(struct hid_device *hdev, int idProduct)
+ 			min_version);
+ 	}
+ }
++EXPORT_SYMBOL_NS(validate_mcu_fw_version, "HID_ASUS");
++
++static void asus_kbd_rgb_work(struct asus_kbd_leds *led)
++{
++	u8 rgb_buf[][FEATURE_KBD_LED_REPORT_SIZE] = {
++		{ FEATURE_KBD_LED_REPORT_ID1, 0xB3 }, /* set mode */
++		{ FEATURE_KBD_LED_REPORT_ID1, 0xB5 }, /* apply mode */
++		{ FEATURE_KBD_LED_REPORT_ID1, 0xB4 }, /* save to mem */
++	};
++	unsigned long flags;
++	uint8_t colors[3];
++	bool rgb_init, rgb_set;
++	int ret;
++
++	spin_lock_irqsave(&led->lock, flags);
++	rgb_init = led->rgb_init;
++	rgb_set = led->rgb_set;
++	led->rgb_set = false;
++	colors[0] = led->rgb_colors[0];
++	colors[1] = led->rgb_colors[1];
++	colors[2] = led->rgb_colors[2];
++	spin_unlock_irqrestore(&led->lock, flags);
++
++	if (!rgb_set)
++		return;
++
++	if (rgb_init) {
++		ret = asus_kbd_init(led->hdev, FEATURE_KBD_LED_REPORT_ID1);
++		if (ret < 0) {
++			hid_err(led->hdev, "Asus failed to init RGB: %d\n", ret);
++			return;
++		}
++		spin_lock_irqsave(&led->lock, flags);
++		led->rgb_init = false;
++		spin_unlock_irqrestore(&led->lock, flags);
++	}
++
++	/* Protocol is: 54b3 zone (0=all) mode (0=solid) RGB */
++	rgb_buf[0][4] = colors[0];
++	rgb_buf[0][5] = colors[1];
++	rgb_buf[0][6] = colors[2];
++
++	for (size_t i = 0; i < ARRAY_SIZE(rgb_buf); i++) {
++		ret = asus_kbd_set_report(led->hdev, rgb_buf[i], sizeof(rgb_buf[i]));
++		if (ret < 0) {
++			hid_err(led->hdev, "Asus failed to set RGB: %d\n", ret);
++			return;
++		}
++	}
++}
++
++static void asus_kbd_work(struct work_struct *work)
++{
++	struct asus_kbd_leds *led = container_of(work, struct asus_kbd_leds,
++						 work);
++	asus_kbd_backlight_work(led);
++	asus_kbd_rgb_work(led);
++}
+ 
+ static int asus_kbd_register_leds(struct hid_device *hdev)
+ {
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+-	struct usb_interface *intf;
+-	struct usb_device *udev;
++	struct asus_kbd_leds *leds;
+ 	unsigned char kbd_func;
++	bool rgb_init = true;
+ 	int ret;
+ 
+-	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD) {
+-		/* Initialize keyboard */
+-		ret = asus_kbd_init(hdev, FEATURE_KBD_REPORT_ID);
+-		if (ret < 0)
+-			return ret;
++	ret = asus_kbd_init(hdev, FEATURE_KBD_REPORT_ID);
++	if (ret < 0)
++		return ret;
+ 
+-		/* The LED endpoint is initialised in two HID */
++	if (drvdata->quirks & QUIRK_ROG_NKEY_LEGACY) {
++		/*
++		 * These keyboards might need 0x5d for shortcuts to work.
++		 * As it has been more than 5 years, it is hard to verify.
++		 */
+ 		ret = asus_kbd_init(hdev, FEATURE_KBD_LED_REPORT_ID1);
+ 		if (ret < 0)
+ 			return ret;
+ 
+-		ret = asus_kbd_init(hdev, FEATURE_KBD_LED_REPORT_ID2);
+-		if (ret < 0)
+-			return ret;
+-
+-		if (dmi_match(DMI_PRODUCT_FAMILY, "ProArt P16")) {
+-			ret = asus_kbd_disable_oobe(hdev);
+-			if (ret < 0)
+-				return ret;
+-		}
+-
+-		if (drvdata->quirks & QUIRK_ROG_ALLY_XPAD) {
+-			intf = to_usb_interface(hdev->dev.parent);
+-			udev = interface_to_usbdev(intf);
+-			validate_mcu_fw_version(hdev,
+-				le16_to_cpu(udev->descriptor.idProduct));
+-		}
++		rgb_init = false;
++	}
+ 
+-	} else {
+-		/* Initialize keyboard */
+-		ret = asus_kbd_init(hdev, FEATURE_KBD_REPORT_ID);
+-		if (ret < 0)
+-			return ret;
++	/* Get keyboard functions */
++	ret = asus_kbd_get_functions(hdev, &kbd_func, FEATURE_KBD_REPORT_ID);
++	if (ret < 0)
++		return ret;
+ 
+-		/* Get keyboard functions */
+-		ret = asus_kbd_get_functions(hdev, &kbd_func, FEATURE_KBD_REPORT_ID);
++	if (dmi_match(DMI_PRODUCT_FAMILY, "ProArt P16")) {
++		ret = asus_kbd_disable_oobe(hdev);
+ 		if (ret < 0)
+ 			return ret;
++	}
+ 
+-		/* Check for backlight support */
+-		if (!(kbd_func & SUPPORT_KBD_BACKLIGHT))
+-			return -ENODEV;
++#if !IS_REACHABLE(CONFIG_HID_ASUS_ALLY)
++	if (drvdata->quirks & QUIRK_ROG_ALLY_XPAD) {
++		struct usb_interface *intf = to_usb_interface(hdev->dev.parent);
++		struct usb_device *udev = interface_to_usbdev(intf);
++		validate_mcu_fw_version(
++			hdev, le16_to_cpu(udev->descriptor.idProduct));
+ 	}
++#endif
++
++	/* Check for backlight support */
++	if (!(kbd_func & SUPPORT_KBD_BACKLIGHT))
++		return -ENODEV;
+ 
+ 	drvdata->kbd_backlight = devm_kzalloc(&hdev->dev,
+ 					      sizeof(struct asus_kbd_leds),
+@@ -685,23 +793,47 @@ static int asus_kbd_register_leds(struct hid_device *hdev)
+ 	if (!drvdata->kbd_backlight)
+ 		return -ENOMEM;
+ 
+-	drvdata->kbd_backlight->removed = false;
+-	drvdata->kbd_backlight->brightness = 0;
+-	drvdata->kbd_backlight->hdev = hdev;
+-	drvdata->kbd_backlight->cdev.name = "asus::kbd_backlight";
+-	drvdata->kbd_backlight->cdev.max_brightness = 3;
+-	drvdata->kbd_backlight->cdev.brightness_set = asus_kbd_backlight_set;
+-	drvdata->kbd_backlight->cdev.brightness_get = asus_kbd_backlight_get;
+-	INIT_WORK(&drvdata->kbd_backlight->work, asus_kbd_backlight_work);
++	leds = drvdata->kbd_backlight;
++	leds->removed = false;
++	leds->brightness = ASUS_EV_MAX_BRIGHTNESS;
++	leds->hdev = hdev;
++	leds->listener.brightness_set = asus_kbd_listener_set;
++
++	leds->rgb_colors[0] = 0;
++	leds->rgb_colors[1] = 0;
++	leds->rgb_colors[2] = 0;
++	leds->rgb_init = rgb_init;
++	leds->rgb_set = false;
++	leds->mc_led.led_cdev.name = devm_kasprintf(&hdev->dev, GFP_KERNEL,
++					"asus-%s:rgb:peripheral",
++					strlen(hdev->uniq) ?
++					hdev->uniq : dev_name(&hdev->dev));
++	leds->mc_led.led_cdev.flags = LED_BRIGHT_HW_CHANGED;
++	leds->mc_led.led_cdev.max_brightness = ASUS_EV_MAX_BRIGHTNESS;
++	leds->mc_led.led_cdev.brightness_set = asus_kbd_brightness_set;
++	leds->mc_led.led_cdev.brightness_get = asus_kbd_brightness_get;
++	leds->mc_led.subled_info = leds->subled_info;
++	leds->mc_led.num_colors = ARRAY_SIZE(leds->subled_info);
++	leds->subled_info[0].color_index = LED_COLOR_ID_RED;
++	leds->subled_info[1].color_index = LED_COLOR_ID_GREEN;
++	leds->subled_info[2].color_index = LED_COLOR_ID_BLUE;
++
++	INIT_WORK(&drvdata->kbd_backlight->work, asus_kbd_work);
+ 	spin_lock_init(&drvdata->kbd_backlight->lock);
+ 
+-	ret = devm_led_classdev_register(&hdev->dev, &drvdata->kbd_backlight->cdev);
+-	if (ret < 0) {
+-		/* No need to have this still around */
+-		devm_kfree(&hdev->dev, drvdata->kbd_backlight);
++	ret = asus_hid_register_listener(&drvdata->kbd_backlight->listener);
++	/* Asus-wmi might not be accessible so this is not fatal. */
++	if (!ret)
++		hid_warn(hdev, "Asus-wmi brightness listener not registered\n");
++
++	if (drvdata->quirks & QUIRK_ROG_NKEY_RGB) {
++		ret = devm_led_classdev_multicolor_register(&hdev->dev, &leds->mc_led);
++		if (!ret)
++			leds->rgb_registered = true;
++		return ret;
+ 	}
+ 
+-	return ret;
++	return 0;
+ }
+ 
+ /*
+@@ -867,6 +999,10 @@ static int asus_input_configured(struct hid_device *hdev, struct hid_input *hi)
+ 	struct input_dev *input = hi->input;
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return 0;
++
+ 	/* T100CHI uses MULTI_INPUT, bind the touchpad to the mouse hid_input */
+ 	if (drvdata->quirks & QUIRK_T100CHI &&
+ 	    hi->report->id != T100CHI_MOUSE_REPORT_ID)
+@@ -920,11 +1056,6 @@ static int asus_input_configured(struct hid_device *hdev, struct hid_input *hi)
+ 
+ 	drvdata->input = input;
+ 
+-	if (drvdata->enable_backlight &&
+-	    !asus_kbd_wmi_led_control_present(hdev) &&
+-	    asus_kbd_register_leds(hdev))
+-		hid_warn(hdev, "Failed to initialize backlight.\n");
+-
+ 	return 0;
+ }
+ 
+@@ -944,6 +1075,10 @@ static int asus_input_mapping(struct hid_device *hdev,
+ 		return -1;
+ 	}
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return 0;
++
+ 	/*
+ 	 * Ignore a bunch of bogus collections in the T100CHI descriptor.
+ 	 * This avoids a bunch of non-functional hid_input devices getting
+@@ -994,15 +1129,6 @@ static int asus_input_mapping(struct hid_device *hdev,
+ 			return -1;
+ 		}
+ 
+-		/*
+-		 * Check and enable backlight only on devices with UsagePage ==
+-		 * 0xff31 to avoid initializing the keyboard firmware multiple
+-		 * times on devices with multiple HID descriptors but same
+-		 * PID/VID.
+-		 */
+-		if (drvdata->quirks & QUIRK_USE_KBD_BACKLIGHT)
+-			drvdata->enable_backlight = true;
+-
+ 		set_bit(EV_REP, hi->input->evbit);
+ 		return 1;
+ 	}
+@@ -1095,7 +1221,7 @@ static int __maybe_unused asus_resume(struct hid_device *hdev) {
+ 
+ 	if (drvdata->kbd_backlight) {
+ 		const u8 buf[] = { FEATURE_KBD_REPORT_ID, 0xba, 0xc5, 0xc4,
+-				drvdata->kbd_backlight->cdev.brightness };
++				drvdata->kbd_backlight->brightness };
+ 		ret = asus_kbd_set_report(hdev, buf, sizeof(buf));
+ 		if (ret < 0) {
+ 			hid_err(hdev, "Asus failed to set keyboard backlight: %d\n", ret);
+@@ -1119,8 +1245,12 @@ static int __maybe_unused asus_reset_resume(struct hid_device *hdev)
+ 
+ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ {
+-	int ret;
++	struct hid_report_enum *rep_enum;
+ 	struct asus_drvdata *drvdata;
++	struct usb_host_endpoint *ep;
++	struct usb_interface *intf;
++	struct hid_report *rep;
++	int ret, is_vendor = 0;
+ 
+ 	drvdata = devm_kzalloc(&hdev->dev, sizeof(*drvdata), GFP_KERNEL);
+ 	if (drvdata == NULL) {
+@@ -1132,6 +1262,18 @@ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 
+ 	drvdata->quirks = id->driver_data;
+ 
++	/* Ignore these endpoints as they are used by hid-asus-ally */
++	#if IS_REACHABLE(CONFIG_HID_ASUS_ALLY)
++	if (drvdata->quirks & QUIRK_ROG_ALLY_XPAD) {
++		intf = to_usb_interface(hdev->dev.parent);
++		ep = intf->cur_altsetting->endpoint;
++		if (ep->desc.bEndpointAddress == ROG_ALLY_X_INTF_IN ||
++			ep->desc.bEndpointAddress == ROG_ALLY_CFG_INTF_IN ||
++			ep->desc.bEndpointAddress == ROG_ALLY_CFG_INTF_OUT)
++			return -ENODEV;
++	}
++	#endif /* IS_REACHABLE(CONFIG_HID_ASUS_ALLY) */
++
+ 	/*
+ 	 * T90CHI's keyboard dock returns same ID values as T100CHI's dock.
+ 	 * Thus, identify T90CHI dock with product name string.
+@@ -1204,12 +1346,41 @@ static int asus_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 		return ret;
+ 	}
+ 
++	/* Check for vendor for RGB init and handle generic devices properly. */
++	rep_enum = &hdev->report_enum[HID_INPUT_REPORT];
++	list_for_each_entry(rep, &rep_enum->report_list, list) {
++		if ((rep->application & HID_USAGE_PAGE) == HID_USAGE_PAGE_VENDOR)
++			is_vendor = true;
++	}
++
++	/*
++	 * For ROG keyboards, make them hid compliant by
++	 * creating one input per application. For interfaces other than
++	 * the vendor one, disable hid-asus handlers.
++	 */
++	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD) {
++		if (!is_vendor)
++			drvdata->quirks |= QUIRK_HANDLE_GENERIC;
++		hdev->quirks |= HID_QUIRK_INPUT_PER_APP;
++	}
++
+ 	ret = hid_hw_start(hdev, HID_CONNECT_DEFAULT);
+ 	if (ret) {
+ 		hid_err(hdev, "Asus hw start failed: %d\n", ret);
+ 		return ret;
+ 	}
+ 
++	if (is_vendor && (drvdata->quirks & QUIRK_USE_KBD_BACKLIGHT) &&
++	    asus_kbd_register_leds(hdev))
++		hid_warn(hdev, "Failed to initialize backlight.\n");
++
++	/*
++	 * For ROG keyboards, skip rename for consistency and ->input check as
++	 * some devices do not have inputs.
++	 */
++	if (drvdata->quirks & QUIRK_ROG_NKEY_KEYBOARD)
++		return 0;
++
+ 	if (!drvdata->input) {
+ 		hid_err(hdev, "Asus input not registered\n");
+ 		ret = -ENOMEM;
+@@ -1240,6 +1411,8 @@ static void asus_remove(struct hid_device *hdev)
+ 	unsigned long flags;
+ 
+ 	if (drvdata->kbd_backlight) {
++		asus_hid_unregister_listener(&drvdata->kbd_backlight->listener);
++
+ 		spin_lock_irqsave(&drvdata->kbd_backlight->lock, flags);
+ 		drvdata->kbd_backlight->removed = true;
+ 		spin_unlock_irqrestore(&drvdata->kbd_backlight->lock, flags);
+@@ -1260,6 +1433,10 @@ static const __u8 *asus_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ {
+ 	struct asus_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
++	/* NOOP on generic HID devices to avoid side effects. */
++	if (drvdata->quirks & QUIRK_HANDLE_GENERIC)
++		return rdesc;
++
+ 	if (drvdata->quirks & QUIRK_FIX_NOTEBOOK_REPORT &&
+ 			*rsize >= 56 && rdesc[54] == 0x25 && rdesc[55] == 0x65) {
+ 		hid_info(hdev, "Fixing up Asus notebook report descriptor\n");
+@@ -1371,22 +1548,21 @@ static const struct hid_device_id asus_devices[] = {
+ 	  QUIRK_USE_KBD_BACKLIGHT },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+ 	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD),
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_LEGACY },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+ 	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD2),
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
+-	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD3),
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_LEGACY },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_Z13_LIGHTBAR),
- 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
-+
-+	/* asus-ally-hid driver takes over */
-+	#if !IS_REACHABLE(CONFIG_ASUS_ALLY_HID)
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_RGB },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY),
- 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD},
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD},
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD
++		| QUIRK_ROG_ALLY_XPAD | QUIRK_ROG_NKEY_RGB },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X),
- 	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD },
-+	#endif /* !IS_REACHABLE(CONFIG_ASUS_ALLY_HID) */
-+
+-	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_ALLY_XPAD },
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD
++		| QUIRK_ROG_ALLY_XPAD | QUIRK_ROG_NKEY_RGB },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_ASUSTEK,
  	    USB_DEVICE_ID_ASUSTEK_ROG_CLAYMORE_II_KEYBOARD),
  	  QUIRK_ROG_CLAYMORE_II_KEYBOARD },
-@@ -1430,4 +1438,5 @@ static struct hid_driver asus_driver = {
- };
- module_hid_driver(asus_driver);
- 
-+MODULE_IMPORT_NS("ASUS_WMI");
- MODULE_LICENSE("GPL");
+@@ -1407,6 +1583,9 @@ static const struct hid_device_id asus_devices[] = {
+ 	 * Note bind to the HID_GROUP_GENERIC group, so that we only bind to the keyboard
+ 	 * part, while letting hid-multitouch.c handle the touchpad.
+ 	 */
++	{ HID_DEVICE(BUS_USB, HID_GROUP_GENERIC,
++		USB_VENDOR_ID_ASUSTEK, USB_DEVICE_ID_ASUSTEK_ROG_Z13_FOLIO),
++	  QUIRK_USE_KBD_BACKLIGHT | QUIRK_ROG_NKEY_KEYBOARD | QUIRK_ROG_NKEY_RGB },
+ 	{ HID_DEVICE(BUS_USB, HID_GROUP_GENERIC,
+ 		USB_VENDOR_ID_ASUSTEK, USB_DEVICE_ID_ASUSTEK_T101HA_KEYBOARD) },
+ 	{ }
+diff --git a/drivers/hid/hid-asus.h b/drivers/hid/hid-asus.h
+new file mode 100644
+index 000000000..f67dd5a3a
+--- /dev/null
++++ b/drivers/hid/hid-asus.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __HID_ASUS_H
++#define __HID_ASUS_H
++
++#include <linux/hid.h>
++
++#define ROG_ALLY_CFG_INTF_IN 0x83
++#define ROG_ALLY_CFG_INTF_OUT 0x04
++#define ROG_ALLY_X_INTF_IN 0x87
++
++void validate_mcu_fw_version(struct hid_device *hdev, int idProduct);
++
++#endif	/* __HID_ASUS_H */
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index b937af010e35..965ee2da07d2 100644
+index b937af010..82f39fa14 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -221,6 +221,7 @@
+@@ -219,8 +219,9 @@
+ #define USB_DEVICE_ID_ASUSTEK_ROG_KEYBOARD3 0x1822
+ #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD	0x1866
  #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD2	0x19b6
- #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD3	0x1a30
+-#define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_KEYBOARD3	0x1a30
++#define USB_DEVICE_ID_ASUSTEK_ROG_Z13_FOLIO		0x1a30
  #define USB_DEVICE_ID_ASUSTEK_ROG_Z13_LIGHTBAR		0x18c6
 +#define USB_DEVICE_ID_ASUSTEK_ROG_RAIKIRI_PAD		0x1abb
  #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY		0x1abe
  #define USB_DEVICE_ID_ASUSTEK_ROG_NKEY_ALLY_X		0x1b4c
  #define USB_DEVICE_ID_ASUSTEK_ROG_CLAYMORE_II_KEYBOARD	0x196b
 diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
-index 43407e76476b..731d18308cb6 100644
+index 43407e764..731d18308 100644
 --- a/drivers/platform/x86/Kconfig
 +++ b/drivers/platform/x86/Kconfig
 @@ -267,6 +267,18 @@ config ASUS_WIRELESS
@@ -4712,7 +3974,7 @@ index 43407e76476b..731d18308cb6 100644
  	tristate "Asus Notebook WMI Driver"
  	depends on ASUS_WMI
 diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index 650dfbebb6c8..3a0085f941d9 100644
+index 9a1884b03..c2461ca2e 100644
 --- a/drivers/platform/x86/Makefile
 +++ b/drivers/platform/x86/Makefile
 @@ -32,6 +32,7 @@ obj-$(CONFIG_APPLE_GMUX)	+= apple-gmux.o
@@ -4725,22 +3987,27 @@ index 650dfbebb6c8..3a0085f941d9 100644
  obj-$(CONFIG_ASUS_TF103C_DOCK)	+= asus-tf103c-dock.o
 diff --git a/drivers/platform/x86/asus-armoury.c b/drivers/platform/x86/asus-armoury.c
 new file mode 100644
-index 000000000000..84abc92bd365
+index 000000000..a461be936
 --- /dev/null
 +++ b/drivers/platform/x86/asus-armoury.c
-@@ -0,0 +1,1202 @@
+@@ -0,0 +1,1174 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
-+ * Asus Armoury (WMI) attributes driver. This driver uses the fw_attributes
-+ * class to expose the various WMI functions that many gaming and some
-+ * non-gaming ASUS laptops have available.
++ * Asus Armoury (WMI) attributes driver.
++ *
++ * This driver uses the fw_attributes class to expose various WMI functions
++ * that are present in many gaming and some non-gaming ASUS laptops.
++ *
 + * These typically don't fit anywhere else in the sysfs such as under LED class,
-+ * hwmon or other, and are set in Windows using the ASUS Armoury Crate tool.
++ * hwmon or others, and are set in Windows using the ASUS Armoury Crate tool.
 + *
 + * Copyright(C) 2024 Luke Jones <luke@ljones.dev>
 + */
 +
++#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
++
 +#include <linux/acpi.h>
++#include <linux/array_size.h>
 +#include <linux/bitfield.h>
 +#include <linux/device.h>
 +#include <linux/dmi.h>
@@ -4752,6 +4019,7 @@ index 000000000000..84abc92bd365
 +#include <linux/module.h>
 +#include <linux/mutex.h>
 +#include <linux/platform_data/x86/asus-wmi.h>
++#include <linux/printk.h>
 +#include <linux/power_supply.h>
 +#include <linux/types.h>
 +
@@ -4782,8 +4050,8 @@ index 000000000000..84abc92bd365
 +#define ATTR_NV_BASE_TGP        "nv_base_tgp"
 +#define ATTR_NV_TGP             "nv_tgp"
 +
-+#define ASUS_POWER_CORE_MASK GENMASK(15, 8)
-+#define ASUS_PERF_CORE_MASK GENMASK(7, 0)
++#define ASUS_POWER_CORE_MASK	GENMASK(15, 8)
++#define ASUS_PERF_CORE_MASK		GENMASK(7, 0)
 +
 +enum cpu_core_type {
 +	CPU_CORE_PERF = 0,
@@ -4812,11 +4080,11 @@ index 000000000000..84abc92bd365
 +
 +struct rog_tunables {
 +	const struct power_limits *power_limits;
-+	u32 ppt_pl1_spl; // cpu
-+	u32 ppt_pl2_sppt; // cpu
-+	u32 ppt_pl3_fppt; // cpu
-+	u32 ppt_apu_sppt; // plat
-+	u32 ppt_platform_sppt; // plat
++	u32 ppt_pl1_spl;			// cpu
++	u32 ppt_pl2_sppt;			// cpu
++	u32 ppt_pl3_fppt;			// cpu
++	u32 ppt_apu_sppt;			// plat
++	u32 ppt_platform_sppt;		// plat
 +
 +	u32 nv_dynamic_boost;
 +	u32 nv_temp_target;
@@ -4909,10 +4177,10 @@ index 000000000000..84abc92bd365
 +}
 +
 +/**
-+ * attr_int_store() - Send an int to wmi method, checks if within min/max exclusive.
++ * attr_uint_store() - Send an uint to wmi method, checks if within min/max exclusive.
 + * @kobj: Pointer to the driver object.
 + * @attr: Pointer to the attribute calling this function.
-+ * @buf: The buffer to read from, this is parsed to `int` type.
++ * @buf: The buffer to read from, this is parsed to `uint` type.
 + * @count: Required by sysfs attribute macros, pass in from the callee attr.
 + * @min: Minimum accepted value. Below this returns -EINVAL.
 + * @max: Maximum accepted value. Above this returns -EINVAL.
@@ -5054,9 +4322,9 @@ index 000000000000..84abc92bd365
 +		return sysfs_emit(buf, "0;1\n");
 +	case ASUS_WMI_DEVID_MINI_LED_MODE2:
 +		return sysfs_emit(buf, "0;1;2\n");
++	default:
++		return -ENODEV;
 +	}
-+
-+	return sysfs_emit(buf, "0\n");
 +}
 +
 +ATTR_GROUP_ENUM_CUSTOM(mini_led_mode, "mini_led_mode", "Set the mini-LED backlight mode");
@@ -5092,7 +4360,7 @@ index 000000000000..84abc92bd365
 +			return err;
 +		if (result && !optimus) {
 +			pr_warn("Can not switch MUX to dGPU mode when eGPU is enabled\n");
-+			return -ENODEV;
++			return -EBUSY;
 +		}
 +	}
 +
@@ -5105,7 +4373,7 @@ index 000000000000..84abc92bd365
 +
 +	return count;
 +}
-+WMI_SHOW_INT(gpu_mux_mode_current_value, "%d\n", asus_armoury.gpu_mux_dev_id);
++WMI_SHOW_INT(gpu_mux_mode_current_value, "%u\n", asus_armoury.gpu_mux_dev_id);
 +ATTR_GROUP_BOOL_CUSTOM(gpu_mux_mode, "gpu_mux_mode", "Set the GPU display MUX mode");
 +
 +/*
@@ -5132,7 +4400,7 @@ index 000000000000..84abc92bd365
 +			return err;
 +		if (!result && disable) {
 +			pr_warn("Can not disable dGPU when the MUX is in dGPU mode\n");
-+			return -ENODEV;
++			return -EBUSY;
 +		}
 +	}
 +
@@ -5171,7 +4439,7 @@ index 000000000000..84abc92bd365
 +		err = asus_wmi_get_devstate_dsts(asus_armoury.gpu_mux_dev_id, &result);
 +		if (err) {
 +			pr_warn("Failed to get GPU MUX status: %d\n", result);
-+			return result;
++			return err;
 +		}
 +		if (!result && enable) {
 +			pr_warn("Can not enable eGPU when the MUX is in dGPU mode\n");
@@ -5192,6 +4460,19 @@ index 000000000000..84abc92bd365
 +
 +/* Device memory available to APU */
 +
++/* Values map for APU memory: some looks out of order but are actually correct */
++static u32 apu_mem_map[] = {
++	[0] = 0x000, /* called "AUTO" on the BIOS, is the minimum available */
++	[1] = 0x102,
++	[2] = 0x103,
++	[3] = 0x104,
++	[4] = 0x105,
++	[5] = 0x107,
++	[6] = 0x108,
++	[7] = 0x109,
++	[8] = 0x106,
++};
++
 +static ssize_t apu_mem_current_value_show(struct kobject *kobj, struct kobj_attribute *attr,
 +					  char *buf)
 +{
@@ -5202,40 +4483,21 @@ index 000000000000..84abc92bd365
 +	if (err)
 +		return err;
 +
-+	switch (mem) {
-+	case 0x100:
-+		mem = 0;
-+		break;
-+	case 0x102:
-+		mem = 1;
-+		break;
-+	case 0x103:
-+		mem = 2;
-+		break;
-+	case 0x104:
-+		mem = 3;
-+		break;
-+	case 0x105:
-+		mem = 4;
-+		break;
-+	case 0x106:
-+		/* This is out of order and looks wrong but is correct */
-+		mem = 8;
-+		break;
-+	case 0x107:
-+		mem = 5;
-+		break;
-+	case 0x108:
-+		mem = 6;
-+		break;
-+	case 0x109:
-+		mem = 7;
-+		break;
-+	default:
-+		mem = 4;
-+		break;
++	if ((mem & ASUS_WMI_DSTS_PRESENCE_BIT) == 0)
++		return -ENODEV;
++
++	mem &= ~ASUS_WMI_DSTS_PRESENCE_BIT;
++
++	/* After 0x000 is set, a read will return 0x100 */
++	if (mem == 0x100)
++		return sysfs_emit(buf, "0\n");
++
++	for (unsigned int i = 0; i < ARRAY_SIZE(apu_mem_map); i++) {
++		if (apu_mem_map[i] == mem)
++			return sysfs_emit(buf, "%u\n", i);
 +	}
 +
++	pr_warn("Unrecognised value for APU mem 0x%08x\n", mem);
 +	return sysfs_emit(buf, "%u\n", mem);
 +}
 +
@@ -5249,38 +4511,10 @@ index 000000000000..84abc92bd365
 +	if (result)
 +		return result;
 +
-+	switch (requested) {
-+	case 0:
-+		mem = 0x000;
-+		break;
-+	case 1:
-+		mem = 0x102;
-+		break;
-+	case 2:
-+		mem = 0x103;
-+		break;
-+	case 3:
-+		mem = 0x104;
-+		break;
-+	case 4:
-+		mem = 0x105;
-+		break;
-+	case 5:
-+		mem = 0x107;
-+		break;
-+	case 6:
-+		mem = 0x108;
-+		break;
-+	case 7:
-+		mem = 0x109;
-+		break;
-+	case 8:
-+		/* This is out of order and looks wrong but is correct */
-+		mem = 0x106;
-+		break;
-+	default:
-+		return -EIO;
-+	}
++	if (requested > ARRAY_SIZE(apu_mem_map))
++		return -EINVAL;
++
++	mem = apu_mem_map[requested];
 +
 +	err = asus_wmi_set_devstate(ASUS_WMI_DEVID_APU_MEM, mem, &result);
 +	if (err) {
@@ -5288,7 +4522,7 @@ index 000000000000..84abc92bd365
 +		return err;
 +	}
 +
-+	pr_info("APU memory changed to %uGB, reboot required\n", requested);
++	pr_info("APU memory changed to %uGB, reboot required\n", requested+1);
 +	sysfs_notify(kobj, NULL, attr->attr.name);
 +
 +	asus_set_reboot_and_signal_event();
@@ -5299,6 +4533,7 @@ index 000000000000..84abc92bd365
 +static ssize_t apu_mem_possible_values_show(struct kobject *kobj, struct kobj_attribute *attr,
 +					    char *buf)
 +{
++	BUILD_BUG_ON(ARRAY_SIZE(apu_mem_map) != 9);
 +	return sysfs_emit(buf, "0;1;2;3;4;5;6;7;8\n");
 +}
 +ATTR_GROUP_ENUM_CUSTOM(apu_mem, "apu_mem", "Set available system RAM (in GB) for the APU to use");
@@ -5308,18 +4543,27 @@ index 000000000000..84abc92bd365
 +	u32 cores;
 +	int err;
 +
++	asus_armoury.cpu_cores = kzalloc(sizeof(struct cpu_cores), GFP_KERNEL);
++	if (!asus_armoury.cpu_cores)
++		return -ENOMEM;
++
 +	err = asus_wmi_get_devstate_dsts(ASUS_WMI_DEVID_CORES_MAX, &cores);
 +	if (err)
 +		return err;
 +
-+	cores &= ~ASUS_WMI_DSTS_PRESENCE_BIT;
++	if ((cores & ASUS_WMI_DSTS_PRESENCE_BIT) == 0) {
++		pr_err("ACPI does not support CPU core count control\n");
++		err = -ENODEV;
++		goto init_max_cpu_cores_err;
++	}
++
 +	asus_armoury.cpu_cores->max_power_cores = FIELD_GET(ASUS_POWER_CORE_MASK, cores);
 +	asus_armoury.cpu_cores->max_perf_cores = FIELD_GET(ASUS_PERF_CORE_MASK, cores);
 +
 +	err = asus_wmi_get_devstate_dsts(ASUS_WMI_DEVID_CORES, &cores);
 +	if (err) {
-+		pr_err("Could not get CPU core count: error %d", err);
-+		return err;
++		pr_err("Could not get CPU core count: error %d\n", err);
++		goto init_max_cpu_cores_err;
 +	}
 +
 +	asus_armoury.cpu_cores->cur_perf_cores = FIELD_GET(ASUS_PERF_CORE_MASK, cores);
@@ -5329,6 +4573,10 @@ index 000000000000..84abc92bd365
 +	asus_armoury.cpu_cores->min_power_cores = CPU_POWR_CORE_COUNT_MIN;
 +
 +	return 0;
++
++init_max_cpu_cores_err:
++	kfree(asus_armoury.cpu_cores);
++	return err;
 +}
 +
 +static ssize_t cores_value_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf,
@@ -5340,17 +4588,17 @@ index 000000000000..84abc92bd365
 +	case CPU_CORE_DEFAULT:
 +	case CPU_CORE_MAX:
 +		if (core_type == CPU_CORE_PERF)
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->max_perf_cores);
 +		else
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->max_power_cores);
 +	case CPU_CORE_MIN:
 +		if (core_type == CPU_CORE_PERF)
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->min_perf_cores);
 +		else
-+			return sysfs_emit(buf, "%d\n",
++			return sysfs_emit(buf, "%u\n",
 +					  asus_armoury.cpu_cores->min_power_cores);
 +	default:
 +		break;
@@ -5361,7 +4609,7 @@ index 000000000000..84abc92bd365
 +	else
 +		cores = asus_armoury.cpu_cores->cur_power_cores;
 +
-+	return sysfs_emit(buf, "%d\n", cores);
++	return sysfs_emit(buf, "%u\n", cores);
 +}
 +
 +static ssize_t cores_current_value_store(struct kobject *kobj, struct kobj_attribute *attr,
@@ -5374,45 +4622,38 @@ index 000000000000..84abc92bd365
 +	if (result)
 +		return result;
 +
-+	mutex_lock(&asus_armoury.cpu_core_mutex);
++	scoped_guard(mutex, &asus_armoury.cpu_core_mutex) {
++		if (core_type == CPU_CORE_PERF) {
++			perf_cores = new_cores;
++			power_cores = asus_armoury.cpu_cores->cur_power_cores;
++			min = asus_armoury.cpu_cores->min_perf_cores;
++			max = asus_armoury.cpu_cores->max_perf_cores;
++		} else {
++			perf_cores = asus_armoury.cpu_cores->cur_perf_cores;
++			power_cores = new_cores;
++			min = asus_armoury.cpu_cores->min_power_cores;
++			max = asus_armoury.cpu_cores->max_power_cores;
++		}
 +
-+	if (core_type == CPU_CORE_PERF) {
-+		perf_cores = new_cores;
-+		power_cores = out_val = asus_armoury.cpu_cores->cur_power_cores;
-+		min = asus_armoury.cpu_cores->min_perf_cores;
-+		max = asus_armoury.cpu_cores->max_perf_cores;
-+	} else {
-+		perf_cores = asus_armoury.cpu_cores->cur_perf_cores;
-+		power_cores = out_val = new_cores;
-+		min = asus_armoury.cpu_cores->min_power_cores;
-+		max = asus_armoury.cpu_cores->max_power_cores;
-+	}
++		if (new_cores < min || new_cores > max)
++			return -EINVAL;
 +
-+	if (new_cores < min || new_cores > max) {
-+		mutex_unlock(&asus_armoury.cpu_core_mutex);
-+		return -EINVAL;
-+	}
++		out_val = FIELD_PREP(ASUS_PERF_CORE_MASK, perf_cores) |
++			FIELD_PREP(ASUS_POWER_CORE_MASK, power_cores);
 +
-+	out_val = 0;
-+	out_val |= FIELD_PREP(ASUS_PERF_CORE_MASK, perf_cores);
-+	out_val |= FIELD_PREP(ASUS_POWER_CORE_MASK, power_cores);
++		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_CORES, out_val, &result);
++		if (err) {
++			pr_warn("Failed to set CPU core count: %d\n", err);
++			return err;
++		}
 +
-+	err = asus_wmi_set_devstate(ASUS_WMI_DEVID_CORES, out_val, &result);
-+
-+	if (err) {
-+		pr_warn("Failed to set CPU core count: %d\n", err);
-+		mutex_unlock(&asus_armoury.cpu_core_mutex);
-+		return err;
-+	}
-+
-+	if (result > 1) {
-+		pr_warn("Failed to set CPU core count (result): 0x%x\n", result);
-+		mutex_unlock(&asus_armoury.cpu_core_mutex);
-+		return -EIO;
++		if (result > 1) {
++			pr_warn("Failed to set CPU core count (result): 0x%x\n", result);
++			return -EIO;
++		}
 +	}
 +
 +	pr_info("CPU core count changed, reboot required\n");
-+	mutex_unlock(&asus_armoury.cpu_core_mutex);
 +
 +	sysfs_notify(kobj, NULL, attr->attr.name);
 +	asus_set_reboot_and_signal_event();
@@ -5567,6 +4808,7 @@ index 000000000000..84abc92bd365
 +	{ &mcu_powersave_attr_group, ASUS_WMI_DEVID_MCU_POWERSAVE },
 +	{ &panel_od_attr_group, ASUS_WMI_DEVID_PANEL_OD },
 +	{ &panel_hd_mode_attr_group, ASUS_WMI_DEVID_PANEL_HD },
++	{ &screen_auto_brightness_attr_group, ASUS_WMI_DEVID_SCREEN_AUTO_BRIGHTNESS },
 +};
 +
 +/**
@@ -5587,7 +4829,7 @@ index 000000000000..84abc92bd365
 +		ATTR_NV_TGP
 +	};
 +
-+	for (int i = 0; i < ARRAY_SIZE(power_tunable_attrs); i++) {
++	for (unsigned int i = 0; i < ARRAY_SIZE(power_tunable_attrs); i++) {
 +		if (!strcmp(name, power_tunable_attrs[i]))
 +			return true;
 +	}
@@ -5700,21 +4942,18 @@ index 000000000000..84abc92bd365
 +
 +		/* Check if this is a power-related tunable requiring limits */
 +		if (asus_armoury.rog_tunables[1] && asus_armoury.rog_tunables[1]->power_limits &&
-+			is_power_tunable_attr(name)) {
++		    is_power_tunable_attr(name)) {
 +			limits = asus_armoury.rog_tunables[1]->power_limits;
 +			/* Check only AC, if DC is not present then AC won't be either */
 +			should_create = has_valid_limit(name, limits);
 +			if (!should_create) {
-+				pr_debug(
-+					"Missing max value on %s for tunable: %s\n",
-+					dmi_get_system_info(DMI_BOARD_NAME),
-+					name);
++				pr_debug("Missing max value on %s for tunable: %s\n",
++					 dmi_get_system_info(DMI_BOARD_NAME), name);
 +			}
 +		}
 +
 +		if (should_create) {
-+			err = sysfs_create_group(
-+				&asus_armoury.fw_attr_kset->kobj,
++			err = sysfs_create_group(&asus_armoury.fw_attr_kset->kobj,
 +				armoury_attr_groups[i].attr_group);
 +			if (err) {
 +				pr_err("Failed to create sysfs-group for %s\n",
@@ -5727,7 +4966,7 @@ index 000000000000..84abc92bd365
 +	return 0;
 +
 +err_remove_groups:
-+	while (--i >= 0) {
++	while (i--) {
 +		if (asus_wmi_is_present(armoury_attr_groups[i].wmi_devid))
 +			sysfs_remove_group(&asus_armoury.fw_attr_kset->kobj,
 +					   armoury_attr_groups[i].attr_group);
@@ -5775,7 +5014,7 @@ index 000000000000..84abc92bd365
 +	ac_limits = power_data->ac_data;
 +	if (ac_limits) {
 +		asus_armoury.rog_tunables[1] =
-+			kzalloc(sizeof(struct rog_tunables), GFP_KERNEL);
++			kzalloc(sizeof(*asus_armoury.rog_tunables[1]), GFP_KERNEL);
 +		if (!asus_armoury.rog_tunables[1])
 +			goto err_nomem;
 +
@@ -5821,7 +5060,7 @@ index 000000000000..84abc92bd365
 +	dc_limits = power_data->dc_data;
 +	if (dc_limits) {
 +		asus_armoury.rog_tunables[0] =
-+			kzalloc(sizeof(struct rog_tunables), GFP_KERNEL);
++			kzalloc(sizeof(*asus_armoury.rog_tunables[0]), GFP_KERNEL);
 +		if (!asus_armoury.rog_tunables[0]) {
 +			if (ac_initialized)
 +				kfree(asus_armoury.rog_tunables[1]);
@@ -5895,13 +5134,8 @@ index 000000000000..84abc92bd365
 +		return -ENODEV;
 +
 +	if (asus_wmi_is_present(ASUS_WMI_DEVID_CORES_MAX)) {
-+		asus_armoury.cpu_cores = kzalloc(sizeof(struct cpu_cores), GFP_KERNEL);
-+		if (!asus_armoury.cpu_cores)
-+			return -ENOMEM;
-+
 +		err = init_max_cpu_cores();
 +		if (err) {
-+			kfree(asus_armoury.cpu_cores);
 +			pr_err("Could not initialise CPU core control %d\n", err);
 +			return err;
 +		}
@@ -5933,7 +5167,7 @@ index 000000000000..84abc92bd365
 +MODULE_ALIAS("wmi:" ASUS_NB_WMI_EVENT_GUID);
 diff --git a/drivers/platform/x86/asus-armoury.h b/drivers/platform/x86/asus-armoury.h
 new file mode 100644
-index 000000000000..438768ea14cc
+index 000000000..438768ea1
 --- /dev/null
 +++ b/drivers/platform/x86/asus-armoury.h
 @@ -0,0 +1,1278 @@
@@ -7215,8 +6449,77 @@ index 000000000000..438768ea14cc
 +};
 +
 +#endif /* _ASUS_ARMOURY_H_ */
+diff --git a/drivers/platform/x86/asus-nb-wmi.c b/drivers/platform/x86/asus-nb-wmi.c
+index f84c3d03c..0c6bdf93f 100644
+--- a/drivers/platform/x86/asus-nb-wmi.c
++++ b/drivers/platform/x86/asus-nb-wmi.c
+@@ -146,8 +146,12 @@ static struct quirk_entry quirk_asus_ignore_fan = {
+ 	.wmi_ignore_fan = true,
+ };
+ 
+-static struct quirk_entry quirk_asus_zenbook_duo_kbd = {
+-	.ignore_key_wlan = true,
++static struct quirk_entry quirk_asus_wlan_ignore = {
++	.key_wlan_event = ASUS_WMI_KEY_IGNORE,
++};
++
++static struct quirk_entry quirk_asus_wlan_armoury = {
++	.key_wlan_event = ASUS_WMI_KEY_ARMOURY,
+ };
+ 
+ static int dmi_matched(const struct dmi_system_id *dmi)
+@@ -528,7 +532,16 @@ static const struct dmi_system_id asus_quirks[] = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "UX8406MA"),
+ 		},
+-		.driver_data = &quirk_asus_zenbook_duo_kbd,
++		.driver_data = &quirk_asus_wlan_ignore,
++	},
++	{
++		.callback = dmi_matched,
++		.ident = "ASUS ROG Z13 2025",
++		.matches = {
++			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
++			DMI_MATCH(DMI_PRODUCT_NAME, "ROG Flow Z13 GZ302"),
++		},
++		.driver_data = &quirk_asus_wlan_armoury,
+ 	},
+ 	{
+ 		.callback = dmi_matched,
+@@ -537,7 +550,7 @@ static const struct dmi_system_id asus_quirks[] = {
+ 			DMI_MATCH(DMI_SYS_VENDOR, "ASUSTeK COMPUTER INC."),
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "UX8406CA"),
+ 		},
+-		.driver_data = &quirk_asus_zenbook_duo_kbd,
++		.driver_data = &quirk_asus_wlan_ignore,
+ 	},
+ 	{},
+ };
+@@ -636,6 +649,7 @@ static const struct key_entry asus_nb_wmi_keymap[] = {
+ 	{ KE_IGNORE, 0xCF, },	/* AC mode */
+ 	{ KE_KEY, 0xFA, { KEY_PROG2 } },           /* Lid flip action */
+ 	{ KE_KEY, 0xBD, { KEY_PROG2 } },           /* Lid flip action on ROG xflow laptops */
++	{ KE_KEY, ASUS_WMI_KEY_ARMOURY, { KEY_PROG3 } },
+ 	{ KE_END, 0},
+ };
+ 
+@@ -655,11 +669,9 @@ static void asus_nb_wmi_key_filter(struct asus_wmi_driver *asus_wmi, int *code,
+ 		if (atkbd_reports_vol_keys)
+ 			*code = ASUS_WMI_KEY_IGNORE;
+ 		break;
+-	case 0x5D: /* Wireless console Toggle */
+-	case 0x5E: /* Wireless console Enable */
+-	case 0x5F: /* Wireless console Disable */
+-		if (quirks->ignore_key_wlan)
+-			*code = ASUS_WMI_KEY_IGNORE;
++	case 0x5F: /* Wireless console Disable / Special Key */
++		if (quirks->key_wlan_event)
++			*code = quirks->key_wlan_event;
+ 		break;
+ 	}
+ }
 diff --git a/drivers/platform/x86/asus-wmi.c b/drivers/platform/x86/asus-wmi.c
-index 47cc766624d7..942f1013d6cb 100644
+index 47cc76662..44eeb8803 100644
 --- a/drivers/platform/x86/asus-wmi.c
 +++ b/drivers/platform/x86/asus-wmi.c
 @@ -55,8 +55,6 @@ module_param(fnlock_default, bool, 0444);
@@ -7237,15 +6540,7 @@ index 47cc766624d7..942f1013d6cb 100644
  #define WMI_EVENT_MASK			0xFFFF
  
  #define FAN_CURVE_POINTS		8
-@@ -127,7 +123,6 @@ module_param(fnlock_default, bool, 0444);
- #define NVIDIA_TEMP_MIN		75
- #define NVIDIA_TEMP_MAX		87
- 
--#define ASUS_SCREENPAD_BRIGHT_MIN 20
- #define ASUS_SCREENPAD_BRIGHT_MAX 255
- #define ASUS_SCREENPAD_BRIGHT_DEFAULT 60
- 
-@@ -142,16 +137,20 @@ module_param(fnlock_default, bool, 0444);
+@@ -142,16 +138,20 @@ module_param(fnlock_default, bool, 0444);
  #define ASUS_MINI_LED_2024_STRONG	0x01
  #define ASUS_MINI_LED_2024_OFF		0x02
  
@@ -7270,7 +6565,16 @@ index 47cc766624d7..942f1013d6cb 100644
  	{
  		.matches = {
  			DMI_MATCH(DMI_BOARD_NAME, "RC71L"),
-@@ -274,9 +273,6 @@ struct asus_wmi {
+@@ -254,6 +254,8 @@ struct asus_wmi {
+ 	int tpd_led_wk;
+ 	struct led_classdev kbd_led;
+ 	int kbd_led_wk;
++	bool kbd_led_avail;
++	bool kbd_led_registered;
+ 	struct led_classdev lightbar_led;
+ 	int lightbar_led_wk;
+ 	struct led_classdev micmute_led;
+@@ -274,9 +276,6 @@ struct asus_wmi {
  	u32 tablet_switch_dev_id;
  	bool tablet_switch_inverted;
  
@@ -7280,7 +6584,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	enum fan_type fan_type;
  	enum fan_type gpu_fan_type;
  	enum fan_type mid_fan_type;
-@@ -336,6 +332,16 @@ struct asus_wmi {
+@@ -336,6 +335,16 @@ struct asus_wmi {
  	struct asus_wmi_driver *driver;
  };
  
@@ -7297,7 +6601,7 @@ index 47cc766624d7..942f1013d6cb 100644
  /* WMI ************************************************************************/
  
  static int asus_wmi_evaluate_method3(u32 method_id,
-@@ -386,7 +392,7 @@ int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1, u32 *retval)
+@@ -386,7 +395,7 @@ int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1, u32 *retval)
  {
  	return asus_wmi_evaluate_method3(method_id, arg0, arg1, 0, retval);
  }
@@ -7306,21 +6610,19 @@ index 47cc766624d7..942f1013d6cb 100644
  
  static int asus_wmi_evaluate_method5(u32 method_id,
  		u32 arg0, u32 arg1, u32 arg2, u32 arg3, u32 arg4, u32 *retval)
-@@ -550,12 +556,51 @@ static int asus_wmi_get_devstate(struct asus_wmi *asus, u32 dev_id, u32 *retval)
+@@ -550,12 +559,46 @@ static int asus_wmi_get_devstate(struct asus_wmi *asus, u32 dev_id, u32 *retval)
  	return 0;
  }
  
 -static int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param,
 -				 u32 *retval)
-+
 +/**
 + * asus_wmi_get_devstate_dsts() - Get the WMI function state.
 + * @dev_id: The WMI method ID to call.
 + * @retval: A pointer to where to store the value returned from WMI.
-+ *
-+ * On success the return value is 0, and the retval is a valid value returned
-+ * by the successful WMI function call otherwise an error is returned if the
-+ * call failed, or if the WMI method ID is unsupported.
++ * @return: 0 on success and retval is filled.
++ * @return: -ENODEV if the method ID is unsupported.
++ * @return: everything else is an error from WMI call.
 + */
 +int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval)
 +{
@@ -7342,14 +6644,11 @@ index 47cc766624d7..942f1013d6cb 100644
 + * @dev_id: The WMI function to call.
 + * @ctrl_param: The argument to be used for this WMI function.
 + * @retval: A pointer to where to store the value returned from WMI.
++ * @return: 0 on success and retval is filled.
++ * @return: everything else is an error from WMI call.
 + *
-+ * The returned WMI function state if not checked here for error as
-+ * asus_wmi_set_devstate() is not called unless first paired with a call to
-+ * asus_wmi_get_devstate_dsts() to check that the WMI function is supported.
-+ *
-+ * On success the return value is 0, and the retval is a valid value returned
-+ * by the successful WMI function call. An error value is returned only if the
-+ * WMI function failed.
++ * A asus_wmi_set_devstate() call must be paired with a
++ * asus_wmi_get_devstate_dsts() to check if the WMI function is supported.
 + */
 +int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval)
  {
@@ -7360,7 +6659,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Helper for special devices with magic return codes */
  static int asus_wmi_get_devstate_bits(struct asus_wmi *asus,
-@@ -688,6 +733,7 @@ static void asus_wmi_tablet_mode_get_state(struct asus_wmi *asus)
+@@ -688,6 +731,7 @@ static void asus_wmi_tablet_mode_get_state(struct asus_wmi *asus)
  }
  
  /* Charging mode, 1=Barrel, 2=USB ******************************************/
@@ -7368,7 +6667,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t charge_mode_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -698,12 +744,16 @@ static ssize_t charge_mode_show(struct device *dev,
+@@ -698,12 +742,16 @@ static ssize_t charge_mode_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7385,7 +6684,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t dgpu_disable_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -714,6 +764,8 @@ static ssize_t dgpu_disable_show(struct device *dev,
+@@ -714,6 +762,8 @@ static ssize_t dgpu_disable_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7394,7 +6693,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -767,8 +819,10 @@ static ssize_t dgpu_disable_store(struct device *dev,
+@@ -767,8 +817,10 @@ static ssize_t dgpu_disable_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(dgpu_disable);
@@ -7405,7 +6704,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t egpu_enable_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -779,6 +833,8 @@ static ssize_t egpu_enable_show(struct device *dev,
+@@ -779,6 +831,8 @@ static ssize_t egpu_enable_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7414,7 +6713,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -835,8 +891,10 @@ static ssize_t egpu_enable_store(struct device *dev,
+@@ -835,8 +889,10 @@ static ssize_t egpu_enable_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(egpu_enable);
@@ -7425,7 +6724,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t egpu_connected_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -847,12 +905,16 @@ static ssize_t egpu_connected_show(struct device *dev,
+@@ -847,12 +903,16 @@ static ssize_t egpu_connected_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7442,7 +6741,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t gpu_mux_mode_show(struct device *dev,
  				 struct device_attribute *attr, char *buf)
  {
-@@ -863,6 +925,8 @@ static ssize_t gpu_mux_mode_show(struct device *dev,
+@@ -863,6 +923,8 @@ static ssize_t gpu_mux_mode_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7451,7 +6750,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -921,6 +985,7 @@ static ssize_t gpu_mux_mode_store(struct device *dev,
+@@ -921,6 +983,7 @@ static ssize_t gpu_mux_mode_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(gpu_mux_mode);
@@ -7459,7 +6758,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* TUF Laptop Keyboard RGB Modes **********************************************/
  static ssize_t kbd_rgb_mode_store(struct device *dev,
-@@ -1044,6 +1109,7 @@ static const struct attribute_group *kbd_rgb_mode_groups[] = {
+@@ -1044,6 +1107,7 @@ static const struct attribute_group *kbd_rgb_mode_groups[] = {
  };
  
  /* Tunable: PPT: Intel=PL1, AMD=SPPT *****************************************/
@@ -7467,7 +6766,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t ppt_pl2_sppt_store(struct device *dev,
  				    struct device_attribute *attr,
  				    const char *buf, size_t count)
-@@ -1082,6 +1148,8 @@ static ssize_t ppt_pl2_sppt_show(struct device *dev,
+@@ -1082,6 +1146,8 @@ static ssize_t ppt_pl2_sppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7476,7 +6775,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_pl2_sppt);
  }
  static DEVICE_ATTR_RW(ppt_pl2_sppt);
-@@ -1124,6 +1192,8 @@ static ssize_t ppt_pl1_spl_show(struct device *dev,
+@@ -1124,6 +1190,8 @@ static ssize_t ppt_pl1_spl_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7485,7 +6784,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_pl1_spl);
  }
  static DEVICE_ATTR_RW(ppt_pl1_spl);
-@@ -1167,6 +1237,8 @@ static ssize_t ppt_fppt_show(struct device *dev,
+@@ -1167,6 +1235,8 @@ static ssize_t ppt_fppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7494,7 +6793,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_fppt);
  }
  static DEVICE_ATTR_RW(ppt_fppt);
-@@ -1210,6 +1282,8 @@ static ssize_t ppt_apu_sppt_show(struct device *dev,
+@@ -1210,6 +1280,8 @@ static ssize_t ppt_apu_sppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7503,7 +6802,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_apu_sppt);
  }
  static DEVICE_ATTR_RW(ppt_apu_sppt);
-@@ -1253,6 +1327,8 @@ static ssize_t ppt_platform_sppt_show(struct device *dev,
+@@ -1253,6 +1325,8 @@ static ssize_t ppt_platform_sppt_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7512,7 +6811,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->ppt_platform_sppt);
  }
  static DEVICE_ATTR_RW(ppt_platform_sppt);
-@@ -1296,6 +1372,8 @@ static ssize_t nv_dynamic_boost_show(struct device *dev,
+@@ -1296,6 +1370,8 @@ static ssize_t nv_dynamic_boost_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7521,7 +6820,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%u\n", asus->nv_dynamic_boost);
  }
  static DEVICE_ATTR_RW(nv_dynamic_boost);
-@@ -1339,11 +1417,53 @@ static ssize_t nv_temp_target_show(struct device *dev,
+@@ -1339,11 +1415,53 @@ static ssize_t nv_temp_target_show(struct device *dev,
  {
  	struct asus_wmi *asus = dev_get_drvdata(dev);
  
@@ -7575,7 +6874,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t mcu_powersave_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -1354,6 +1474,8 @@ static ssize_t mcu_powersave_show(struct device *dev,
+@@ -1354,6 +1472,8 @@ static ssize_t mcu_powersave_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7584,7 +6883,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -1389,6 +1511,7 @@ static ssize_t mcu_powersave_store(struct device *dev,
+@@ -1389,6 +1509,7 @@ static ssize_t mcu_powersave_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(mcu_powersave);
@@ -7592,7 +6891,235 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Battery ********************************************************************/
  
-@@ -2262,6 +2385,7 @@ static int asus_wmi_rfkill_init(struct asus_wmi *asus)
+@@ -1488,6 +1609,92 @@ static void asus_wmi_battery_exit(struct asus_wmi *asus)
+ 
+ /* LEDs ***********************************************************************/
+ 
++struct asus_hid_ref {
++	struct list_head listeners;
++	struct asus_wmi *asus;
++	spinlock_t lock;
++};
++
++struct asus_hid_ref asus_ref = {
++	.listeners = LIST_HEAD_INIT(asus_ref.listeners),
++	.asus = NULL,
++	.lock = __SPIN_LOCK_UNLOCKED(asus_ref.lock),
++};
++
++int asus_hid_register_listener(struct asus_hid_listener *bdev)
++{
++	unsigned long flags;
++	int ret = 0;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	list_add_tail(&bdev->list, &asus_ref.listeners);
++	if (asus_ref.asus) {
++		if (asus_ref.asus->kbd_led_registered && asus_ref.asus->kbd_led_wk >= 0)
++			bdev->brightness_set(bdev, asus_ref.asus->kbd_led_wk);
++
++		if (!asus_ref.asus->kbd_led_registered) {
++			ret = led_classdev_register(
++				&asus_ref.asus->platform_device->dev,
++				&asus_ref.asus->kbd_led);
++			if (!ret)
++				asus_ref.asus->kbd_led_registered = true;
++		}
++	}
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++
++	return ret;
++}
++EXPORT_SYMBOL_GPL(asus_hid_register_listener);
++
++void asus_hid_unregister_listener(struct asus_hid_listener *bdev)
++{
++	unsigned long flags;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	list_del(&bdev->list);
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++}
++EXPORT_SYMBOL_GPL(asus_hid_unregister_listener);
++
++static void do_kbd_led_set(struct led_classdev *led_cdev, int value);
++
++int asus_hid_event(enum asus_hid_event event)
++{
++	unsigned long flags;
++	int brightness;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	if (!asus_ref.asus || !asus_ref.asus->kbd_led_registered) {
++		spin_unlock_irqrestore(&asus_ref.lock, flags);
++		return -EBUSY;
++	}
++	brightness = asus_ref.asus->kbd_led_wk;
++
++	switch (event) {
++	case ASUS_EV_BRTUP:
++		brightness += 1;
++		break;
++	case ASUS_EV_BRTDOWN:
++		brightness -= 1;
++		break;
++	case ASUS_EV_BRTTOGGLE:
++		if (brightness >= ASUS_EV_MAX_BRIGHTNESS)
++			brightness = 0;
++		else
++			brightness += 1;
++		break;
++	}
++
++	do_kbd_led_set(&asus_ref.asus->kbd_led, brightness);
++	led_classdev_notify_brightness_hw_changed(&asus_ref.asus->kbd_led,
++						  asus_ref.asus->kbd_led_wk);
++
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++
++	return 0;
++}
++EXPORT_SYMBOL_GPL(asus_hid_event);
++
+ /*
+  * These functions actually update the LED's, and are called from a
+  * workqueue. By doing this as separate work rather than when the LED
+@@ -1567,6 +1774,7 @@ static int kbd_led_read(struct asus_wmi *asus, int *level, int *env)
+ 
+ static void do_kbd_led_set(struct led_classdev *led_cdev, int value)
+ {
++	struct asus_hid_listener *listener;
+ 	struct asus_wmi *asus;
+ 	int max_level;
+ 
+@@ -1574,25 +1782,39 @@ static void do_kbd_led_set(struct led_classdev *led_cdev, int value)
+ 	max_level = asus->kbd_led.max_brightness;
+ 
+ 	asus->kbd_led_wk = clamp_val(value, 0, max_level);
+-	kbd_led_update(asus);
++
++	if (asus->kbd_led_avail)
++		kbd_led_update(asus);
++
++	list_for_each_entry(listener, &asus_ref.listeners, list)
++		listener->brightness_set(listener, asus->kbd_led_wk);
+ }
+ 
+ static void kbd_led_set(struct led_classdev *led_cdev,
+ 			enum led_brightness value)
+ {
++	unsigned long flags;
++
+ 	/* Prevent disabling keyboard backlight on module unregister */
+ 	if (led_cdev->flags & LED_UNREGISTERING)
+ 		return;
+ 
++	spin_lock_irqsave(&asus_ref.lock, flags);
+ 	do_kbd_led_set(led_cdev, value);
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
+ }
+ 
+ static void kbd_led_set_by_kbd(struct asus_wmi *asus, enum led_brightness value)
+ {
+-	struct led_classdev *led_cdev = &asus->kbd_led;
++	struct led_classdev *led_cdev;
++	unsigned long flags;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	led_cdev = &asus->kbd_led;
+ 
+ 	do_kbd_led_set(led_cdev, value);
+ 	led_classdev_notify_brightness_hw_changed(led_cdev, asus->kbd_led_wk);
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
+ }
+ 
+ static enum led_brightness kbd_led_get(struct led_classdev *led_cdev)
+@@ -1602,6 +1824,9 @@ static enum led_brightness kbd_led_get(struct led_classdev *led_cdev)
+ 
+ 	asus = container_of(led_cdev, struct asus_wmi, kbd_led);
+ 
++	if (!asus->kbd_led_avail)
++		return asus->kbd_led_wk;
++
+ 	retval = kbd_led_read(asus, &value, NULL);
+ 	if (retval < 0)
+ 		return retval;
+@@ -1717,7 +1942,15 @@ static int camera_led_set(struct led_classdev *led_cdev,
+ 
+ static void asus_wmi_led_exit(struct asus_wmi *asus)
+ {
+-	led_classdev_unregister(&asus->kbd_led);
++	unsigned long flags;
++
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	asus_ref.asus = NULL;
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
++
++	if (asus->kbd_led_registered)
++		led_classdev_unregister(&asus->kbd_led);
++
+ 	led_classdev_unregister(&asus->tpd_led);
+ 	led_classdev_unregister(&asus->wlan_led);
+ 	led_classdev_unregister(&asus->lightbar_led);
+@@ -1731,6 +1964,8 @@ static void asus_wmi_led_exit(struct asus_wmi *asus)
+ static int asus_wmi_led_init(struct asus_wmi *asus)
+ {
+ 	int rv = 0, num_rgb_groups = 0, led_val;
++	struct asus_hid_listener *listener;
++	unsigned long flags;
+ 
+ 	if (asus->kbd_rgb_dev)
+ 		kbd_rgb_mode_groups[num_rgb_groups++] = &kbd_rgb_mode_group;
+@@ -1755,23 +1990,38 @@ static int asus_wmi_led_init(struct asus_wmi *asus)
+ 			goto error;
+ 	}
+ 
+-	if (!kbd_led_read(asus, &led_val, NULL) && !dmi_check_system(asus_use_hid_led_dmi_ids)) {
+-		pr_info("using asus-wmi for asus::kbd_backlight\n");
++	asus->kbd_led.name = "asus::kbd_backlight";
++	asus->kbd_led.flags = LED_BRIGHT_HW_CHANGED;
++	asus->kbd_led.brightness_set = kbd_led_set;
++	asus->kbd_led.brightness_get = kbd_led_get;
++	asus->kbd_led.max_brightness = ASUS_EV_MAX_BRIGHTNESS;
++	asus->kbd_led_avail = !kbd_led_read(asus, &led_val, NULL);
++
++	if (asus->kbd_led_avail)
+ 		asus->kbd_led_wk = led_val;
+-		asus->kbd_led.name = "asus::kbd_backlight";
+-		asus->kbd_led.flags = LED_BRIGHT_HW_CHANGED;
+-		asus->kbd_led.brightness_set = kbd_led_set;
+-		asus->kbd_led.brightness_get = kbd_led_get;
+-		asus->kbd_led.max_brightness = 3;
++	else
++		asus->kbd_led_wk = -1;
+ 
+-		if (num_rgb_groups != 0)
+-			asus->kbd_led.groups = kbd_rgb_mode_groups;
++	if (asus->kbd_led_avail && num_rgb_groups != 0)
++		asus->kbd_led.groups = kbd_rgb_mode_groups;
+ 
++	spin_lock_irqsave(&asus_ref.lock, flags);
++	if (asus->kbd_led_avail || !list_empty(&asus_ref.listeners)) {
+ 		rv = led_classdev_register(&asus->platform_device->dev,
+ 					   &asus->kbd_led);
+-		if (rv)
++		if (rv) {
++			spin_unlock_irqrestore(&asus_ref.lock, flags);
+ 			goto error;
++		}
++		asus->kbd_led_registered = true;
++
++		if (asus->kbd_led_wk >= 0) {
++			list_for_each_entry(listener, &asus_ref.listeners, list)
++				listener->brightness_set(listener, asus->kbd_led_wk);
++		}
+ 	}
++	asus_ref.asus = asus;
++	spin_unlock_irqrestore(&asus_ref.lock, flags);
+ 
+ 	if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_WIRELESS_LED)
+ 			&& (asus->driver->quirks->wapf > 0)) {
+@@ -2262,6 +2512,7 @@ static int asus_wmi_rfkill_init(struct asus_wmi *asus)
  }
  
  /* Panel Overdrive ************************************************************/
@@ -7600,7 +7127,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t panel_od_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -2272,6 +2396,8 @@ static ssize_t panel_od_show(struct device *dev,
+@@ -2272,6 +2523,8 @@ static ssize_t panel_od_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7609,7 +7136,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -2308,9 +2434,10 @@ static ssize_t panel_od_store(struct device *dev,
+@@ -2308,9 +2561,10 @@ static ssize_t panel_od_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(panel_od);
@@ -7621,7 +7148,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t boot_sound_show(struct device *dev,
  			     struct device_attribute *attr, char *buf)
  {
-@@ -2321,6 +2448,8 @@ static ssize_t boot_sound_show(struct device *dev,
+@@ -2321,6 +2575,8 @@ static ssize_t boot_sound_show(struct device *dev,
  	if (result < 0)
  		return result;
  
@@ -7630,7 +7157,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", result);
  }
  
-@@ -2356,8 +2485,10 @@ static ssize_t boot_sound_store(struct device *dev,
+@@ -2356,8 +2612,10 @@ static ssize_t boot_sound_store(struct device *dev,
  	return count;
  }
  static DEVICE_ATTR_RW(boot_sound);
@@ -7641,7 +7168,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t mini_led_mode_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -2388,6 +2519,8 @@ static ssize_t mini_led_mode_show(struct device *dev,
+@@ -2388,6 +2646,8 @@ static ssize_t mini_led_mode_show(struct device *dev,
  		}
  	}
  
@@ -7650,7 +7177,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	return sysfs_emit(buf, "%d\n", value);
  }
  
-@@ -2458,10 +2591,13 @@ static ssize_t available_mini_led_mode_show(struct device *dev,
+@@ -2458,10 +2718,13 @@ static ssize_t available_mini_led_mode_show(struct device *dev,
  		return sysfs_emit(buf, "0 1 2\n");
  	}
  
@@ -7664,7 +7191,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Quirks *********************************************************************/
  
-@@ -3749,6 +3885,7 @@ static int throttle_thermal_policy_set_default(struct asus_wmi *asus)
+@@ -3749,6 +4012,7 @@ static int throttle_thermal_policy_set_default(struct asus_wmi *asus)
  	return throttle_thermal_policy_write(asus);
  }
  
@@ -7672,7 +7199,7 @@ index 47cc766624d7..942f1013d6cb 100644
  static ssize_t throttle_thermal_policy_show(struct device *dev,
  				   struct device_attribute *attr, char *buf)
  {
-@@ -3792,6 +3929,7 @@ static ssize_t throttle_thermal_policy_store(struct device *dev,
+@@ -3792,6 +4056,7 @@ static ssize_t throttle_thermal_policy_store(struct device *dev,
   * Throttle thermal policy: 0 - default, 1 - overboost, 2 - silent
   */
  static DEVICE_ATTR_RW(throttle_thermal_policy);
@@ -7680,7 +7207,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  /* Platform profile ***********************************************************/
  static int asus_wmi_platform_profile_get(struct device *dev,
-@@ -3811,7 +3949,7 @@ static int asus_wmi_platform_profile_get(struct device *dev,
+@@ -3811,7 +4076,7 @@ static int asus_wmi_platform_profile_get(struct device *dev,
  		*profile = PLATFORM_PROFILE_PERFORMANCE;
  		break;
  	case ASUS_THROTTLE_THERMAL_POLICY_SILENT:
@@ -7689,7 +7216,7 @@ index 47cc766624d7..942f1013d6cb 100644
  		break;
  	default:
  		return -EINVAL;
-@@ -3835,7 +3973,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
+@@ -3835,7 +4100,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
  	case PLATFORM_PROFILE_BALANCED:
  		tp = ASUS_THROTTLE_THERMAL_POLICY_DEFAULT;
  		break;
@@ -7698,7 +7225,7 @@ index 47cc766624d7..942f1013d6cb 100644
  		tp = ASUS_THROTTLE_THERMAL_POLICY_SILENT;
  		break;
  	default:
-@@ -3848,7 +3986,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
+@@ -3848,7 +4113,7 @@ static int asus_wmi_platform_profile_set(struct device *dev,
  
  static int asus_wmi_platform_profile_probe(void *drvdata, unsigned long *choices)
  {
@@ -7707,103 +7234,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	set_bit(PLATFORM_PROFILE_BALANCED, choices);
  	set_bit(PLATFORM_PROFILE_PERFORMANCE, choices);
  
-@@ -4101,43 +4239,37 @@ static int read_screenpad_brightness(struct backlight_device *bd)
- 		return err;
- 	/* The device brightness can only be read if powered, so return stored */
- 	if (err == BACKLIGHT_POWER_OFF)
--		return asus->driver->screenpad_brightness - ASUS_SCREENPAD_BRIGHT_MIN;
-+		return bd->props.brightness;
- 
- 	err = asus_wmi_get_devstate(asus, ASUS_WMI_DEVID_SCREENPAD_LIGHT, &retval);
- 	if (err < 0)
- 		return err;
- 
--	return (retval & ASUS_WMI_DSTS_BRIGHTNESS_MASK) - ASUS_SCREENPAD_BRIGHT_MIN;
-+	return (retval & ASUS_WMI_DSTS_BRIGHTNESS_MASK);
- }
- 
- static int update_screenpad_bl_status(struct backlight_device *bd)
- {
--	struct asus_wmi *asus = bl_get_data(bd);
--	int power, err = 0;
-+	int err = 0;
- 	u32 ctrl_param;
- 
--	power = read_screenpad_backlight_power(asus);
--	if (power < 0)
--		return power;
--
--	if (bd->props.power != power) {
--		if (power != BACKLIGHT_POWER_ON) {
--			/* Only brightness > 0 can power it back on */
--			ctrl_param = asus->driver->screenpad_brightness - ASUS_SCREENPAD_BRIGHT_MIN;
--			err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_LIGHT,
--						    ctrl_param, NULL);
--		} else {
--			err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, 0, NULL);
--		}
--	} else if (power == BACKLIGHT_POWER_ON) {
--		/* Only set brightness if powered on or we get invalid/unsync state */
--		ctrl_param = bd->props.brightness + ASUS_SCREENPAD_BRIGHT_MIN;
-+	ctrl_param = bd->props.brightness;
-+	if (ctrl_param >= 0 && bd->props.power) {
-+		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, 1,
-+					    NULL);
-+		if (err < 0)
-+			return err;
-+		ctrl_param = bd->props.brightness;
- 		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_LIGHT, ctrl_param, NULL);
-+		if (err < 0)
-+			return err;
- 	}
- 
--	/* Ensure brightness is stored to turn back on with */
--	if (err == 0)
--		asus->driver->screenpad_brightness = bd->props.brightness + ASUS_SCREENPAD_BRIGHT_MIN;
-+	if (!bd->props.power) {
-+		err = asus_wmi_set_devstate(ASUS_WMI_DEVID_SCREENPAD_POWER, 0, NULL);
-+		if (err < 0)
-+			return err;
-+	}
- 
- 	return err;
- }
-@@ -4155,22 +4287,19 @@ static int asus_screenpad_init(struct asus_wmi *asus)
- 	int err, power;
- 	int brightness = 0;
- 
--	power = read_screenpad_backlight_power(asus);
-+	power = asus_wmi_get_devstate_simple(asus, ASUS_WMI_DEVID_SCREENPAD_POWER);
- 	if (power < 0)
- 		return power;
- 
--	if (power != BACKLIGHT_POWER_OFF) {
-+	if (power) {
- 		err = asus_wmi_get_devstate(asus, ASUS_WMI_DEVID_SCREENPAD_LIGHT, &brightness);
- 		if (err < 0)
- 			return err;
- 	}
--	/* default to an acceptable min brightness on boot if too low */
--	if (brightness < ASUS_SCREENPAD_BRIGHT_MIN)
--		brightness = ASUS_SCREENPAD_BRIGHT_DEFAULT;
- 
- 	memset(&props, 0, sizeof(struct backlight_properties));
- 	props.type = BACKLIGHT_RAW; /* ensure this bd is last to be picked */
--	props.max_brightness = ASUS_SCREENPAD_BRIGHT_MAX - ASUS_SCREENPAD_BRIGHT_MIN;
-+	props.max_brightness = ASUS_SCREENPAD_BRIGHT_MAX;
- 	bd = backlight_device_register("asus_screenpad",
- 				       &asus->platform_device->dev, asus,
- 				       &asus_screenpad_bl_ops, &props);
-@@ -4181,7 +4310,7 @@ static int asus_screenpad_init(struct asus_wmi *asus)
- 
- 	asus->screenpad_backlight_device = bd;
- 	asus->driver->screenpad_brightness = brightness;
--	bd->props.brightness = brightness - ASUS_SCREENPAD_BRIGHT_MIN;
-+	bd->props.brightness = brightness;
- 	bd->props.power = power;
- 	backlight_update_status(bd);
- 
-@@ -4393,27 +4522,29 @@ static struct attribute *platform_attributes[] = {
+@@ -4393,27 +4658,29 @@ static struct attribute *platform_attributes[] = {
  	&dev_attr_camera.attr,
  	&dev_attr_cardr.attr,
  	&dev_attr_touchpad.attr,
@@ -7851,7 +7282,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	NULL
  };
  
-@@ -4435,7 +4566,11 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
+@@ -4435,7 +4702,11 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
  		devid = ASUS_WMI_DEVID_LID_RESUME;
  	else if (attr == &dev_attr_als_enable.attr)
  		devid = ASUS_WMI_DEVID_ALS_ENABLE;
@@ -7864,7 +7295,7 @@ index 47cc766624d7..942f1013d6cb 100644
  		devid = ASUS_WMI_DEVID_CHARGE_MODE;
  	else if (attr == &dev_attr_egpu_enable.attr)
  		ok = asus->egpu_enable_available;
-@@ -4473,6 +4608,7 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
+@@ -4473,6 +4744,7 @@ static umode_t asus_sysfs_is_visible(struct kobject *kobj,
  		ok = asus->mini_led_dev_id != 0;
  	else if (attr == &dev_attr_available_mini_led_mode.attr)
  		ok = asus->mini_led_dev_id != 0;
@@ -7872,7 +7303,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  	if (devid != -1) {
  		ok = !(asus_wmi_get_devstate_simple(asus, devid) < 0);
-@@ -4712,7 +4848,23 @@ static int asus_wmi_add(struct platform_device *pdev)
+@@ -4712,7 +4984,23 @@ static int asus_wmi_add(struct platform_device *pdev)
  	if (err)
  		goto fail_platform;
  
@@ -7896,7 +7327,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	asus->ppt_pl2_sppt = 5;
  	asus->ppt_pl1_spl = 5;
  	asus->ppt_apu_sppt = 5;
-@@ -4725,8 +4877,6 @@ static int asus_wmi_add(struct platform_device *pdev)
+@@ -4725,8 +5013,6 @@ static int asus_wmi_add(struct platform_device *pdev)
  	asus->dgpu_disable_available = asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_DGPU);
  	asus->kbd_rgb_state_available = asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_TUF_RGB_STATE);
  	asus->oobe_state_available = asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_OOBE);
@@ -7905,7 +7336,7 @@ index 47cc766624d7..942f1013d6cb 100644
  
  	if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_MINI_LED_MODE))
  		asus->mini_led_dev_id = ASUS_WMI_DEVID_MINI_LED_MODE;
-@@ -4737,17 +4887,18 @@ static int asus_wmi_add(struct platform_device *pdev)
+@@ -4737,17 +5023,18 @@ static int asus_wmi_add(struct platform_device *pdev)
  		asus->gpu_mux_dev = ASUS_WMI_DEVID_GPU_MUX;
  	else if (asus_wmi_dev_is_present(asus, ASUS_WMI_DEVID_GPU_MUX_VIVO))
  		asus->gpu_mux_dev = ASUS_WMI_DEVID_GPU_MUX_VIVO;
@@ -7929,7 +7360,7 @@ index 47cc766624d7..942f1013d6cb 100644
  	err = fan_boost_mode_check_present(asus);
  	if (err)
  		goto fail_fan_boost_mode;
-@@ -4913,34 +5064,6 @@ static int asus_hotk_resume(struct device *device)
+@@ -4913,34 +5200,6 @@ static int asus_hotk_resume(struct device *device)
  	return 0;
  }
  
@@ -7964,19 +7395,10 @@ index 47cc766624d7..942f1013d6cb 100644
  static int asus_hotk_restore(struct device *device)
  {
  	struct asus_wmi *asus = dev_get_drvdata(device);
-@@ -4988,11 +5111,34 @@ static int asus_hotk_restore(struct device *device)
+@@ -4988,11 +5247,50 @@ static int asus_hotk_restore(struct device *device)
  	return 0;
  }
  
-+static void asus_ally_s2idle_restore(void)
-+{
-+	if (use_ally_mcu_hack == ASUS_WMI_ALLY_MCU_HACK_ENABLED) {
-+		acpi_execute_simple_method(NULL, ASUS_USB0_PWR_EC0_CSEE,
-+					   ASUS_USB0_PWR_EC0_CSEE_ON);
-+		msleep(ASUS_USB0_PWR_EC0_CSEE_WAIT);
-+	}
-+}
-+
 +static int asus_hotk_prepare(struct device *device)
 +{
 +	if (use_ally_mcu_hack == ASUS_WMI_ALLY_MCU_HACK_ENABLED) {
@@ -7987,10 +7409,35 @@ index 47cc766624d7..942f1013d6cb 100644
 +	return 0;
 +}
 +
++#if defined(CONFIG_SUSPEND)
++static void asus_ally_s2idle_restore(void)
++{
++	if (use_ally_mcu_hack == ASUS_WMI_ALLY_MCU_HACK_ENABLED) {
++		acpi_execute_simple_method(NULL, ASUS_USB0_PWR_EC0_CSEE,
++					   ASUS_USB0_PWR_EC0_CSEE_ON);
++		msleep(ASUS_USB0_PWR_EC0_CSEE_WAIT);
++	}
++}
++
 +/* Use only for Ally devices due to the wake_on_ac */
 +static struct acpi_s2idle_dev_ops asus_ally_s2idle_dev_ops = {
 +	.restore = asus_ally_s2idle_restore,
 +};
++
++static void asus_s2idle_check_register(void)
++{
++	if (acpi_register_lps0_dev(&asus_ally_s2idle_dev_ops))
++		pr_warn("failed to register LPS0 sleep handler in asus-wmi\n");
++}
++
++static void asus_s2idle_check_unregister(void)
++{
++	acpi_unregister_lps0_dev(&asus_ally_s2idle_dev_ops);
++}
++#else
++static void asus_s2idle_check_register(void) {}
++static void asus_s2idle_check_unregister(void) {}
++#endif /* CONFIG_SUSPEND */
 +
  static const struct dev_pm_ops asus_pm_ops = {
  	.thaw = asus_hotk_thaw,
@@ -8000,27 +7447,47 @@ index 47cc766624d7..942f1013d6cb 100644
  	.prepare = asus_hotk_prepare,
  };
  
-@@ -5020,6 +5166,10 @@ static int asus_wmi_probe(struct platform_device *pdev)
+@@ -5020,6 +5318,8 @@ static int asus_wmi_probe(struct platform_device *pdev)
  			return ret;
  	}
  
-+	ret = acpi_register_lps0_dev(&asus_ally_s2idle_dev_ops);
-+	if (ret)
-+		pr_warn("failed to register LPS0 sleep handler in asus-wmi\n");
++	asus_s2idle_check_register();
 +
  	return asus_wmi_add(pdev);
  }
  
-@@ -5052,6 +5202,7 @@ EXPORT_SYMBOL_GPL(asus_wmi_register_driver);
+@@ -5052,6 +5352,8 @@ EXPORT_SYMBOL_GPL(asus_wmi_register_driver);
  
  void asus_wmi_unregister_driver(struct asus_wmi_driver *driver)
  {
-+	acpi_unregister_lps0_dev(&asus_ally_s2idle_dev_ops);
++	asus_s2idle_check_unregister();
++
  	platform_device_unregister(driver->platform_device);
  	platform_driver_unregister(&driver->platform_driver);
  	used = false;
+diff --git a/drivers/platform/x86/asus-wmi.h b/drivers/platform/x86/asus-wmi.h
+index 018dfde40..5cd4392b9 100644
+--- a/drivers/platform/x86/asus-wmi.h
++++ b/drivers/platform/x86/asus-wmi.h
+@@ -18,6 +18,7 @@
+ #include <linux/i8042.h>
+ 
+ #define ASUS_WMI_KEY_IGNORE (-1)
++#define ASUS_WMI_KEY_ARMOURY	0xffff01
+ #define ASUS_WMI_BRN_DOWN	0x2e
+ #define ASUS_WMI_BRN_UP		0x2f
+ 
+@@ -40,7 +41,7 @@ struct quirk_entry {
+ 	bool wmi_force_als_set;
+ 	bool wmi_ignore_fan;
+ 	bool filter_i8042_e1_extended_codes;
+-	bool ignore_key_wlan;
++	int key_wlan_event;
+ 	enum asus_wmi_tablet_switch_mode tablet_switch_mode;
+ 	int wapf;
+ 	/*
 diff --git a/include/linux/platform_data/x86/asus-wmi.h b/include/linux/platform_data/x86/asus-wmi.h
-index 783e2a336861..de281fd850c0 100644
+index 783e2a336..bf428546f 100644
 --- a/include/linux/platform_data/x86/asus-wmi.h
 +++ b/include/linux/platform_data/x86/asus-wmi.h
 @@ -6,6 +6,9 @@
@@ -8065,7 +7532,7 @@ index 783e2a336861..de281fd850c0 100644
  /* gpu mux switch, 0 = dGPU, 1 = Optimus */
  #define ASUS_WMI_DEVID_GPU_MUX		0x00090016
  #define ASUS_WMI_DEVID_GPU_MUX_VIVO	0x00090026
-@@ -157,9 +172,33 @@
+@@ -157,17 +172,71 @@
  #define ASUS_WMI_DSTS_MAX_BRIGTH_MASK	0x0000FF00
  #define ASUS_WMI_DSTS_LIGHTBAR_MASK	0x0000000F
  
@@ -8075,12 +7542,29 @@ index 783e2a336861..de281fd850c0 100644
 +	ASUS_WMI_ALLY_MCU_HACK_DISABLED,
 +};
 +
++struct asus_hid_listener {
++	struct list_head list;
++	void (*brightness_set)(struct asus_hid_listener *listener, int brightness);
++};
++
++enum asus_hid_event {
++	ASUS_EV_BRTUP,
++	ASUS_EV_BRTDOWN,
++	ASUS_EV_BRTTOGGLE,
++};
++
++#define ASUS_EV_MAX_BRIGHTNESS 3
++
  #if IS_REACHABLE(CONFIG_ASUS_WMI)
 +void set_ally_mcu_hack(enum asus_ally_mcu_hack status);
 +void set_ally_mcu_powersave(bool enabled);
 +int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval);
 +int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval);
  int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1, u32 *retval);
++
++int asus_hid_register_listener(struct asus_hid_listener *cdev);
++void asus_hid_unregister_listener(struct asus_hid_listener *cdev);
++int asus_hid_event(enum asus_hid_event event);
  #else
 +static inline void set_ally_mcu_hack(enum asus_ally_mcu_hack status)
 +{
@@ -8088,24 +7572,49 @@ index 783e2a336861..de281fd850c0 100644
 +static inline void set_ally_mcu_powersave(bool enabled)
 +{
 +}
-+static inline int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval)
++static inline int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval)
 +{
 +	return -ENODEV;
 +}
-+static inline int asus_wmi_set_devstate(u32 dev_id, u32 ctrl_param, u32 *retval)
++static inline int asus_wmi_get_devstate_dsts(u32 dev_id, u32 *retval)
 +{
 +	return -ENODEV;
 +}
  static inline int asus_wmi_evaluate_method(u32 method_id, u32 arg0, u32 arg1,
  					   u32 *retval)
  {
--- 
-2.50.1
-
-From 3c311e38a0083539839f47260633cae7876d11a8 Mon Sep 17 00:00:00 2001
+ 	return -ENODEV;
+ }
++
++static inline int asus_hid_register_listener(struct asus_hid_listener *bdev)
++{
++	return -ENODEV;
++}
++static inline void asus_hid_unregister_listener(struct asus_hid_listener *bdev)
++{
++}
++static inline int asus_hid_event(enum asus_hid_event event)
++{
++	return -ENODEV;
++}
+ #endif
+ 
+ /* To be used by both hid-asus and asus-wmi to determine which controls kbd_brightness */
++#if IS_REACHABLE(CONFIG_ASUS_WMI) || IS_REACHABLE(CONFIG_HID_ASUS)
+ static const struct dmi_system_id asus_use_hid_led_dmi_ids[] = {
+ 	{
+ 		.matches = {
+@@ -206,5 +275,6 @@ static const struct dmi_system_id asus_use_hid_led_dmi_ids[] = {
+ 	},
+ 	{ },
+ };
++#endif
+ 
+ #endif	/* __PLATFORM_DATA_X86_ASUS_WMI_H */
+From 54df6e1e7c824b9936f4edc3daf9bc8575742371 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:07 +0200
-Subject: [PATCH 3/6] bbr3
+Subject: [PATCH 3/7] bbr3
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -8128,7 +7637,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  16 files changed, 1941 insertions(+), 555 deletions(-)
 
 diff --git a/include/linux/tcp.h b/include/linux/tcp.h
-index 5c7c5038d47b..56286a2c7bca 100644
+index 5c7c5038d..56286a2c7 100644
 --- a/include/linux/tcp.h
 +++ b/include/linux/tcp.h
 @@ -248,7 +248,8 @@ struct tcp_sock {
@@ -8152,7 +7661,7 @@ index 5c7c5038d47b..56286a2c7bca 100644
  
  	/* RX read-write hotpath cache lines */
 diff --git a/include/net/inet_connection_sock.h b/include/net/inet_connection_sock.h
-index 1735db332aab..2c4a94af7093 100644
+index 1735db332..2c4a94af7 100644
 --- a/include/net/inet_connection_sock.h
 +++ b/include/net/inet_connection_sock.h
 @@ -132,8 +132,8 @@ struct inet_connection_sock {
@@ -8167,7 +7676,7 @@ index 1735db332aab..2c4a94af7093 100644
  
  #define ICSK_TIME_RETRANS	1	/* Retransmit timer */
 diff --git a/include/net/tcp.h b/include/net/tcp.h
-index 4450c384ef17..61f73ca30be3 100644
+index 4450c384e..61f73ca30 100644
 --- a/include/net/tcp.h
 +++ b/include/net/tcp.h
 @@ -379,11 +379,14 @@ static inline void tcp_dec_quickack_mode(struct sock *sk)
@@ -8345,7 +7854,7 @@ index 4450c384ef17..61f73ca30be3 100644
  static inline void tcp_plb_init(const struct sock *sk,
  				struct tcp_plb_state *plb)
 diff --git a/include/uapi/linux/inet_diag.h b/include/uapi/linux/inet_diag.h
-index 86bb2e8b17c9..9d9a3eb2ce9b 100644
+index 86bb2e8b1..9d9a3eb2c 100644
 --- a/include/uapi/linux/inet_diag.h
 +++ b/include/uapi/linux/inet_diag.h
 @@ -229,6 +229,29 @@ struct tcp_bbr_info {
@@ -8379,7 +7888,7 @@ index 86bb2e8b17c9..9d9a3eb2ce9b 100644
  
  union tcp_cc_info {
 diff --git a/include/uapi/linux/rtnetlink.h b/include/uapi/linux/rtnetlink.h
-index dab9493c791b..cce4975fdcfe 100644
+index dab9493c7..cce4975fd 100644
 --- a/include/uapi/linux/rtnetlink.h
 +++ b/include/uapi/linux/rtnetlink.h
 @@ -517,12 +517,14 @@ enum {
@@ -8399,19 +7908,19 @@ index dab9493c791b..cce4975fdcfe 100644
  struct rta_session {
  	__u8	proto;
 diff --git a/include/uapi/linux/tcp.h b/include/uapi/linux/tcp.h
-index dc8fdc80e16b..6b2003dbae81 100644
+index dc8fdc80e..0d579d558 100644
 --- a/include/uapi/linux/tcp.h
 +++ b/include/uapi/linux/tcp.h
 @@ -184,6 +184,7 @@ enum tcp_fastopen_client_fail {
  #define TCPI_OPT_ECN_SEEN	16 /* we received at least one packet with ECT */
  #define TCPI_OPT_SYN_DATA	32 /* SYN-ACK acked data in SYN sent or rcvd */
  #define TCPI_OPT_USEC_TS	64 /* usec timestamps */
-+#define TCPI_OPT_ECN_LOW	128 /* Low-latency ECN enabled at conn init */
++#define TCPI_OPT_ECN_LOW	128 /* Low-latency ECN configured at init */
  
  /*
   * Sender's congestion state indicating normal or abnormal situations
 diff --git a/net/ipv4/Kconfig b/net/ipv4/Kconfig
-index 6d2c97f8e9ef..ddc116ef22cb 100644
+index 6d2c97f8e..ddc116ef2 100644
 --- a/net/ipv4/Kconfig
 +++ b/net/ipv4/Kconfig
 @@ -669,15 +669,18 @@ config TCP_CONG_BBR
@@ -8443,7 +7952,7 @@ index 6d2c97f8e9ef..ddc116ef22cb 100644
  choice
  	prompt "Default TCP congestion control"
 diff --git a/net/ipv4/bpf_tcp_ca.c b/net/ipv4/bpf_tcp_ca.c
-index e01492234b0b..27893b774e08 100644
+index e01492234..27893b774 100644
 --- a/net/ipv4/bpf_tcp_ca.c
 +++ b/net/ipv4/bpf_tcp_ca.c
 @@ -280,7 +280,7 @@ static void bpf_tcp_ca_pkts_acked(struct sock *sk, const struct ack_sample *samp
@@ -8465,7 +7974,7 @@ index e01492234b0b..27893b774e08 100644
  	.undo_cwnd = bpf_tcp_ca_undo_cwnd,
  	.sndbuf_expand = bpf_tcp_ca_sndbuf_expand,
 diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
-index 905cf7635f77..c8c90c1b31ed 100644
+index 905cf7635..c8c90c1b3 100644
 --- a/net/ipv4/tcp.c
 +++ b/net/ipv4/tcp.c
 @@ -3411,6 +3411,7 @@ int tcp_disconnect(struct sock *sk, int flags)
@@ -8486,7 +7995,7 @@ index 905cf7635f77..c8c90c1b31ed 100644
  		info->tcpi_options |= TCPI_OPT_SYN_DATA;
  	if (tp->tcp_usec_ts)
 diff --git a/net/ipv4/tcp_bbr.c b/net/ipv4/tcp_bbr.c
-index 760941e55153..066da5e5747c 100644
+index 760941e55..066da5e57 100644
 --- a/net/ipv4/tcp_bbr.c
 +++ b/net/ipv4/tcp_bbr.c
 @@ -1,18 +1,19 @@
@@ -11132,7 +10641,7 @@ index 760941e55153..066da5e5747c 100644
  MODULE_DESCRIPTION("TCP BBR (Bottleneck Bandwidth and RTT)");
 +MODULE_VERSION(__stringify(BBR_VERSION));
 diff --git a/net/ipv4/tcp_cong.c b/net/ipv4/tcp_cong.c
-index df758adbb445..e98e5dbc050e 100644
+index df758adbb..e98e5dbc0 100644
 --- a/net/ipv4/tcp_cong.c
 +++ b/net/ipv4/tcp_cong.c
 @@ -237,6 +237,7 @@ void tcp_init_congestion_control(struct sock *sk)
@@ -11144,7 +10653,7 @@ index df758adbb445..e98e5dbc050e 100644
  		icsk->icsk_ca_ops->init(sk);
  	if (tcp_ca_needs_ecn(sk))
 diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
-index bce2a111cc9e..ba2db4641c2b 100644
+index ca24c2ea3..4181f212e 100644
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
 @@ -381,7 +381,7 @@ static void tcp_data_ecn_check(struct sock *sk, const struct sk_buff *skb)
@@ -11260,7 +10769,7 @@ index bce2a111cc9e..ba2db4641c2b 100644
  	return 1;
  
  old_ack:
-@@ -5791,13 +5816,14 @@ static void __tcp_ack_snd_check(struct sock *sk, int ofo_possible)
+@@ -5793,13 +5818,14 @@ static void __tcp_ack_snd_check(struct sock *sk, int ofo_possible)
  
  	    /* More than one full frame received... */
  	if (((tp->rcv_nxt - tp->rcv_wup) > inet_csk(sk)->icsk_ack.rcv_mss &&
@@ -11278,7 +10787,7 @@ index bce2a111cc9e..ba2db4641c2b 100644
  	    tcp_in_quickack_mode(sk) ||
  	    /* Protocol state mandates a one-time immediate ACK */
 diff --git a/net/ipv4/tcp_minisocks.c b/net/ipv4/tcp_minisocks.c
-index fb9349be36b8..3c53e39f8201 100644
+index fb9349be3..3c53e39f8 100644
 --- a/net/ipv4/tcp_minisocks.c
 +++ b/net/ipv4/tcp_minisocks.c
 @@ -472,6 +472,8 @@ void tcp_ca_openreq_child(struct sock *sk, const struct dst_entry *dst)
@@ -11291,7 +10800,7 @@ index fb9349be36b8..3c53e39f8201 100644
  		const struct tcp_congestion_ops *ca;
  
 diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
-index 13295a59d22e..3effb6e51e96 100644
+index 13295a59d..3effb6e51 100644
 --- a/net/ipv4/tcp_output.c
 +++ b/net/ipv4/tcp_output.c
 @@ -339,10 +339,9 @@ static void tcp_ecn_send_syn(struct sock *sk, struct sk_buff *skb)
@@ -11402,7 +10911,7 @@ index 13295a59d22e..3effb6e51e96 100644
  		goto rearm_timer;
  
 diff --git a/net/ipv4/tcp_rate.c b/net/ipv4/tcp_rate.c
-index a8f6d9d06f2e..8737f2134648 100644
+index a8f6d9d06..8737f2134 100644
 --- a/net/ipv4/tcp_rate.c
 +++ b/net/ipv4/tcp_rate.c
 @@ -34,6 +34,24 @@
@@ -11482,7 +10991,7 @@ index a8f6d9d06f2e..8737f2134648 100644
  	rs->interval_us = max(snd_us, ack_us);
  
 diff --git a/net/ipv4/tcp_timer.c b/net/ipv4/tcp_timer.c
-index e4c616bbd727..e4a7a25d667d 100644
+index e4c616bbd..e4a7a25d6 100644
 --- a/net/ipv4/tcp_timer.c
 +++ b/net/ipv4/tcp_timer.c
 @@ -565,7 +565,7 @@ void tcp_retransmit_timer(struct sock *sk)
@@ -11503,22 +11012,302 @@ index e4c616bbd727..e4a7a25d667d 100644
  	tcp_mstamp_refresh(tcp_sk(sk));
  	event = icsk->icsk_pending;
  
--- 
-2.50.1
-
-From 9e1ba99ba55457abd78c90121b3b77b84ba728e6 Mon Sep 17 00:00:00 2001
+From 99ebe5c8fef3a67c5bc3b92649a39ceba446ddee Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
-Date: Fri, 25 Jul 2025 20:24:21 +0200
-Subject: [PATCH 4/6] cachy
+Date: Fri, 15 Aug 2025 21:56:53 +0200
+Subject: [PATCH 4/7] block
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
- .gitignore                                    |    3 +
- .../ABI/testing/sysfs-driver-intel-xe-hwmon   |   24 +
+ block/bfq-iosched.c | 52 +++++++++++++++++++++++++++++++++++++++------
+ block/bfq-iosched.h | 12 +++++++++--
+ block/mq-deadline.c | 48 +++++++++++++++++++++++++++++++++++------
+ 3 files changed, 96 insertions(+), 16 deletions(-)
+
+diff --git a/block/bfq-iosched.c b/block/bfq-iosched.c
+index 67c42d276..2f19c38ef 100644
+--- a/block/bfq-iosched.c
++++ b/block/bfq-iosched.c
+@@ -467,6 +467,21 @@ static struct bfq_io_cq *bfq_bic_lookup(struct request_queue *q)
+ 	return icq;
+ }
+ 
++static struct bfq_io_cq *bfq_bic_try_lookup(struct request_queue *q)
++{
++	if (!current->io_context)
++		return NULL;
++	if (spin_trylock_irq(&q->queue_lock)) {
++		struct bfq_io_cq *icq;
++
++		icq = icq_to_bic(ioc_lookup_icq(q));
++		spin_unlock_irq(&q->queue_lock);
++		return icq;
++	}
++
++	return NULL;
++}
++
+ /*
+  * Scheduler run of queue, if there are requests pending and no one in the
+  * driver that will restart queueing.
+@@ -2463,10 +2478,21 @@ static bool bfq_bio_merge(struct request_queue *q, struct bio *bio,
+ 	 * returned by bfq_bic_lookup does not go away before
+ 	 * bfqd->lock is taken.
+ 	 */
+-	struct bfq_io_cq *bic = bfq_bic_lookup(q);
++	struct bfq_io_cq *bic = bfq_bic_try_lookup(q);
+ 	bool ret;
+ 
+-	spin_lock_irq(&bfqd->lock);
++	/*
++	 * bio merging is called for every bio queued, and it's very easy
++	 * to run into contention because of that. If we fail getting
++	 * the dd lock, just skip this merge attempt. For related IO, the
++	 * plug will be the successful merging point. If we get here, we
++	 * already failed doing the obvious merge. Chances of actually
++	 * getting a merge off this path is a lot slimmer, so skipping an
++	 * occassional lookup that will most likely not succeed anyway should
++	 * not be a problem.
++	 */
++	if (!spin_trylock_irq(&bfqd->lock))
++		return false;
+ 
+ 	if (bic) {
+ 		/*
+@@ -5315,6 +5341,18 @@ static struct request *bfq_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 	struct bfq_queue *in_serv_queue;
+ 	bool waiting_rq, idle_timer_disabled = false;
+ 
++	/*
++	 * If someone else is already dispatching, skip this one. This will
++	 * defer the next dispatch event to when something completes, and could
++	 * potentially lower the queue depth for contended cases.
++	 *
++	 * See the logic in blk_mq_do_dispatch_sched(), which loops and
++	 * retries if nothing is dispatched.
++	 */
++	if (test_bit(BFQ_DISPATCHING, &bfqd->run_state) ||
++	    test_and_set_bit_lock(BFQ_DISPATCHING, &bfqd->run_state))
++		return NULL;
++
+ 	spin_lock_irq(&bfqd->lock);
+ 
+ 	in_serv_queue = bfqd->in_service_queue;
+@@ -5326,6 +5364,7 @@ static struct request *bfq_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 			waiting_rq && !bfq_bfqq_wait_request(in_serv_queue);
+ 	}
+ 
++	clear_bit_unlock(BFQ_DISPATCHING, &bfqd->run_state);
+ 	spin_unlock_irq(&bfqd->lock);
+ 	bfq_update_dispatch_stats(hctx->queue, rq,
+ 			idle_timer_disabled ? in_serv_queue : NULL,
+@@ -6248,10 +6287,9 @@ static inline void bfq_update_insert_stats(struct request_queue *q,
+ 
+ static struct bfq_queue *bfq_init_rq(struct request *rq);
+ 
+-static void bfq_insert_request(struct blk_mq_hw_ctx *hctx, struct request *rq,
++static void bfq_insert_request(struct request_queue *q, struct request *rq,
+ 			       blk_insert_t flags)
+ {
+-	struct request_queue *q = hctx->queue;
+ 	struct bfq_data *bfqd = q->elevator->elevator_data;
+ 	struct bfq_queue *bfqq;
+ 	bool idle_timer_disabled = false;
+@@ -6313,7 +6351,7 @@ static void bfq_insert_requests(struct blk_mq_hw_ctx *hctx,
+ 
+ 		rq = list_first_entry(list, struct request, queuelist);
+ 		list_del_init(&rq->queuelist);
+-		bfq_insert_request(hctx, rq, flags);
++		bfq_insert_request(hctx->queue, rq, flags);
+ 	}
+ }
+ 
+@@ -7251,6 +7289,8 @@ static int bfq_init_queue(struct request_queue *q, struct elevator_type *e)
+ 	q->elevator = eq;
+ 	spin_unlock_irq(&q->queue_lock);
+ 
++	spin_lock_init(&bfqd->lock);
++
+ 	/*
+ 	 * Our fallback bfqq if bfq_find_alloc_queue() runs into OOM issues.
+ 	 * Grab a permanent reference to it, so that the normal code flow
+@@ -7368,8 +7408,6 @@ static int bfq_init_queue(struct request_queue *q, struct elevator_type *e)
+ 	/* see comments on the definition of next field inside bfq_data */
+ 	bfqd->actuator_load_threshold = 4;
+ 
+-	spin_lock_init(&bfqd->lock);
+-
+ 	/*
+ 	 * The invocation of the next bfq_create_group_hierarchy
+ 	 * function is the head of a chain of function calls
+diff --git a/block/bfq-iosched.h b/block/bfq-iosched.h
+index 31217f196..a250c5599 100644
+--- a/block/bfq-iosched.h
++++ b/block/bfq-iosched.h
+@@ -504,12 +504,22 @@ struct bfq_io_cq {
+ 	unsigned int requests;	/* Number of requests this process has in flight */
+ };
+ 
++enum {
++	BFQ_DISPATCHING	= 0,
++};
++
+ /**
+  * struct bfq_data - per-device data structure.
+  *
+  * All the fields are protected by @lock.
+  */
+ struct bfq_data {
++	struct {
++		spinlock_t lock;
++	} ____cacheline_aligned_in_smp;
++
++	unsigned long run_state;
++
+ 	/* device request queue */
+ 	struct request_queue *queue;
+ 	/* dispatch queue */
+@@ -795,8 +805,6 @@ struct bfq_data {
+ 	/* fallback dummy bfqq for extreme OOM conditions */
+ 	struct bfq_queue oom_bfqq;
+ 
+-	spinlock_t lock;
+-
+ 	/*
+ 	 * bic associated with the task issuing current bio for
+ 	 * merging. This and the next field are used as a support to
+diff --git a/block/mq-deadline.c b/block/mq-deadline.c
+index ed0e0f70f..ccfbd61bd 100644
+--- a/block/mq-deadline.c
++++ b/block/mq-deadline.c
+@@ -79,10 +79,20 @@ struct dd_per_prio {
+ 	struct io_stats_per_prio stats;
+ };
+ 
++enum {
++	DD_DISPATCHING	= 0,
++};
++
+ struct deadline_data {
+ 	/*
+ 	 * run time data
+ 	 */
++	struct {
++		spinlock_t lock;
++		spinlock_t zone_lock;
++	} ____cacheline_aligned_in_smp;
++
++	unsigned long run_state;
+ 
+ 	struct dd_per_prio per_prio[DD_PRIO_COUNT];
+ 
+@@ -100,8 +110,6 @@ struct deadline_data {
+ 	int front_merges;
+ 	u32 async_depth;
+ 	int prio_aging_expire;
+-
+-	spinlock_t lock;
+ };
+ 
+ /* Maps an I/O priority class to a deadline scheduler priority. */
+@@ -466,6 +474,18 @@ static struct request *dd_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 	struct request *rq;
+ 	enum dd_prio prio;
+ 
++	/*
++	 * If someone else is already dispatching, skip this one. This will
++	 * defer the next dispatch event to when something completes, and could
++	 * potentially lower the queue depth for contended cases.
++	 *
++	 * See the logic in blk_mq_do_dispatch_sched(), which loops and
++	 * retries if nothing is dispatched.
++	 */
++	if (test_bit(DD_DISPATCHING, &dd->run_state) ||
++	    test_and_set_bit_lock(DD_DISPATCHING, &dd->run_state))
++		return NULL;
++
+ 	spin_lock(&dd->lock);
+ 	rq = dd_dispatch_prio_aged_requests(dd, now);
+ 	if (rq)
+@@ -482,6 +502,7 @@ static struct request *dd_dispatch_request(struct blk_mq_hw_ctx *hctx)
+ 	}
+ 
+ unlock:
++	clear_bit_unlock(DD_DISPATCHING, &dd->run_state);
+ 	spin_unlock(&dd->lock);
+ 
+ 	return rq;
+@@ -571,6 +592,9 @@ static int dd_init_sched(struct request_queue *q, struct elevator_type *e)
+ 
+ 	eq->elevator_data = dd;
+ 
++	spin_lock_init(&dd->lock);
++	spin_lock_init(&dd->zone_lock);
++
+ 	for (prio = 0; prio <= DD_PRIO_MAX; prio++) {
+ 		struct dd_per_prio *per_prio = &dd->per_prio[prio];
+ 
+@@ -587,7 +611,6 @@ static int dd_init_sched(struct request_queue *q, struct elevator_type *e)
+ 	dd->last_dir = DD_WRITE;
+ 	dd->fifo_batch = fifo_batch;
+ 	dd->prio_aging_expire = prio_aging_expire;
+-	spin_lock_init(&dd->lock);
+ 
+ 	/* We dispatch from request queue wide instead of hw queue */
+ 	blk_queue_flag_set(QUEUE_FLAG_SQ_SCHED, q);
+@@ -643,7 +666,19 @@ static bool dd_bio_merge(struct request_queue *q, struct bio *bio,
+ 	struct request *free = NULL;
+ 	bool ret;
+ 
+-	spin_lock(&dd->lock);
++	/*
++	 * bio merging is called for every bio queued, and it's very easy
++	 * to run into contention because of that. If we fail getting
++	 * the dd lock, just skip this merge attempt. For related IO, the
++	 * plug will be the successful merging point. If we get here, we
++	 * already failed doing the obvious merge. Chances of actually
++	 * getting a merge off this path is a lot slimmer, so skipping an
++	 * occassional lookup that will most likely not succeed anyway should
++	 * not be a problem.
++	 */
++	if (!spin_trylock(&dd->lock))
++		return false;
++
+ 	ret = blk_mq_sched_try_merge(q, bio, nr_segs, &free);
+ 	spin_unlock(&dd->lock);
+ 
+@@ -656,10 +691,9 @@ static bool dd_bio_merge(struct request_queue *q, struct bio *bio,
+ /*
+  * add rq to rbtree and fifo
+  */
+-static void dd_insert_request(struct blk_mq_hw_ctx *hctx, struct request *rq,
++static void dd_insert_request(struct request_queue *q, struct request *rq,
+ 			      blk_insert_t flags, struct list_head *free)
+ {
+-	struct request_queue *q = hctx->queue;
+ 	struct deadline_data *dd = q->elevator->elevator_data;
+ 	const enum dd_data_dir data_dir = rq_data_dir(rq);
+ 	u16 ioprio = req_get_ioprio(rq);
+@@ -717,7 +751,7 @@ static void dd_insert_requests(struct blk_mq_hw_ctx *hctx,
+ 
+ 		rq = list_first_entry(list, struct request, queuelist);
+ 		list_del_init(&rq->queuelist);
+-		dd_insert_request(hctx, rq, flags, &free);
++		dd_insert_request(q, rq, flags, &free);
+ 	}
+ 	spin_unlock(&dd->lock);
+ 
+From 121167381198a57897e6f2e408c7672835138ce6 Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Fri, 25 Jul 2025 20:24:21 +0200
+Subject: [PATCH 5/7] cachy
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ .gitignore                                    |    2 +
  .../admin-guide/kernel-parameters.txt         |   12 +
  Documentation/admin-guide/sysctl/vm.rst       |   72 +
- MAINTAINERS                                   |    5 +
- Makefile                                      |   48 +-
+ Makefile                                      |   33 +-
  arch/Kconfig                                  |   19 +
  arch/x86/Kconfig.cpu                          |   70 +
  arch/x86/Makefile                             |   17 +
@@ -11526,7 +11315,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  arch/x86/pci/common.c                         |    7 +-
  block/Kconfig.iosched                         |   14 +
  block/Makefile                                |    8 +
- block/adios.c                                 | 1450 ++++++++
+ block/adios.c                                 | 1593 ++++++++
  block/elevator.c                              |   12 +
  drivers/Makefile                              |   13 +-
  drivers/ata/ahci.c                            |   23 +-
@@ -11546,13 +11335,17 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  drivers/gpu/drm/xe/xe_hwmon.c                 |  125 +-
  drivers/gpu/drm/xe/xe_pci.c                   |    4 +
  drivers/gpu/drm/xe/xe_pcode_api.h             |    3 +
+ drivers/hid/amd-sfh-hid/amd_sfh_client.c      |   23 +
+ drivers/hid/amd-sfh-hid/amd_sfh_hid.h         |    2 +-
+ drivers/hid/amd-sfh-hid/amd_sfh_pcie.c        |    4 +
+ drivers/hid/amd-sfh-hid/amd_sfh_pcie.h        |    1 +
  drivers/input/evdev.c                         |   19 +-
  drivers/md/dm-crypt.c                         |    5 +
  drivers/media/v4l2-core/Kconfig               |    5 +
  drivers/media/v4l2-core/Makefile              |    2 +
- drivers/media/v4l2-core/v4l2loopback.c        | 3313 +++++++++++++++++
+ drivers/media/v4l2-core/v4l2loopback.c        | 3315 +++++++++++++++++
  drivers/media/v4l2-core/v4l2loopback.h        |  108 +
- .../media/v4l2-core/v4l2loopback_formats.h    |  445 +++
+ .../media/v4l2-core/v4l2loopback_formats.h    |  453 +++
  drivers/pci/controller/Makefile               |    6 +
  drivers/pci/controller/intel-nvme-remap.c     |  462 +++
  drivers/pci/quirks.c                          |  101 +
@@ -11587,12 +11380,10 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  mm/vmpressure.c                               |    4 +
  mm/vmscan.c                                   |  157 +-
  net/ipv4/inet_connection_sock.c               |    2 +-
- scripts/Makefile.build                        |   52 +-
- scripts/Makefile.lib                          |    7 +-
- scripts/Makefile.vmlinux_o                    |   16 +-
- scripts/Makefile.vmlinux_thinlink             |   53 +
- scripts/head-object-list.txt                  |    1 +
- 79 files changed, 8103 insertions(+), 68 deletions(-)
+ scripts/Makefile.thinlto                      |   38 +
+ scripts/Makefile.vmlinux_a                    |   83 +
+ scripts/mod/modpost.c                         |   15 +-
+ 79 files changed, 8245 insertions(+), 71 deletions(-)
  create mode 100644 block/adios.c
  create mode 100644 drivers/media/v4l2-core/v4l2loopback.c
  create mode 100644 drivers/media/v4l2-core/v4l2loopback.h
@@ -11601,70 +11392,31 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  create mode 100644 drivers/scsi/vhba/Kconfig
  create mode 100644 drivers/scsi/vhba/Makefile
  create mode 100644 drivers/scsi/vhba/vhba.c
- create mode 100644 scripts/Makefile.vmlinux_thinlink
+ create mode 100644 scripts/Makefile.thinlto
+ create mode 100644 scripts/Makefile.vmlinux_a
 
 diff --git a/.gitignore b/.gitignore
-index f2f63e47fb88..b83a68185ef4 100644
+index f2f63e47f..dc1dfd672 100644
 --- a/.gitignore
 +++ b/.gitignore
-@@ -12,6 +12,7 @@
+@@ -54,6 +54,7 @@
+ *.zst
+ Module.symvers
+ dtbs-list
++builtin.order
+ modules.order
+ 
  #
- .*
- *.a
-+*.a_thinlto_native
- *.asn1.[ch]
- *.bin
- *.bz2
-@@ -39,6 +40,7 @@
- *.mod.c
- *.o
- *.o.*
-+*.o_thinlto_native
- *.patch
- *.rmeta
- *.rpm
-@@ -64,6 +66,7 @@ modules.order
- /vmlinux
+@@ -65,6 +66,7 @@ modules.order
  /vmlinux.32
  /vmlinux.map
-+/vmlinux.thinlink
  /vmlinux.symvers
++/vmlinux.thinlto-index
  /vmlinux.unstripped
  /vmlinux-gdb.py
-diff --git a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
-index cb207c79680d..6fbab98fb639 100644
---- a/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
-+++ b/Documentation/ABI/testing/sysfs-driver-intel-xe-hwmon
-@@ -124,3 +124,27 @@ Contact:	intel-xe@lists.freedesktop.org
- Description:	RO. VRAM temperature in millidegree Celsius.
- 
- 		Only supported for particular Intel Xe graphics platforms.
-+
-+What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan1_input
-+Date:		March 2025
-+KernelVersion:	6.14
-+Contact:	intel-xe@lists.freedesktop.org
-+Description:	RO. Fan 1 speed in RPM.
-+
-+		Only supported for particular Intel Xe graphics platforms.
-+
-+What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan2_input
-+Date:		March 2025
-+KernelVersion:	6.14
-+Contact:	intel-xe@lists.freedesktop.org
-+Description:	RO. Fan 2 speed in RPM.
-+
-+		Only supported for particular Intel Xe graphics platforms.
-+
-+What:		/sys/bus/pci/drivers/xe/.../hwmon/hwmon<i>/fan3_input
-+Date:		March 2025
-+KernelVersion:	6.14
-+Contact:	intel-xe@lists.freedesktop.org
-+Description:	RO. Fan 3 speed in RPM.
-+
-+		Only supported for particular Intel Xe graphics platforms.
+ /vmlinuz
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 76a34e0aef76..186454e1c55b 100644
+index 76a34e0ae..186454e1c 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -2318,6 +2318,9 @@
@@ -11694,7 +11446,7 @@ index 76a34e0aef76..186454e1c55b 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/Documentation/admin-guide/sysctl/vm.rst b/Documentation/admin-guide/sysctl/vm.rst
-index 8290177b4f75..2a94faa5a4ca 100644
+index 8290177b4..2a94faa5a 100644
 --- a/Documentation/admin-guide/sysctl/vm.rst
 +++ b/Documentation/admin-guide/sysctl/vm.rst
 @@ -25,6 +25,9 @@ files can be found in mm/swap.c.
@@ -11790,37 +11542,11 @@ index 8290177b4f75..2a94faa5a4ca 100644
  
  unprivileged_userfaultfd
  ========================
-diff --git a/MAINTAINERS b/MAINTAINERS
-index dd844ac8d910..4feb3b9f8f73 100644
---- a/MAINTAINERS
-+++ b/MAINTAINERS
-@@ -5790,6 +5790,11 @@ F:	scripts/Makefile.clang
- F:	scripts/clang-tools/
- K:	\b(?i:clang|llvm)\b
- 
-+CLANG/LLVM THINLTO DISTRIBUTED BUILD
-+M:	Rong Xu <xur@google.com>
-+S:	Supported
-+F:	scripts/Makefile.vmlinux_thinlink
-+
- CLK API
- M:	Russell King <linux@armlinux.org.uk>
- L:	linux-clk@vger.kernel.org
 diff --git a/Makefile b/Makefile
-index 8e2d03723368..9db3d9c480d3 100644
+index 3a9650df9..f30488d35 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -298,7 +298,8 @@ no-dot-config-targets := $(clean-targets) \
- 			 outputmakefile rustavailable rustfmt rustfmtcheck
- no-sync-config-targets := $(no-dot-config-targets) %install modules_sign kernelrelease \
- 			  image_name
--single-targets := %.a %.i %.ko %.lds %.ll %.lst %.mod %.o %.rsi %.s %/
-+single-targets := %.a %.i %.ko %.lds %.ll %.lst %.mod %.o %.rsi %.s %.o_thinlto_native \
-+	          %.a_thinlto_native %.o.thinlto.bc %/
- 
- config-build	:=
- mixed-build	:=
-@@ -857,11 +858,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
+@@ -857,11 +857,19 @@ KBUILD_CFLAGS	+= -fno-delete-null-pointer-checks
  ifdef CONFIG_CC_OPTIMIZE_FOR_PERFORMANCE
  KBUILD_CFLAGS += -O2
  KBUILD_RUSTFLAGS += -Copt-level=2
@@ -11840,7 +11566,7 @@ index 8e2d03723368..9db3d9c480d3 100644
  # Always set `debug-assertions` and `overflow-checks` because their default
  # depends on `opt-level` and `debug-assertions`, respectively.
  KBUILD_RUSTFLAGS += -Cdebug-assertions=$(if $(CONFIG_RUST_DEBUG_ASSERTIONS),y,n)
-@@ -991,10 +1000,10 @@ export CC_FLAGS_SCS
+@@ -991,10 +999,10 @@ export CC_FLAGS_SCS
  endif
  
  ifdef CONFIG_LTO_CLANG
@@ -11849,67 +11575,61 @@ index 8e2d03723368..9db3d9c480d3 100644
 -else
 +ifdef CONFIG_LTO_CLANG_FULL
  CC_FLAGS_LTO	:= -flto
-+else # for CONFIG_LTO_CLANG_THIN or CONFIG_LTO_CLANG_THIN_DIST
++else
 +CC_FLAGS_LTO	:= -flto=thin -fsplit-lto-unit
  endif
  CC_FLAGS_LTO	+= -fvisibility=hidden
  
-@@ -1213,8 +1222,34 @@ vmlinux.a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
- 	$(call if_changed,ar_vmlinux.a)
+@@ -1192,7 +1200,7 @@ else
+ KBUILD_VMLINUX_LIBS := $(patsubst %/,%/lib.a, $(libs-y))
+ endif
+ 
+-export KBUILD_VMLINUX_LIBS
++export KBUILD_VMLINUX_OBJS KBUILD_VMLINUX_LIBS
+ export KBUILD_LDS          := arch/$(SRCARCH)/kernel/vmlinux.lds
+ 
+ ifdef CONFIG_TRIM_UNUSED_KSYMS
+@@ -1201,16 +1209,12 @@ ifdef CONFIG_TRIM_UNUSED_KSYMS
+ KBUILD_MODULES := 1
+ endif
+ 
+-# '$(AR) mPi' needs 'T' to workaround the bug of llvm-ar <= 14
+-quiet_cmd_ar_vmlinux.a = AR      $@
+-      cmd_ar_vmlinux.a = \
+-	rm -f $@; \
+-	$(AR) cDPrST $@ $(KBUILD_VMLINUX_OBJS); \
+-	$(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep -F -f $(srctree)/scripts/head-object-list.txt)
++PHONY += vmlinux_a
++vmlinux_a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
++	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.vmlinux_a
+ 
+-targets += vmlinux.a
+-vmlinux.a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
+-	$(call if_changed,ar_vmlinux.a)
++vmlinux.a: vmlinux_a
++	@:
  
  PHONY += vmlinux_o
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+vmlinux.thinlink: vmlinux.a $(KBUILD_VMLINUX_LIBS) FORCE
-+	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.vmlinux_thinlink
-+targets += vmlinux.thinlink
-+
-+vmlinux.a_thinlto_native := $(patsubst %.a,%.a_thinlto_native,$(KBUILD_VMLINUX_OBJS))
-+quiet_cmd_ar_vmlinux.a_thinlto_native = AR      $@
-+      cmd_ar_vmlinux.a_thinlto_native = \
-+	rm -f $@; \
-+	$(AR) cDPrST $@ $(vmlinux.a_thinlto_native); \
-+	$(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep -F -f $(srctree)/scripts/head-object-list.txt)
-+
-+define rule_gen_vmlinux.a_thinlto_native
-+	+$(Q)$(MAKE) $(build)=. need-builtin=1 thinlto_final_pass=1 need-modorder=1 built-in.a_thinlto_native
-+	$(call cmd_and_savecmd,ar_vmlinux.a_thinlto_native)
-+endef
-+
-+vmlinux.a_thinlto_native: vmlinux.thinlink scripts/head-object-list.txt FORCE
-+	$(call if_changed_rule,gen_vmlinux.a_thinlto_native)
-+
-+targets += vmlinux.a_thinlto_native
-+
-+vmlinux_o: vmlinux.a_thinlto_native
-+	$(Q)$(MAKE) thinlto_final_pass=1 -f $(srctree)/scripts/Makefile.vmlinux_o
-+else
  vmlinux_o: vmlinux.a $(KBUILD_VMLINUX_LIBS)
- 	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.vmlinux_o
-+endif
- 
- vmlinux.o modules.builtin.modinfo modules.builtin: vmlinux_o
- 	@:
-@@ -1572,7 +1607,8 @@ CLEAN_FILES += vmlinux.symvers modules-only.symvers \
+@@ -1570,6 +1574,7 @@ endif # CONFIG_MODULES
+ CLEAN_FILES += vmlinux.symvers modules-only.symvers \
+ 	       modules.builtin modules.builtin.modinfo modules.nsdeps \
  	       modules.builtin.ranges vmlinux.o.map vmlinux.unstripped \
++	       vmlinux.thinlto-index builtin.order \
  	       compile_commands.json rust/test \
  	       rust-project.json .vmlinux.objs .vmlinux.export.c \
--               .builtin-dtbs-list .builtin-dtb.S
-+	       .builtin-dtbs-list .builtin-dtb.S \
-+	       .vmlinux_thinlto_bc_files vmlinux.thinlink
- 
- # Directories & files removed with 'make mrproper'
- MRPROPER_FILES += include/config include/generated          \
-@@ -2023,6 +2059,8 @@ clean: $(clean-dirs)
- 		-o -name '*.symtypes' -o -name 'modules.order' \
- 		-o -name '*.c.[012]*.*' \
- 		-o -name '*.ll' \
-+		-o -name '*.a_thinlto_native' -o -name '*.o_thinlto_native' \
-+		-o -name '*.o.thinlto.bc' \
- 		-o -name '*.gcno' \
- 		\) -type f -print \
- 		-o -name '.tmp_*' -print \
+                .builtin-dtbs-list .builtin-dtb.S
+@@ -2011,7 +2016,7 @@ clean: $(clean-dirs)
+ 	$(call cmd,rmfiles)
+ 	@find . $(RCS_FIND_IGNORE) \
+ 		\( -name '*.[aios]' -o -name '*.rsi' -o -name '*.ko' -o -name '.*.cmd' \
+-		-o -name '*.ko.*' \
++		-o -name '*.ko.*' -o -name '*.o.thinlto.bc' \
+ 		-o -name '*.dtb' -o -name '*.dtbo' \
+ 		-o -name '*.dtb.S' -o -name '*.dtbo.S' \
+ 		-o -name '*.dt.yaml' -o -name 'dtbs-list' \
 diff --git a/arch/Kconfig b/arch/Kconfig
-index b0adb665041f..30dccda07c67 100644
+index b0adb6650..1c2ddb1b7 100644
 --- a/arch/Kconfig
 +++ b/arch/Kconfig
 @@ -810,6 +810,25 @@ config LTO_CLANG_THIN
@@ -11927,7 +11647,7 @@ index b0adb665041f..30dccda07c67 100644
 +	  ThinLTO index files. Subsequently, the build system explicitly
 +	  invokes ThinLTO backend compilation using these index files
 +	  and pre-linked IR objects. The resulting native object files
-+	  are with the .o_thinlto_native suffix.
++	  are with the .thinlto-native.o suffix.
 +
 +	  This build mode offers improved visibility into the ThinLTO
 +	  process through explicit subcommand exposure. It also makes
@@ -11939,7 +11659,7 @@ index b0adb665041f..30dccda07c67 100644
  
  config ARCH_SUPPORTS_AUTOFDO_CLANG
 diff --git a/arch/x86/Kconfig.cpu b/arch/x86/Kconfig.cpu
-index 753b8763abae..d4ce964d9713 100644
+index 753b8763a..d4ce964d9 100644
 --- a/arch/x86/Kconfig.cpu
 +++ b/arch/x86/Kconfig.cpu
 @@ -245,6 +245,76 @@ config MATOM
@@ -12020,7 +11740,7 @@ index 753b8763abae..d4ce964d9713 100644
  	bool "Generic x86 support"
  	depends on X86_32
 diff --git a/arch/x86/Makefile b/arch/x86/Makefile
-index 594723005d95..cbd234e9e743 100644
+index 594723005..cbd234e9e 100644
 --- a/arch/x86/Makefile
 +++ b/arch/x86/Makefile
 @@ -173,8 +173,25 @@ else
@@ -12050,7 +11770,7 @@ index 594723005d95..cbd234e9e743 100644
          KBUILD_CFLAGS += -mno-red-zone
          KBUILD_CFLAGS += -mcmodel=kernel
 diff --git a/arch/x86/include/asm/pci.h b/arch/x86/include/asm/pci.h
-index b3ab80a03365..5e883b397ff3 100644
+index b3ab80a03..5e883b397 100644
 --- a/arch/x86/include/asm/pci.h
 +++ b/arch/x86/include/asm/pci.h
 @@ -26,6 +26,7 @@ struct pci_sysdata {
@@ -12074,7 +11794,7 @@ index b3ab80a03365..5e883b397ff3 100644
     already-configured bus numbers - to be used for buggy BIOSes
     or architectures with incomplete PCI setup by the loader */
 diff --git a/arch/x86/pci/common.c b/arch/x86/pci/common.c
-index ddb798603201..7c20387d8202 100644
+index ddb798603..7c20387d8 100644
 --- a/arch/x86/pci/common.c
 +++ b/arch/x86/pci/common.c
 @@ -723,12 +723,15 @@ int pci_ext_cfg_avail(void)
@@ -12096,7 +11816,7 @@ index ddb798603201..7c20387d8202 100644
  }
 -#endif
 diff --git a/block/Kconfig.iosched b/block/Kconfig.iosched
-index 27f11320b8d1..e98585dd83e0 100644
+index 27f11320b..e98585dd8 100644
 --- a/block/Kconfig.iosched
 +++ b/block/Kconfig.iosched
 @@ -16,6 +16,20 @@ config MQ_IOSCHED_KYBER
@@ -12121,7 +11841,7 @@ index 27f11320b8d1..e98585dd83e0 100644
  	tristate "BFQ I/O scheduler"
  	select BLK_ICQ
 diff --git a/block/Makefile b/block/Makefile
-index 3a941dc0d27f..94e3bf608bd2 100644
+index 3a941dc0d..94e3bf608 100644
 --- a/block/Makefile
 +++ b/block/Makefile
 @@ -23,6 +23,7 @@ obj-$(CONFIG_BLK_CGROUP_IOLATENCY)	+= blk-iolatency.o
@@ -12145,10 +11865,10 @@ index 3a941dc0d27f..94e3bf608bd2 100644
 +
 diff --git a/block/adios.c b/block/adios.c
 new file mode 100644
-index 000000000000..b1201ac165ed
+index 000000000..1191d617b
 --- /dev/null
 +++ b/block/adios.c
-@@ -0,0 +1,1450 @@
+@@ -0,0 +1,1593 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Adaptive Deadline I/O Scheduler (ADIOS)
@@ -12174,9 +11894,56 @@ index 000000000000..b1201ac165ed
 +#include "blk-mq.h"
 +#include "blk-mq-sched.h"
 +
-+#define ADIOS_VERSION "2.3.0"
++#define ADIOS_VERSION "2.5.4"
 +
-+// Define operation types supported by ADIOS
++/* Request Types:
++ *
++ * Tier 0 (Highest Priority): Emergency & System Integrity Requests
++ * -----------------------------------------------------------------
++ * - Target: Requests with the BLK_MQ_INSERT_AT_HEAD flag.
++ * - Purpose: For critical, non-negotiable operations such as device error
++ *   recovery or flush sequences that must bypass all other scheduling logic.
++ * - Implementation: Placed in a dedicated, high-priority FIFO queue
++ *   (`prio_queue[0]`) for immediate dispatch.
++ *
++ * Tier 1 (High Priority): Data Persistence & Ordering Guarantees
++ * ---------------------------------------------------------------
++ * - Target: Requests with integrity-sensitive flags like REQ_FUA or
++ *   REQ_PREFLUSH, typically originating from O_DIRECT I/O.
++ * - Purpose: To ensure strict ordering and data persistence guarantees,
++ *   preventing data corruption in applications like databases.
++ * - Implementation: Handled in a separate, secondary FIFO queue
++ *   (`prio_queue[1]`) to ensure they are processed in submission order and
++ *   before any lower-priority requests.
++ *
++ * Tier 2 (Medium Priority): Application Responsiveness
++ * ----------------------------------------------------
++ * - Target: Normal synchronous requests (e.g., from standard file reads).
++ * - Purpose: To ensure correct application behavior for operations that
++ *   depend on sequential I/O completion (e.g., file system mounts) and to
++ *   provide low latency for interactive applications.
++ * - Implementation: The deadline for these requests is set to their start
++ *   time (`rq->start_time_ns`). This effectively enforces FIFO-like behavior
++ *   within the deadline-sorted red-black tree, preventing out-of-order
++ *   execution of dependent synchronous operations.
++ *
++ * Tier 3 (Normal Priority): Background Throughput
++ * -----------------------------------------------
++ * - Target: Asynchronous requests.
++ * - Purpose: To maximize disk throughput for background tasks where latency
++ *   is not critical.
++ * - Implementation: These are the only requests where ADIOS's adaptive
++ *   latency prediction model is used. A dynamic deadline is calculated based
++ *   on the predicted I/O latency, allowing for aggressive reordering to
++ *   optimize I/O efficiency.
++ *
++ * Dispatch Logic:
++ * The scheduler always dispatches requests in strict priority order:
++ * 1. prio_queue[0] (Tier 0)
++ * 2. prio_queue[1] (Tier 1)
++ * 3. The deadline-sorted batch queue (which naturally prioritizes Tier 2
++ *    over Tier 3 due to their calculated deadlines).
++ */
 +enum adios_op_type {
 +	ADIOS_READ    = 0,
 +	ADIOS_WRITE   = 1,
@@ -12186,9 +11953,12 @@ index 000000000000..b1201ac165ed
 +};
 +
 +// Global variable to control the latency
-+static u64 default_global_latency_window = 32000000ULL;
++static u64 default_global_latency_window = 24000000ULL;
 +// Ratio below which batch queues should be refilled
 +static u8  default_bq_refill_below_ratio = 25;
++// Use predicted latency in deadline calculation of async requests
++static u8  default_place_deadline_pred_lat = 0;
++static u64 default_lat_model_latency_limit = 500000000ULL;
 +
 +// Dynamic thresholds for shrinkage
 +static u32 default_lm_shrink_at_kreqs  =  5000;
@@ -12233,7 +12003,7 @@ index 000000000000..b1201ac165ed
 +	u32 count;
 +};
 +
-+// New structure to hold per-cpu buckets, improving data locality and code clarity.
++// Structure to hold per-cpu buckets, improving data locality and code clarity.
 +struct lm_buckets {
 +	struct latency_bucket_small small_bucket[LM_LAT_BUCKET_COUNT];
 +	struct latency_bucket_large large_bucket[LM_LAT_BUCKET_COUNT];
@@ -12261,10 +12031,15 @@ index 000000000000..b1201ac165ed
 +#define ADIOS_BQ_PAGES 2
 +#define ADIOS_MAX_INSERTS_PER_LOCK 16
 +
++static void insert_request_pre_stability(struct blk_mq_hw_ctx *hctx,
++	struct request *rq, blk_insert_t insert_flags, struct list_head *free);
++static void insert_request_post_stability(struct blk_mq_hw_ctx *hctx,
++	struct request *rq, blk_insert_t insert_flags, struct list_head *free);
++
 +// Adios scheduler data
 +struct adios_data {
 +	spinlock_t pq_lock;
-+	struct list_head prio_queue;
++	struct list_head prio_queue[2];
 +
 +	struct rb_root_cached dl_tree[2];
 +	spinlock_t lock;
@@ -12272,13 +12047,18 @@ index 000000000000..b1201ac165ed
 +	s64 dl_bias;
 +	s32 dl_prio[2];
 +
++	void (*insert_request_fn)(struct blk_mq_hw_ctx *, struct request *,
++								blk_insert_t, struct list_head *);
++
 +	u64 global_latency_window;
 +	u64 latency_target[ADIOS_OPTYPES];
 +	u32 batch_limit[ADIOS_OPTYPES];
 +	u32 batch_actual_max_size[ADIOS_OPTYPES];
 +	u32 batch_actual_max_total;
 +	u32 async_depth;
++	u32 lat_model_latency_limit;
 +	u8  bq_refill_below_ratio;
++	u8  place_deadline_pred_lat;
 +
 +	bool bq_page;
 +	bool more_bq_ready;
@@ -12292,6 +12072,7 @@ index 000000000000..b1201ac165ed
 +	struct timer_list update_timer;
 +
 +	atomic64_t total_pred_lat;
++	u64 last_completed_time;
 +
 +	struct kmem_cache *rq_data_pool;
 +	struct kmem_cache *dl_group_pool;
@@ -12572,11 +12353,12 @@ index 000000000000..b1201ac165ed
 +// Input latency data into the latency model
 +static void latency_model_input(struct adios_data *ad,
 +		struct latency_model *model, u32 block_size, u64 latency, u64 pred_lat) {
++	unsigned long flags;
 +	u8 bucket_index;
 +	struct lm_buckets *buckets;
-+	int cpu = get_cpu();
 +
-+	buckets = per_cpu_ptr(model->pcpu_buckets, cpu);
++	local_irq_save(flags);
++	buckets = per_cpu_ptr(model->pcpu_buckets, __smp_processor_id());
 +
 +	if (block_size <= LM_BLOCK_SIZE_THRESHOLD) {
 +		// Handle small requests
@@ -12588,7 +12370,7 @@ index 000000000000..b1201ac165ed
 +		buckets->small_bucket[bucket_index].count++;
 +		buckets->small_bucket[bucket_index].sum_latency += latency;
 +
-+		put_cpu();
++		local_irq_restore(flags);
 +
 +		if (unlikely(!model->base)) {
 +			latency_model_update(ad, model);
@@ -12597,7 +12379,7 @@ index 000000000000..b1201ac165ed
 +	} else {
 +		// Handle large requests
 +		if (!model->base || !pred_lat) {
-+			put_cpu();
++			local_irq_restore(flags);
 +			return;
 +		}
 +
@@ -12610,7 +12392,7 @@ index 000000000000..b1201ac165ed
 +		buckets->large_bucket[bucket_index].sum_latency += latency;
 +		buckets->large_bucket[bucket_index].sum_block_size += block_size;
 +
-+		put_cpu();
++		local_irq_restore(flags);
 +	}
 +}
 +
@@ -12665,12 +12447,19 @@ index 000000000000..b1201ac165ed
 +	struct adios_rq_data *rd = get_rq_data(rq);
 +	struct dl_group *dlg;
 +
-+	rd->block_size = blk_rq_bytes(rq);
-+	u8 optype = adios_optype(rq);
-+	rd->pred_lat =
-+		latency_model_predict(&ad->latency_model[optype], rd->block_size);
-+	rd->deadline =
-+		rq->start_time_ns + ad->latency_target[optype] + rd->pred_lat;
++	/* Tier-2: Synchronous Requests
++	 * - Needs to be FIFO within a same optype
++	 * - Relaxed order between different optypes
++	 * - basically needs to be processed in early time */
++	rd->deadline = rq->start_time_ns;
++
++	/* Tier-3: Aynchronous Requests
++	 * - Can be reordered and delayed freely */
++	if (!(rq->cmd_flags & REQ_SYNC)) {
++		rd->deadline += ad->latency_target[adios_optype(rq)];
++		if (ad->place_deadline_pred_lat)
++			rd->deadline += rd->pred_lat;
++	}
 +
 +	while (*link) {
 +		dlg = rb_entry(*link, struct dl_group, node);
@@ -12793,12 +12582,16 @@ index 000000000000..b1201ac165ed
 +// Try to merge a bio into an existing rq before associating it with an rq
 +static bool adios_bio_merge(struct request_queue *q, struct bio *bio,
 +		unsigned int nr_segs) {
++	unsigned long flags;
 +	struct adios_data *ad = q->elevator->elevator_data;
 +	struct request *free = NULL;
 +	bool ret;
 +
-+	scoped_guard(spinlock_irqsave, &ad->lock)
-+		ret = blk_mq_sched_try_merge(q, bio, nr_segs, &free);
++	if (!spin_trylock_irqsave(&ad->lock, flags))
++		return false;
++
++	ret = blk_mq_sched_try_merge(q, bio, nr_segs, &free);
++	spin_unlock_irqrestore(&ad->lock, flags);
 +
 +	if (free)
 +		blk_mq_free_request(free);
@@ -12806,16 +12599,54 @@ index 000000000000..b1201ac165ed
 +	return ret;
 +}
 +
-+// Insert a request into the scheduler
-+static void insert_request(struct blk_mq_hw_ctx *hctx, struct request *rq,
-+				  blk_insert_t insert_flags, struct list_head *free) {
-+	bool dl_idx = adios_optype_not_read(rq);
++// Insert a request into the scheduler (before Read & Write models stabilizes)
++static void insert_request_pre_stability(struct blk_mq_hw_ctx *hctx,
++		struct request *rq, blk_insert_t insert_flags, struct list_head *free) {
++	struct adios_data *ad = hctx->queue->elevator->elevator_data;
++	struct adios_rq_data *rd = get_rq_data(rq);
++	u8 optype = adios_optype(rq);
++	u8 idx = !(insert_flags & BLK_MQ_INSERT_AT_HEAD);
++
++	rd->block_size = blk_rq_bytes(rq);
++	rd->pred_lat =
++		latency_model_predict(&ad->latency_model[optype], rd->block_size);
++
++	atomic64_add(rd->pred_lat, &ad->total_pred_lat);
++	scoped_guard(spinlock_irqsave, &ad->pq_lock)
++		list_add_tail(&rq->queuelist, &ad->prio_queue[idx]);
++
++	if (ad->latency_model[ADIOS_READ].base > 0 &&
++		ad->latency_model[ADIOS_WRITE].base > 0)
++			ad->insert_request_fn = insert_request_post_stability;
++}
++
++// Insert a request into the scheduler (after Read & Write models stabilized)
++static void insert_request_post_stability(struct blk_mq_hw_ctx *hctx,
++		struct request *rq, blk_insert_t insert_flags, struct list_head *free) {
 +	struct request_queue *q = hctx->queue;
 +	struct adios_data *ad = q->elevator->elevator_data;
++	struct adios_rq_data *rd = get_rq_data(rq);
++	bool dl_idx = adios_optype_not_read(rq);
++	u8 optype = adios_optype(rq);
 +
++	rd->block_size = blk_rq_bytes(rq);
++	rd->pred_lat =
++		latency_model_predict(&ad->latency_model[optype], rd->block_size);
++
++	/* Tier-0: BLK_MQ_INSERT_AT_HEAD Requests
++	 * - Needs to be processed ASAP at all costs in any case */
 +	if (insert_flags & BLK_MQ_INSERT_AT_HEAD) {
++		atomic64_add(rd->pred_lat, &ad->total_pred_lat);
 +		scoped_guard(spinlock_irqsave, &ad->pq_lock)
-+			list_add_tail(&rq->queuelist, &ad->prio_queue);
++			list_add_tail(&rq->queuelist, &ad->prio_queue[0]);
++		return;
++	}
++	/* Tier-1: Integrity-sensitive Requests
++	 * - Needs to be FIFO across all optypes */
++	if (rq->cmd_flags & (REQ_FUA | REQ_PREFLUSH)) {
++		atomic64_add(rd->pred_lat, &ad->total_pred_lat);
++		scoped_guard(spinlock_irqsave, &ad->pq_lock)
++			list_add_tail(&rq->queuelist, &ad->prio_queue[1]);
 +		return;
 +	}
 +
@@ -12850,7 +12681,7 @@ index 000000000000..b1201ac165ed
 +			}
 +			rq = list_first_entry(list, struct request, queuelist);
 +			list_del_init(&rq->queuelist);
-+			insert_request(hctx, rq, insert_flags, &free);
++			ad->insert_request_fn(hctx, rq, insert_flags, &free);
 +		}
 +	} while (!stop);
 +
@@ -12860,7 +12691,7 @@ index 000000000000..b1201ac165ed
 +// Prepare a request before it is inserted into the scheduler
 +static void adios_prepare_request(struct request *rq) {
 +	struct adios_data *ad = rq->q->elevator->elevator_data;
-+	struct adios_rq_data *rd;
++	struct adios_rq_data *rd = get_rq_data(rq);
 +
 +	rq->elv.priv[0] = NULL;
 +
@@ -12883,13 +12714,14 @@ index 000000000000..b1201ac165ed
 +}
 +
 +// Fill the batch queues with requests from the deadline-sorted red-black tree
-+static bool fill_batch_queues(struct adios_data *ad, u64 current_lat) {
++static bool fill_batch_queues(struct adios_data *ad, u64 tpl) {
 +	struct adios_rq_data *rd;
 +	struct request *rq;
 +	u32 optype_count[ADIOS_OPTYPES] = {0};
 +	u32 count = 0;
 +	u8 optype;
 +	bool page = !ad->bq_page, dl_idx, bias_idx, reduce_bias;
++	u64 added_lat = 0;
 +
 +	// Reset batch queue counts for the back page
 +	memset(&ad->batch_count[page], 0, sizeof(ad->batch_count[page]));
@@ -12914,14 +12746,14 @@ index 000000000000..b1201ac165ed
 +				reduce_bias = (trd[bias_idx]->deadline > trd[!bias_idx]->deadline);
 +			} else
 +				reduce_bias = (bias_idx == dl_idx);
-+			
++
 +			rq = rd->rq;
 +			optype = adios_optype(rq);
 +
 +			// Check batch size and total predicted latency
 +			if (count && (!ad->latency_model[optype].base ||
 +					ad->batch_count[page][optype] >= ad->batch_limit[optype] ||
-+					(current_lat + rd->pred_lat) > ad->global_latency_window))
++					(tpl + added_lat + rd->pred_lat) > ad->global_latency_window))
 +				break;
 +
 +			if (reduce_bias) {
@@ -12938,14 +12770,14 @@ index 000000000000..b1201ac165ed
 +
 +			// Add request to the corresponding batch queue
 +			list_add_tail(&rq->queuelist, &ad->batch_queue[page][optype]);
-+			atomic64_add(rd->pred_lat, &ad->total_pred_lat);
-+			current_lat += rd->pred_lat;
++			added_lat += rd->pred_lat;
 +			ad->batch_count[page][optype]++;
 +			optype_count[optype]++;
 +			count++;
 +		}
 +
 +	if (count) {
++		atomic64_add(added_lat, &ad->total_pred_lat);
 +		ad->more_bq_ready = true;
 +		for (u8 optype = 0; optype < ADIOS_OPTYPES; optype++)
 +			if (ad->batch_actual_max_size[optype] < optype_count[optype])
@@ -12965,11 +12797,10 @@ index 000000000000..b1201ac165ed
 +// Dispatch a request from the batch queues
 +static struct request *dispatch_from_bq(struct adios_data *ad) {
 +	struct request *rq = NULL;
-+	u64 tpl;
 +
 +	guard(spinlock_irqsave)(&ad->bq_lock);
 +
-+	tpl = atomic64_read(&ad->total_pred_lat);
++	u64 tpl = atomic64_read(&ad->total_pred_lat);
 +
 +	if (!ad->more_bq_ready && (!tpl || tpl < div_u64(
 +			ad->global_latency_window * ad->bq_refill_below_ratio, 100)))
@@ -13001,9 +12832,13 @@ index 000000000000..b1201ac165ed
 +
 +	guard(spinlock_irqsave)(&ad->pq_lock);
 +
-+	if (!list_empty(&ad->prio_queue)) {
-+		rq = list_first_entry(&ad->prio_queue, struct request, queuelist);
-+		list_del_init(&rq->queuelist);
++	for (int i = 0; i < 2; i++) {
++		struct list_head *q = &ad->prio_queue[i];
++		if (!list_empty(q)) {
++			rq = list_first_entry(q, struct request, queuelist);
++			list_del_init(&rq->queuelist);
++			break;
++		}
 +	}
 +	return rq;
 +}
@@ -13035,11 +12870,16 @@ index 000000000000..b1201ac165ed
 +	struct adios_data *ad = rq->q->elevator->elevator_data;
 +	struct adios_rq_data *rd = get_rq_data(rq);
 +
-+	atomic64_sub(rd->pred_lat, &ad->total_pred_lat);
++	u64 tpl_after = atomic64_sub_return(rd->pred_lat, &ad->total_pred_lat);
++	u64 lct = ad->last_completed_time ?: rq->io_start_time_ns;
++	ad->last_completed_time = (tpl_after) ? now : 0;
 +
-+	if (!rq->io_start_time_ns || !rd->block_size)
++	if (!rq->io_start_time_ns || !rd->block_size || unlikely(now < lct))
 +		return;
-+	u64 latency = now - rq->io_start_time_ns;
++
++	u64 latency = now - lct;
++	if (latency > ad->lat_model_latency_limit)
++		return;
 +	u8 optype = adios_optype(rq);
 +	latency_model_input(ad, &ad->latency_model[optype],
 +		rd->block_size, latency, rd->pred_lat);
@@ -13059,7 +12899,9 @@ index 000000000000..b1201ac165ed
 +
 +static inline bool pq_has_work(struct adios_data *ad) {
 +	guard(spinlock_irqsave)(&ad->pq_lock);
-+	return !list_empty(&ad->prio_queue);
++	for (int i = 0; i < 2; i++)
++		if (!list_empty(&ad->prio_queue[i])) return true;
++	return false;
 +}
 +
 +static inline bool bq_has_work(struct adios_data *ad) {
@@ -13127,8 +12969,11 @@ index 000000000000..b1201ac165ed
 +
 +	ad->global_latency_window = default_global_latency_window;
 +	ad->bq_refill_below_ratio = default_bq_refill_below_ratio;
++	ad->place_deadline_pred_lat = default_place_deadline_pred_lat;
++	ad->lat_model_latency_limit = default_lat_model_latency_limit;
 +
-+	INIT_LIST_HEAD(&ad->prio_queue);
++	for (int i = 0; i < 2; i++)
++		INIT_LIST_HEAD(&ad->prio_queue[i]);
 +	for (u8 i = 0; i < 2; i++)
 +		ad->dl_tree[i] = RB_ROOT_CACHED;
 +	ad->dl_bias = 0;
@@ -13159,7 +13004,7 @@ index 000000000000..b1201ac165ed
 +		ad->batch_limit[optype] = default_batch_limit[optype];
 +	}
 +	timer_setup(&ad->update_timer, update_timer_callback, 0);
-+	
++
 +	for (u8 page = 0; page < ADIOS_BQ_PAGES; page++)
 +		for (u8 optype = 0; optype < ADIOS_OPTYPES; optype++)
 +			INIT_LIST_HEAD(&ad->batch_queue[page][optype]);
@@ -13167,6 +13012,8 @@ index 000000000000..b1201ac165ed
 +	spin_lock_init(&ad->lock);
 +	spin_lock_init(&ad->pq_lock);
 +	spin_lock_init(&ad->bq_lock);
++
++	ad->insert_request_fn = insert_request_pre_stability;
 +
 +	/* We dispatch from request queue wide instead of hw queue */
 +	blk_queue_flag_set(QUEUE_FLAG_SQ_SCHED, q);
@@ -13201,7 +13048,8 @@ index 000000000000..b1201ac165ed
 +
 +	timer_shutdown_sync(&ad->update_timer);
 +
-+	WARN_ON_ONCE(!list_empty(&ad->prio_queue));
++	for (int i = 0; i < 2; i++)
++		WARN_ON_ONCE(!list_empty(&ad->prio_queue[i]));
 +
 +	for (u8 i = 0; i < ADIOS_OPTYPES; i++) {
 +		struct latency_model *model = &ad->latency_model[i];
@@ -13271,6 +13119,11 @@ index 000000000000..b1201ac165ed
 +	reset_buckets(ad->aggr_buckets); \
 +	return count; \
 +} \
++static ssize_t adios_lat_target_##name##_show( \
++		struct elevator_queue *e, char *page) { \
++	struct adios_data *ad = e->elevator_data; \
++	return sprintf(page, "%llu\n", ad->latency_target[optype]); \
++} \
 +static ssize_t adios_lat_target_##name##_store( \
 +		struct elevator_queue *e, const char *page, size_t count) { \
 +	struct adios_data *ad = e->elevator_data; \
@@ -13283,10 +13136,10 @@ index 000000000000..b1201ac165ed
 +	ad->latency_target[optype] = nsec; \
 +	return count; \
 +} \
-+static ssize_t adios_lat_target_##name##_show( \
++static ssize_t adios_batch_limit_##name##_show( \
 +		struct elevator_queue *e, char *page) { \
 +	struct adios_data *ad = e->elevator_data; \
-+	return sprintf(page, "%llu\n", ad->latency_target[optype]); \
++	return sprintf(page, "%u\n", ad->batch_limit[optype]); \
 +} \
 +static ssize_t adios_batch_limit_##name##_store( \
 +		struct elevator_queue *e, const char *page, size_t count) { \
@@ -13298,11 +13151,6 @@ index 000000000000..b1201ac165ed
 +	struct adios_data *ad = e->elevator_data; \
 +	ad->batch_limit[optype] = max_batch; \
 +	return count; \
-+} \
-+static ssize_t adios_batch_limit_##name##_show( \
-+		struct elevator_queue *e, char *page) { \
-+	struct adios_data *ad = e->elevator_data; \
-+	return sprintf(page, "%u\n", ad->batch_limit[optype]); \
 +}
 +
 +SYSFS_OPTYPE_DECL(read, ADIOS_READ);
@@ -13325,6 +13173,13 @@ index 000000000000..b1201ac165ed
 +		total_count, discard_count, read_count, write_count);
 +}
 +
++// Show the global latency window
++static ssize_t adios_global_latency_window_show(
++		struct elevator_queue *e, char *page) {
++	struct adios_data *ad = e->elevator_data;
++	return sprintf(page, "%llu\n", ad->global_latency_window);
++}
++
 +// Set the global latency window
 +static ssize_t adios_global_latency_window_store(
 +		struct elevator_queue *e, const char *page, size_t count) {
@@ -13341,35 +13196,41 @@ index 000000000000..b1201ac165ed
 +	return count;
 +}
 +
-+// Show the global latency window
-+static ssize_t adios_global_latency_window_show(
-+		struct elevator_queue *e, char *page) {
-+	struct adios_data *ad = e->elevator_data;
-+	return sprintf(page, "%llu\n", ad->global_latency_window);
++#define SYSFS_INT_DECL(field, min_val, max_val) \
++static ssize_t adios_##field##_show( \
++		struct elevator_queue *e, char *page) { \
++	struct adios_data *ad = e->elevator_data; \
++	return sprintf(page, "%d\n", ad->field); \
++} \
++static ssize_t adios_##field##_store( \
++		struct elevator_queue *e, const char *page, size_t count) { \
++	struct adios_data *ad = e->elevator_data; \
++	int val; \
++	int ret; \
++	ret = kstrtoint(page, 10, &val); \
++	if (ret || val < (min_val) || val > (max_val)) \
++		return -EINVAL; \
++	ad->field = val; \
++	return count; \
 +}
 +
-+// Show the bq_refill_below_ratio
-+static ssize_t adios_bq_refill_below_ratio_show(
-+		struct elevator_queue *e, char *page) {
-+	struct adios_data *ad = e->elevator_data;
-+	return sprintf(page, "%d\n", ad->bq_refill_below_ratio);
-+}
-+
-+// Set the bq_refill_below_ratio
-+static ssize_t adios_bq_refill_below_ratio_store(
-+		struct elevator_queue *e, const char *page, size_t count) {
-+	struct adios_data *ad = e->elevator_data;
-+	int ratio;
-+	int ret;
-+
-+	ret = kstrtoint(page, 10, &ratio);
-+	if (ret || ratio < 0 || ratio > 100)
-+		return -EINVAL;
-+
-+	ad->bq_refill_below_ratio = ratio;
-+
-+	return count;
-+}
++SYSFS_INT_DECL(bq_refill_below_ratio, 0, 100)
++/* place_deadline_pred_lat: A sysfs-tunable switch for latency optimization
++ *
++ * This flag controls whether predicted latency (`pred_lat`) is used to
++ * calculate deadlines for asynchronous (Tier 3) requests.
++ *
++ * When enabled (1), this allows small, latency-sensitive I/Os (e.g., from
++ * interactive tasks) to be prioritized over large background transfers.
++ * This aggressive reordering may improve perceived system responsiveness.
++ *
++ * However, this can expose ordering issues in older filesystems like
++ * FAT which may implicitly assume more strict async I/O order dependencies.
++ *
++ * For maximum compatibility, this is disabled by default (0).
++ */
++SYSFS_INT_DECL(place_deadline_pred_lat, 0, 1)
++SYSFS_INT_DECL(lat_model_latency_limit, 0, 2*NSEC_PER_SEC)
 +
 +// Show the read priority
 +static ssize_t adios_read_priority_show(
@@ -13526,6 +13387,8 @@ index 000000000000..b1201ac165ed
 +	AD_ATTR_RO(batch_actual_max),
 +	AD_ATTR_RW(bq_refill_below_ratio),
 +	AD_ATTR_RW(global_latency_window),
++	AD_ATTR_RW(place_deadline_pred_lat),
++	AD_ATTR_RW(lat_model_latency_limit),
 +
 +	AD_ATTR_RW(batch_limit_read),
 +	AD_ATTR_RW(batch_limit_write),
@@ -13601,7 +13464,7 @@ index 000000000000..b1201ac165ed
 +MODULE_DESCRIPTION(ADIOS_PROGNAME);
 \ No newline at end of file
 diff --git a/block/elevator.c b/block/elevator.c
-index dc4cadef728e..6757ed11bf60 100644
+index dc4cadef7..56fc294ac 100644
 --- a/block/elevator.c
 +++ b/block/elevator.c
 @@ -556,11 +556,23 @@ static struct elevator_type *elevator_get_default(struct request_queue *q)
@@ -13610,7 +13473,7 @@ index dc4cadef728e..6757ed11bf60 100644
  
 +#ifdef CONFIG_MQ_IOSCHED_DEFAULT_ADIOS
 +	return elevator_find_get("adios");
-+#endif // CONFIG_MQ_IOSCHED_DEFAULT_ADIOS
++#endif // !CONFIG_MQ_IOSCHED_DEFAULT_ADIOS
 +
  	if (q->nr_hw_queues != 1 &&
  	    !blk_mq_is_shared_tags(q->tag_set->flags))
@@ -13629,7 +13492,7 @@ index dc4cadef728e..6757ed11bf60 100644
  
  /*
 diff --git a/drivers/Makefile b/drivers/Makefile
-index b5749cf67044..5beba9f57254 100644
+index b5749cf67..5beba9f57 100644
 --- a/drivers/Makefile
 +++ b/drivers/Makefile
 @@ -64,14 +64,8 @@ obj-y				+= char/
@@ -13662,7 +13525,7 @@ index b5749cf67044..5beba9f57254 100644
  obj-$(CONFIG_MTD)		+= mtd/
  obj-$(CONFIG_SPI)		+= spi/
 diff --git a/drivers/ata/ahci.c b/drivers/ata/ahci.c
-index 931da4749e80..9764029754dc 100644
+index f0c4e2251..25a792684 100644
 --- a/drivers/ata/ahci.c
 +++ b/drivers/ata/ahci.c
 @@ -1662,7 +1662,7 @@ static irqreturn_t ahci_thunderx_irq_handler(int irq, void *dev_instance)
@@ -13706,7 +13569,7 @@ index 931da4749e80..9764029754dc 100644
  }
  
  static int ahci_get_irq_vector(struct ata_host *host, int port)
-@@ -1945,7 +1938,9 @@ static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
+@@ -1955,7 +1948,9 @@ static int ahci_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
  		return -ENOMEM;
  
  	/* detect remapped nvme devices */
@@ -13718,7 +13581,7 @@ index 931da4749e80..9764029754dc 100644
  	sysfs_add_file_to_group(&pdev->dev.kobj,
  				&dev_attr_remapped_nvme.attr,
 diff --git a/drivers/cpufreq/Kconfig.x86 b/drivers/cpufreq/Kconfig.x86
-index 2c5c228408bf..918e2bebfe78 100644
+index 2c5c22840..918e2bebf 100644
 --- a/drivers/cpufreq/Kconfig.x86
 +++ b/drivers/cpufreq/Kconfig.x86
 @@ -9,7 +9,6 @@ config X86_INTEL_PSTATE
@@ -13738,10 +13601,10 @@ index 2c5c228408bf..918e2bebfe78 100644
  	  This driver adds a CPUFreq driver which utilizes a fine grain
  	  processor performance frequency control range instead of legacy
 diff --git a/drivers/cpufreq/intel_pstate.c b/drivers/cpufreq/intel_pstate.c
-index ba9bf06f1c77..b8ceac594acd 100644
+index c1c42c273..beda68b1d 100644
 --- a/drivers/cpufreq/intel_pstate.c
 +++ b/drivers/cpufreq/intel_pstate.c
-@@ -3828,6 +3828,8 @@ static int __init intel_pstate_setup(char *str)
+@@ -3830,6 +3830,8 @@ static int __init intel_pstate_setup(char *str)
  
  	if (!strcmp(str, "disable"))
  		no_load = 1;
@@ -13751,7 +13614,7 @@ index ba9bf06f1c77..b8ceac594acd 100644
  		default_driver = &intel_pstate;
  	else if (!strcmp(str, "passive"))
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu.h b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
-index c3641331d4de..ce1072fe4921 100644
+index c3641331d..ce1072fe4 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu.h
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu.h
 @@ -161,6 +161,7 @@ struct amdgpu_watchdog_timer {
@@ -13763,7 +13626,7 @@ index c3641331d4de..ce1072fe4921 100644
  extern int amdgpu_gart_size;
  extern int amdgpu_gtt_size;
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 72c807f5822e..6ef3fedc1233 100644
+index 72c807f58..6ef3fedc1 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -143,6 +143,7 @@ enum AMDGPU_DEBUG_MASK {
@@ -13791,7 +13654,7 @@ index 72c807f5822e..6ef3fedc1233 100644
   * DOC: vramlimit (int)
   * Restrict the total amount of VRAM in MiB for testing.  The default is 0 (Use full VRAM).
 diff --git a/drivers/gpu/drm/amd/display/Kconfig b/drivers/gpu/drm/amd/display/Kconfig
-index abd3b6564373..46937e6fa78d 100644
+index abd3b6564..46937e6fa 100644
 --- a/drivers/gpu/drm/amd/display/Kconfig
 +++ b/drivers/gpu/drm/amd/display/Kconfig
 @@ -56,4 +56,10 @@ config DRM_AMD_SECURE_DISPLAY
@@ -13806,10 +13669,10 @@ index abd3b6564373..46937e6fa78d 100644
 +
  endmenu
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
-index 87c2bc5f64a6..927fb4992a6a 100644
+index 75e7af5c5..366437af4 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
-@@ -4574,7 +4574,7 @@ static int amdgpu_dm_mode_config_init(struct amdgpu_device *adev)
+@@ -4587,7 +4587,7 @@ static int amdgpu_dm_mode_config_init(struct amdgpu_device *adev)
  		return r;
  	}
  
@@ -13819,7 +13682,7 @@ index 87c2bc5f64a6..927fb4992a6a 100644
  		dc_state_release(state->context);
  		kfree(state);
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c
-index ebabfe3a512f..4d3ebcaacca1 100644
+index ebabfe3a5..4d3ebcaac 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_color.c
 @@ -97,7 +97,7 @@ static inline struct fixed31_32 amdgpu_dm_fixpt_from_s3132(__u64 x)
@@ -13832,7 +13695,7 @@ index ebabfe3a512f..4d3ebcaacca1 100644
   *
   * AMD driver supports pre-defined mathematical functions for transferring
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c
-index db157b38f862..5d5210f99dcf 100644
+index db157b38f..5d5210f99 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_crtc.c
 @@ -481,7 +481,7 @@ static int amdgpu_dm_crtc_late_register(struct drm_crtc *crtc)
@@ -13863,7 +13726,7 @@ index db157b38f862..5d5210f99dcf 100644
  #endif
  	return 0;
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
-index 3e0f45f1711c..f645cb7831a0 100644
+index 3e0f45f17..f645cb783 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_plane.c
 @@ -1601,7 +1601,7 @@ static void amdgpu_dm_plane_drm_plane_destroy_state(struct drm_plane *plane,
@@ -13894,10 +13757,10 @@ index 3e0f45f1711c..f645cb7831a0 100644
  #endif
  	/* Create (reset) the plane state */
 diff --git a/drivers/gpu/drm/amd/pm/amdgpu_pm.c b/drivers/gpu/drm/amd/pm/amdgpu_pm.c
-index 922def51685b..da76611edb10 100644
+index 21da5123d..c13822ee6 100644
 --- a/drivers/gpu/drm/amd/pm/amdgpu_pm.c
 +++ b/drivers/gpu/drm/amd/pm/amdgpu_pm.c
-@@ -3055,6 +3055,9 @@ static ssize_t amdgpu_hwmon_show_power_cap_min(struct device *dev,
+@@ -3057,6 +3057,9 @@ static ssize_t amdgpu_hwmon_show_power_cap_min(struct device *dev,
  					 struct device_attribute *attr,
  					 char *buf)
  {
@@ -13908,7 +13771,7 @@ index 922def51685b..da76611edb10 100644
  }
  
 diff --git a/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c b/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c
-index 46cce1d2aaf3..e3adb7aea969 100644
+index 46cce1d2a..e3adb7aea 100644
 --- a/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c
 +++ b/drivers/gpu/drm/amd/pm/swsmu/amdgpu_smu.c
 @@ -2854,7 +2854,10 @@ int smu_get_power_limit(void *handle,
@@ -13940,7 +13803,7 @@ index 46cce1d2aaf3..e3adb7aea969 100644
  			"New power limit (%d) is out of range [%d,%d]\n",
  			limit, smu->min_power_limit, smu->max_power_limit);
 diff --git a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
-index 8846eb9ce2a4..c7d5d782e3f9 100644
+index 8846eb9ce..c7d5d782e 100644
 --- a/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
 +++ b/drivers/gpu/drm/xe/regs/xe_pcode_regs.h
 @@ -21,6 +21,9 @@
@@ -13954,7 +13817,7 @@ index 8846eb9ce2a4..c7d5d782e3f9 100644
  #define BMG_PACKAGE_TEMPERATURE			XE_REG(0x138434)
  #define BMG_PACKAGE_RAPL_LIMIT			XE_REG(0x138440)
 diff --git a/drivers/gpu/drm/xe/xe_device_types.h b/drivers/gpu/drm/xe/xe_device_types.h
-index 0482f26aa480..0564164935c6 100644
+index 0482f26aa..056416493 100644
 --- a/drivers/gpu/drm/xe/xe_device_types.h
 +++ b/drivers/gpu/drm/xe/xe_device_types.h
 @@ -314,6 +314,8 @@ struct xe_device {
@@ -13967,7 +13830,7 @@ index 0482f26aa480..0564164935c6 100644
  		u8 has_flat_ccs:1;
  		/** @info.has_heci_cscfi: device has heci cscfi */
 diff --git a/drivers/gpu/drm/xe/xe_hwmon.c b/drivers/gpu/drm/xe/xe_hwmon.c
-index 48d80ffdf7bb..eb293aec36a0 100644
+index 48d80ffdf..eb293aec3 100644
 --- a/drivers/gpu/drm/xe/xe_hwmon.c
 +++ b/drivers/gpu/drm/xe/xe_hwmon.c
 @@ -5,6 +5,7 @@
@@ -14187,7 +14050,7 @@ index 48d80ffdf7bb..eb293aec36a0 100644
  
  static void xe_hwmon_mutex_destroy(void *arg)
 diff --git a/drivers/gpu/drm/xe/xe_pci.c b/drivers/gpu/drm/xe/xe_pci.c
-index 57547d02daa7..ecb0cf7c66fa 100644
+index 57547d02d..ecb0cf7c6 100644
 --- a/drivers/gpu/drm/xe/xe_pci.c
 +++ b/drivers/gpu/drm/xe/xe_pci.c
 @@ -62,6 +62,7 @@ struct xe_device_desc {
@@ -14223,7 +14086,7 @@ index 57547d02daa7..ecb0cf7c66fa 100644
  	xe->info.has_heci_cscfi = desc->has_heci_cscfi;
  	xe->info.has_llc = desc->has_llc;
 diff --git a/drivers/gpu/drm/xe/xe_pcode_api.h b/drivers/gpu/drm/xe/xe_pcode_api.h
-index 2bae9afdbd35..e622ae17f08d 100644
+index 2bae9afdb..e622ae17f 100644
 --- a/drivers/gpu/drm/xe/xe_pcode_api.h
 +++ b/drivers/gpu/drm/xe/xe_pcode_api.h
 @@ -49,6 +49,9 @@
@@ -14236,8 +14099,103 @@ index 2bae9afdbd35..e622ae17f08d 100644
  #define PCODE_SCRATCH(x)		XE_REG(0x138320 + ((x) * 4))
  /* PCODE_SCRATCH0 */
  #define   AUXINFO_REG_OFFSET		REG_GENMASK(17, 15)
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_client.c b/drivers/hid/amd-sfh-hid/amd_sfh_client.c
+index 3438d3929..0f2cbae39 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_client.c
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_client.c
+@@ -146,6 +146,8 @@ static const char *get_sensor_name(int idx)
+ 		return "gyroscope";
+ 	case mag_idx:
+ 		return "magnetometer";
++	case op_idx:
++		return "operating-mode";
+ 	case als_idx:
+ 	case ACS_IDX: /* ambient color sensor */
+ 		return "ALS";
+@@ -243,6 +245,20 @@ int amd_sfh_hid_client_init(struct amd_mp2_dev *privdata)
+ 			rc = -ENOMEM;
+ 			goto cleanup;
+ 		}
++
++		if (cl_data->sensor_idx[i] == op_idx) {
++			info.period = AMD_SFH_IDLE_LOOP;
++			info.sensor_idx = cl_data->sensor_idx[i];
++			info.dma_address = cl_data->sensor_dma_addr[i];
++			mp2_ops->start(privdata, info);
++			cl_data->sensor_sts[i] = amd_sfh_wait_for_response(privdata,
++									   cl_data->sensor_idx[i],
++									   SENSOR_ENABLED);
++			if (cl_data->sensor_sts[i] == SENSOR_ENABLED)
++				cl_data->is_any_sensor_enabled = true;
++			continue;
++		}
++
+ 		cl_data->sensor_sts[i] = SENSOR_DISABLED;
+ 		cl_data->sensor_requested_cnt[i] = 0;
+ 		cl_data->cur_hid_dev = i;
+@@ -303,6 +319,13 @@ int amd_sfh_hid_client_init(struct amd_mp2_dev *privdata)
+ 
+ 	for (i = 0; i < cl_data->num_hid_devices; i++) {
+ 		cl_data->cur_hid_dev = i;
++		if (cl_data->sensor_idx[i] == op_idx) {
++			dev_dbg(dev, "sid 0x%x (%s) status 0x%x\n",
++				cl_data->sensor_idx[i], get_sensor_name(cl_data->sensor_idx[i]),
++				cl_data->sensor_sts[i]);
++			continue;
++		}
++
+ 		if (cl_data->sensor_sts[i] == SENSOR_ENABLED) {
+ 			rc = amdtp_hid_probe(i, cl_data);
+ 			if (rc)
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_hid.h b/drivers/hid/amd-sfh-hid/amd_sfh_hid.h
+index 1c91be8da..7452b0302 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_hid.h
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_hid.h
+@@ -11,7 +11,7 @@
+ #ifndef AMDSFH_HID_H
+ #define AMDSFH_HID_H
+ 
+-#define MAX_HID_DEVICES		6
++#define MAX_HID_DEVICES		7
+ #define AMD_SFH_HID_VENDOR	0x1022
+ #define AMD_SFH_HID_PRODUCT	0x0001
+ 
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c
+index 1c1fd6333..2983af969 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.c
+@@ -29,6 +29,7 @@
+ #define ACEL_EN		BIT(0)
+ #define GYRO_EN		BIT(1)
+ #define MAGNO_EN	BIT(2)
++#define OP_EN		BIT(15)
+ #define HPD_EN		BIT(16)
+ #define ALS_EN		BIT(19)
+ #define ACS_EN		BIT(22)
+@@ -232,6 +233,9 @@ int amd_mp2_get_sensor_num(struct amd_mp2_dev *privdata, u8 *sensor_id)
+ 	if (MAGNO_EN & activestatus)
+ 		sensor_id[num_of_sensors++] = mag_idx;
+ 
++	if (OP_EN & activestatus)
++		sensor_id[num_of_sensors++] = op_idx;
++
+ 	if (ALS_EN & activestatus)
+ 		sensor_id[num_of_sensors++] = als_idx;
+ 
+diff --git a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h
+index 05e400a4a..2eb61f4e8 100644
+--- a/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h
++++ b/drivers/hid/amd-sfh-hid/amd_sfh_pcie.h
+@@ -79,6 +79,7 @@ enum sensor_idx {
+ 	accel_idx = 0,
+ 	gyro_idx = 1,
+ 	mag_idx = 2,
++	op_idx = 15,
+ 	als_idx = 19
+ };
+ 
 diff --git a/drivers/input/evdev.c b/drivers/input/evdev.c
-index b5cbb57ee5f6..a0f7fa1518c6 100644
+index b5cbb57ee..a0f7fa151 100644
 --- a/drivers/input/evdev.c
 +++ b/drivers/input/evdev.c
 @@ -46,6 +46,7 @@ struct evdev_client {
@@ -14301,7 +14259,7 @@ index b5cbb57ee5f6..a0f7fa1518c6 100644
  }
  
 diff --git a/drivers/md/dm-crypt.c b/drivers/md/dm-crypt.c
-index 9dfdb63220d7..91aeee72a15e 100644
+index 9dfdb6322..91aeee72a 100644
 --- a/drivers/md/dm-crypt.c
 +++ b/drivers/md/dm-crypt.c
 @@ -3284,6 +3284,11 @@ static int crypt_ctr(struct dm_target *ti, unsigned int argc, char **argv)
@@ -14317,7 +14275,7 @@ index 9dfdb63220d7..91aeee72a15e 100644
  	if (ret < 0)
  		goto bad;
 diff --git a/drivers/media/v4l2-core/Kconfig b/drivers/media/v4l2-core/Kconfig
-index 331b8e535e5b..80dabeebf580 100644
+index 331b8e535..80dabeebf 100644
 --- a/drivers/media/v4l2-core/Kconfig
 +++ b/drivers/media/v4l2-core/Kconfig
 @@ -40,6 +40,11 @@ config VIDEO_TUNER
@@ -14333,7 +14291,7 @@ index 331b8e535e5b..80dabeebf580 100644
  config V4L2_H264
  	tristate
 diff --git a/drivers/media/v4l2-core/Makefile b/drivers/media/v4l2-core/Makefile
-index 2177b9d63a8f..c179507cedc4 100644
+index 2177b9d63..c179507ce 100644
 --- a/drivers/media/v4l2-core/Makefile
 +++ b/drivers/media/v4l2-core/Makefile
 @@ -33,5 +33,7 @@ obj-$(CONFIG_V4L2_JPEG_HELPER) += v4l2-jpeg.o
@@ -14346,10 +14304,10 @@ index 2177b9d63a8f..c179507cedc4 100644
  obj-$(CONFIG_VIDEO_DEV) += v4l2-dv-timings.o videodev.o
 diff --git a/drivers/media/v4l2-core/v4l2loopback.c b/drivers/media/v4l2-core/v4l2loopback.c
 new file mode 100644
-index 000000000000..74bd8125caa3
+index 000000000..80b67b283
 --- /dev/null
 +++ b/drivers/media/v4l2-core/v4l2loopback.c
-@@ -0,0 +1,3313 @@
+@@ -0,0 +1,3315 @@
 +/* -*- c-file-style: "linux" -*- */
 +/*
 + * v4l2loopback.c  --  video4linux2 loopback driver
@@ -14397,7 +14355,7 @@ index 000000000000..74bd8125caa3
 +#define strscpy strlcpy
 +#endif
 +
-+#if defined(timer_setup) && defined(from_timer)
++#if defined(timer_setup)
 +#define HAVE_TIMER_SETUP
 +#endif
 +
@@ -17021,7 +16979,8 @@ index 000000000000..74bd8125caa3
 +#ifdef HAVE_TIMER_SETUP
 +static void sustain_timer_clb(struct timer_list *t)
 +{
-+	struct v4l2_loopback_device *dev = from_timer(dev, t, sustain_timer);
++	struct v4l2_loopback_device *dev =
++		container_of(t, struct v4l2_loopback_device, sustain_timer);
 +#else
 +static void sustain_timer_clb(unsigned long nr)
 +{
@@ -17046,7 +17005,8 @@ index 000000000000..74bd8125caa3
 +#ifdef HAVE_TIMER_SETUP
 +static void timeout_timer_clb(struct timer_list *t)
 +{
-+	struct v4l2_loopback_device *dev = from_timer(dev, t, timeout_timer);
++	struct v4l2_loopback_device *dev =
++		container_of(t, struct v4l2_loopback_device, timeout_timer);
 +#else
 +static void timeout_timer_clb(unsigned long nr)
 +{
@@ -17665,7 +17625,7 @@ index 000000000000..74bd8125caa3
 +module_exit(v4l2loopback_cleanup_module);
 diff --git a/drivers/media/v4l2-core/v4l2loopback.h b/drivers/media/v4l2-core/v4l2loopback.h
 new file mode 100644
-index 000000000000..e48e0ce5949d
+index 000000000..8beca10d7
 --- /dev/null
 +++ b/drivers/media/v4l2-core/v4l2loopback.h
 @@ -0,0 +1,108 @@
@@ -17683,7 +17643,7 @@ index 000000000000..e48e0ce5949d
 +
 +#define V4L2LOOPBACK_VERSION_MAJOR 0
 +#define V4L2LOOPBACK_VERSION_MINOR 15
-+#define V4L2LOOPBACK_VERSION_BUGFIX 0
++#define V4L2LOOPBACK_VERSION_BUGFIX 1
 +
 +/* /dev/v4l2loopback interface */
 +
@@ -17779,10 +17739,10 @@ index 000000000000..e48e0ce5949d
 +#endif /* _V4L2LOOPBACK_H */
 diff --git a/drivers/media/v4l2-core/v4l2loopback_formats.h b/drivers/media/v4l2-core/v4l2loopback_formats.h
 new file mode 100644
-index 000000000000..d855a3796554
+index 000000000..ac2f1cbc0
 --- /dev/null
 +++ b/drivers/media/v4l2-core/v4l2loopback_formats.h
-@@ -0,0 +1,445 @@
+@@ -0,0 +1,453 @@
 +static const struct v4l2l_format formats[] = {
 +#ifndef V4L2_PIX_FMT_VP9
 +#define V4L2_PIX_FMT_VP9 v4l2_fourcc('V', 'P', '9', '0')
@@ -17820,6 +17780,14 @@ index 000000000000..d855a3796554
 +	{
 +		.name = "32 bpp RGBA, le",
 +		.fourcc = V4L2_PIX_FMT_ABGR32,
++		.depth = 32,
++		.flags = 0,
++	},
++#endif
++#ifdef V4L2_PIX_FMT_XBGR32
++	{
++		.name = "32 bpp BGRX-8-8-8-8",
++		.fourcc = V4L2_PIX_FMT_XBGR32,
 +		.depth = 32,
 +		.flags = 0,
 +	},
@@ -18229,7 +18197,7 @@ index 000000000000..d855a3796554
 +#endif /* V4L2_PIX_FMT_HEVC */
 +};
 diff --git a/drivers/pci/controller/Makefile b/drivers/pci/controller/Makefile
-index 038ccbd9e3ba..de5e4f5145af 100644
+index 038ccbd9e..de5e4f514 100644
 --- a/drivers/pci/controller/Makefile
 +++ b/drivers/pci/controller/Makefile
 @@ -1,4 +1,10 @@
@@ -18245,7 +18213,7 @@ index 038ccbd9e3ba..de5e4f5145af 100644
  obj-$(CONFIG_PCI_IXP4XX) += pci-ixp4xx.o
 diff --git a/drivers/pci/controller/intel-nvme-remap.c b/drivers/pci/controller/intel-nvme-remap.c
 new file mode 100644
-index 000000000000..e105e6f5cc91
+index 000000000..e105e6f5c
 --- /dev/null
 +++ b/drivers/pci/controller/intel-nvme-remap.c
 @@ -0,0 +1,462 @@
@@ -18712,10 +18680,10 @@ index 000000000000..e105e6f5cc91
 +MODULE_AUTHOR("Daniel Drake <drake@endlessm.com>");
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index d0f7b749b9a6..f5aaa23b254a 100644
+index 6e29f2b39..3c6593048 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
-@@ -3747,6 +3747,106 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
+@@ -3749,6 +3749,106 @@ static void quirk_no_bus_reset(struct pci_dev *dev)
  	dev->dev_flags |= PCI_DEV_FLAGS_NO_BUS_RESET;
  }
  
@@ -18822,7 +18790,7 @@ index d0f7b749b9a6..f5aaa23b254a 100644
  /*
   * Some NVIDIA GPU devices do not work with bus reset, SBR needs to be
   * prevented for those affected devices.
-@@ -5194,6 +5294,7 @@ static const struct pci_dev_acs_enabled {
+@@ -5196,6 +5296,7 @@ static const struct pci_dev_acs_enabled {
  	{ PCI_VENDOR_ID_ZHAOXIN, PCI_ANY_ID, pci_quirk_zhaoxin_pcie_ports_acs },
  	/* Wangxun nics */
  	{ PCI_VENDOR_ID_WANGXUN, PCI_ANY_ID, pci_quirk_wangxun_nic_acs },
@@ -18831,7 +18799,7 @@ index d0f7b749b9a6..f5aaa23b254a 100644
  };
  
 diff --git a/drivers/scsi/Kconfig b/drivers/scsi/Kconfig
-index 5a3c670aec27..831ffcf7c730 100644
+index 5a3c670ae..831ffcf7c 100644
 --- a/drivers/scsi/Kconfig
 +++ b/drivers/scsi/Kconfig
 @@ -1521,4 +1521,6 @@ endif # SCSI_LOWLEVEL
@@ -18842,7 +18810,7 @@ index 5a3c670aec27..831ffcf7c730 100644
 +
  endmenu
 diff --git a/drivers/scsi/Makefile b/drivers/scsi/Makefile
-index 16de3e41f94c..4e88f6e3e67b 100644
+index 16de3e41f..4e88f6e3e 100644
 --- a/drivers/scsi/Makefile
 +++ b/drivers/scsi/Makefile
 @@ -152,6 +152,7 @@ obj-$(CONFIG_CHR_DEV_SCH)	+= ch.o
@@ -18855,7 +18823,7 @@ index 16de3e41f94c..4e88f6e3e67b 100644
  obj-$(CONFIG_SCSI_DEBUG)	+= scsi_debug.o
 diff --git a/drivers/scsi/vhba/Kconfig b/drivers/scsi/vhba/Kconfig
 new file mode 100644
-index 000000000000..e70a381fe3df
+index 000000000..e70a381fe
 --- /dev/null
 +++ b/drivers/scsi/vhba/Kconfig
 @@ -0,0 +1,9 @@
@@ -18870,7 +18838,7 @@ index 000000000000..e70a381fe3df
 +	  will be called vhba.
 diff --git a/drivers/scsi/vhba/Makefile b/drivers/scsi/vhba/Makefile
 new file mode 100644
-index 000000000000..2d7524b66199
+index 000000000..2d7524b66
 --- /dev/null
 +++ b/drivers/scsi/vhba/Makefile
 @@ -0,0 +1,4 @@
@@ -18880,7 +18848,7 @@ index 000000000000..2d7524b66199
 +ccflags-y := -DVHBA_VERSION=\"$(VHBA_VERSION)\" -Werror
 diff --git a/drivers/scsi/vhba/vhba.c b/drivers/scsi/vhba/vhba.c
 new file mode 100644
-index 000000000000..878a3be0ba2b
+index 000000000..878a3be0b
 --- /dev/null
 +++ b/drivers/scsi/vhba/vhba.c
 @@ -0,0 +1,1132 @@
@@ -20017,7 +19985,7 @@ index 000000000000..878a3be0ba2b
 +module_exit(vhba_exit);
 +
 diff --git a/fs/select.c b/fs/select.c
-index 7da531b1cf6b..0eaf3522abe9 100644
+index 7da531b1c..0eaf3522a 100644
 --- a/fs/select.c
 +++ b/fs/select.c
 @@ -857,7 +857,7 @@ static inline __poll_t do_pollfd(struct pollfd *pollfd, poll_table *pwait,
@@ -20030,10 +19998,10 @@ index 7da531b1cf6b..0eaf3522abe9 100644
  
  	CLASS(fd, f)(fd);
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index 2e4584e1bfcd..9ff3f9a1f7b4 100644
+index 82b7bea9f..9daa7444d 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
-@@ -193,6 +193,14 @@ static inline void __mm_zero_struct_page(struct page *page)
+@@ -194,6 +194,14 @@ static inline void __mm_zero_struct_page(struct page *page)
  
  extern int sysctl_max_map_count;
  
@@ -20049,7 +20017,7 @@ index 2e4584e1bfcd..9ff3f9a1f7b4 100644
  extern unsigned long sysctl_admin_reserve_kbytes;
  
 diff --git a/include/linux/pagemap.h b/include/linux/pagemap.h
-index 26baa78f1ca7..8fa2ff2682bc 100644
+index 26baa78f1..8fa2ff268 100644
 --- a/include/linux/pagemap.h
 +++ b/include/linux/pagemap.h
 @@ -1341,7 +1341,7 @@ struct readahead_control {
@@ -20062,7 +20030,7 @@ index 26baa78f1ca7..8fa2ff2682bc 100644
  void page_cache_ra_unbounded(struct readahead_control *,
  		unsigned long nr_to_read, unsigned long lookahead_count);
 diff --git a/include/linux/user_namespace.h b/include/linux/user_namespace.h
-index a0bb6d012137..93129fea552e 100644
+index a0bb6d012..93129fea5 100644
 --- a/include/linux/user_namespace.h
 +++ b/include/linux/user_namespace.h
 @@ -168,6 +168,8 @@ static inline void set_userns_rlimit_max(struct user_namespace *ns,
@@ -20084,7 +20052,7 @@ index a0bb6d012137..93129fea552e 100644
  {
  	return &init_user_ns;
 diff --git a/include/linux/wait.h b/include/linux/wait.h
-index 965a19809c7e..3d442267a256 100644
+index 965a19809..3d442267a 100644
 --- a/include/linux/wait.h
 +++ b/include/linux/wait.h
 @@ -163,6 +163,7 @@ static inline bool wq_has_sleeper(struct wait_queue_head *wq_head)
@@ -20104,7 +20072,7 @@ index 965a19809c7e..3d442267a256 100644
  void finish_wait(struct wait_queue_head *wq_head, struct wait_queue_entry *wq_entry);
  long wait_woken(struct wait_queue_entry *wq_entry, unsigned mode, long timeout);
 diff --git a/init/Kconfig b/init/Kconfig
-index bf3a920064be..c524858118d2 100644
+index b2367239a..3bd8f03f9 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -163,6 +163,10 @@ config THREAD_INFO_IN_TASK
@@ -20155,7 +20123,7 @@ index bf3a920064be..c524858118d2 100644
  	bool "Optimize for size (-Os)"
  	help
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index ce1435cb08b1..e1359db5561e 100644
+index ce1435cb0..e1359db55 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -40,6 +40,27 @@ choice
@@ -20197,7 +20165,7 @@ index ce1435cb08b1..e1359db5561e 100644
  
  config SCHED_HRTICK
 diff --git a/kernel/Kconfig.preempt b/kernel/Kconfig.preempt
-index 54ea59ff8fbe..18f87e0dd137 100644
+index 54ea59ff8..18f87e0dd 100644
 --- a/kernel/Kconfig.preempt
 +++ b/kernel/Kconfig.preempt
 @@ -88,7 +88,7 @@ endchoice
@@ -20210,7 +20178,7 @@ index 54ea59ff8fbe..18f87e0dd137 100644
  	help
  	  This option turns the kernel into a real-time kernel by replacing
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 168681fc4b25..39e47bfaea58 100644
+index 168681fc4..39e47bfae 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -106,6 +106,10 @@
@@ -20249,7 +20217,7 @@ index 168681fc4b25..39e47bfaea58 100644
  	if (err)
  		goto bad_unshare_out;
 diff --git a/kernel/locking/rwsem.c b/kernel/locking/rwsem.c
-index 2ddb827e3bea..464049c4af3f 100644
+index 2ddb827e3..464049c4a 100644
 --- a/kernel/locking/rwsem.c
 +++ b/kernel/locking/rwsem.c
 @@ -747,6 +747,7 @@ rwsem_spin_on_owner(struct rw_semaphore *sem)
@@ -20271,7 +20239,7 @@ index 2ddb827e3bea..464049c4af3f 100644
  
  	return state;
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 1a1caae2b2f7..ff9070239624 100644
+index 9bf6931c8..86db81fb8 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -76,10 +76,19 @@ unsigned int sysctl_sched_tunable_scaling = SCHED_TUNABLESCALING_LOG;
@@ -20308,7 +20276,7 @@ index 1a1caae2b2f7..ff9070239624 100644
  #ifdef CONFIG_NUMA_BALANCING
  /* Restrict the NUMA promotion throughput (MB/s) for each target node. */
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index d6f82833f652..ad6cbf2d9683 100644
+index d6f82833f..ad6cbf2d9 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2790,7 +2790,7 @@ extern void deactivate_task(struct rq *rq, struct task_struct *p, int flags);
@@ -20321,7 +20289,7 @@ index d6f82833f652..ad6cbf2d9683 100644
  #else
  # define SCHED_NR_MIGRATE_BREAK 32
 diff --git a/kernel/sched/wait.c b/kernel/sched/wait.c
-index 51e38f5f4701..c5cc616484ba 100644
+index 51e38f5f4..c5cc61648 100644
 --- a/kernel/sched/wait.c
 +++ b/kernel/sched/wait.c
 @@ -47,6 +47,17 @@ void add_wait_queue_priority(struct wait_queue_head *wq_head, struct wait_queue_
@@ -20363,7 +20331,7 @@ index 51e38f5f4701..c5cc616484ba 100644
  {
  	wq_entry->flags = flags;
 diff --git a/kernel/sysctl.c b/kernel/sysctl.c
-index 3b7a7308e35b..fe7bec454345 100644
+index 3b7a7308e..fe7bec454 100644
 --- a/kernel/sysctl.c
 +++ b/kernel/sysctl.c
 @@ -70,6 +70,9 @@
@@ -20393,7 +20361,7 @@ index 3b7a7308e35b..fe7bec454345 100644
  	{
  		.procname	= "tainted",
 diff --git a/kernel/user_namespace.c b/kernel/user_namespace.c
-index 682f40d5632d..434a25f7b2ed 100644
+index 682f40d56..434a25f7b 100644
 --- a/kernel/user_namespace.c
 +++ b/kernel/user_namespace.c
 @@ -22,6 +22,13 @@
@@ -20411,7 +20379,7 @@ index 682f40d5632d..434a25f7b2ed 100644
  static DEFINE_MUTEX(userns_state_mutex);
  
 diff --git a/mm/Kconfig b/mm/Kconfig
-index e113f713b493..825b5932debc 100644
+index e113f713b..825b5932d 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
 @@ -462,6 +462,69 @@ config ARCH_WANT_OPTIMIZE_HUGETLB_VMEMMAP
@@ -20494,7 +20462,7 @@ index e113f713b493..825b5932debc 100644
  
  #
 diff --git a/mm/compaction.c b/mm/compaction.c
-index ca71fd3c3181..2070b1e5106f 100644
+index ca71fd3c3..2070b1e51 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -1923,7 +1923,11 @@ static int sysctl_compact_unevictable_allowed __read_mostly = CONFIG_COMPACT_UNE
@@ -20510,7 +20478,7 @@ index ca71fd3c3181..2070b1e5106f 100644
  static int __read_mostly sysctl_compact_memory;
  
 diff --git a/mm/huge_memory.c b/mm/huge_memory.c
-index 47d76d03ce30..48615051a8cf 100644
+index 213780e73..b6278caf4 100644
 --- a/mm/huge_memory.c
 +++ b/mm/huge_memory.c
 @@ -64,7 +64,11 @@ unsigned long transparent_hugepage_flags __read_mostly =
@@ -20526,7 +20494,7 @@ index 47d76d03ce30..48615051a8cf 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index eedce9321e13..8201039f1c1c 100644
+index eedce9321..8201039f1 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -2732,6 +2732,7 @@ static void __init mem_init_print_info(void)
@@ -20538,7 +20506,7 @@ index eedce9321e13..8201039f1c1c 100644
  
  void __init __weak arch_mm_preinit(void)
 diff --git a/mm/page-writeback.c b/mm/page-writeback.c
-index 20e1d76f1eba..2d1f99f1ef3d 100644
+index 20e1d76f1..2d1f99f1e 100644
 --- a/mm/page-writeback.c
 +++ b/mm/page-writeback.c
 @@ -71,7 +71,11 @@ static long ratelimit_pages = 32;
@@ -20566,7 +20534,7 @@ index 20e1d76f1eba..2d1f99f1ef3d 100644
  EXPORT_SYMBOL_GPL(dirty_writeback_interval);
  
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 4f29e393f6af..4632022638a5 100644
+index 4f29e393f..463202263 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -274,7 +274,11 @@ const char * const migratetype_names[MIGRATE_TYPES] = {
@@ -20582,7 +20550,7 @@ index 4f29e393f6af..4632022638a5 100644
  int defrag_mode;
  
 diff --git a/mm/swap.c b/mm/swap.c
-index 77b2d5997873..443eb4a8b42b 100644
+index 77b2d5997..443eb4a8b 100644
 --- a/mm/swap.c
 +++ b/mm/swap.c
 @@ -1091,6 +1091,10 @@ static const struct ctl_table swap_sysctl_table[] = {
@@ -20605,7 +20573,7 @@ index 77b2d5997873..443eb4a8b42b 100644
  	 * Right now other parts of the system means that we
  	 * _really_ don't want to cluster much more
 diff --git a/mm/util.c b/mm/util.c
-index 448117da071f..b9334775c51d 100644
+index 448117da0..b9334775c 100644
 --- a/mm/util.c
 +++ b/mm/util.c
 @@ -857,6 +857,40 @@ static const struct ctl_table util_sysctl_table[] = {
@@ -20650,7 +20618,7 @@ index 448117da071f..b9334775c51d 100644
  
  static int __init init_vm_util_sysctls(void)
 diff --git a/mm/vmpressure.c b/mm/vmpressure.c
-index bd5183dfd879..3a410f53a07c 100644
+index bd5183dfd..3a410f53a 100644
 --- a/mm/vmpressure.c
 +++ b/mm/vmpressure.c
 @@ -43,7 +43,11 @@ static const unsigned long vmpressure_win = SWAP_CLUSTER_MAX * 16;
@@ -20666,7 +20634,7 @@ index bd5183dfd879..3a410f53a07c 100644
  
  /*
 diff --git a/mm/vmscan.c b/mm/vmscan.c
-index 3783e45bfc92..75f48ea2b336 100644
+index d3bce4d7a..882417c57 100644
 --- a/mm/vmscan.c
 +++ b/mm/vmscan.c
 @@ -148,6 +148,15 @@ struct scan_control {
@@ -20709,7 +20677,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  
  #ifdef CONFIG_MEMCG
  
-@@ -1147,6 +1169,10 @@ static unsigned int shrink_folio_list(struct list_head *folio_list,
+@@ -1155,6 +1177,10 @@ static unsigned int shrink_folio_list(struct list_head *folio_list,
  		if (!sc->may_unmap && folio_mapped(folio))
  			goto keep_locked;
  
@@ -20720,7 +20688,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  		/*
  		 * The number of dirty pages determines if a node is marked
  		 * reclaim_congested. kswapd will stall and start writing
-@@ -2521,6 +2547,15 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
+@@ -2529,6 +2555,15 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
  		goto out;
  	}
  
@@ -20736,7 +20704,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  	/*
  	 * If there is enough inactive page cache, we do not reclaim
  	 * anything from the anonymous working right now.
-@@ -2638,6 +2673,14 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
+@@ -2646,6 +2681,14 @@ static void get_scan_count(struct lruvec *lruvec, struct scan_control *sc,
  			BUG();
  		}
  
@@ -20751,7 +20719,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  		nr[lru] = scan;
  	}
  }
-@@ -2657,6 +2700,96 @@ static bool can_age_anon_pages(struct pglist_data *pgdat,
+@@ -2665,6 +2708,96 @@ static bool can_age_anon_pages(struct pglist_data *pgdat,
  	return can_demote(pgdat->node_id, sc);
  }
  
@@ -20848,7 +20816,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  #ifdef CONFIG_LRU_GEN
  
  #ifdef CONFIG_LRU_GEN_ENABLED
-@@ -4623,11 +4756,21 @@ static int get_tier_idx(struct lruvec *lruvec, int type)
+@@ -4631,11 +4764,21 @@ static int get_tier_idx(struct lruvec *lruvec, int type)
  	return tier - 1;
  }
  
@@ -20872,7 +20840,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  		return LRU_GEN_FILE;
  
  	if (swappiness >= MAX_SWAPPINESS)
-@@ -4646,7 +4789,7 @@ static int isolate_folios(struct lruvec *lruvec, struct scan_control *sc, int sw
+@@ -4654,7 +4797,7 @@ static int isolate_folios(struct lruvec *lruvec, struct scan_control *sc, int sw
  			  int *type_scanned, struct list_head *list)
  {
  	int i;
@@ -20881,7 +20849,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  
  	for_each_evictable_type(i, swappiness) {
  		int scanned;
-@@ -4889,6 +5032,12 @@ static int shrink_one(struct lruvec *lruvec, struct scan_control *sc)
+@@ -4897,6 +5040,12 @@ static int shrink_one(struct lruvec *lruvec, struct scan_control *sc)
  	struct mem_cgroup *memcg = lruvec_memcg(lruvec);
  	struct pglist_data *pgdat = lruvec_pgdat(lruvec);
  
@@ -20894,7 +20862,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  	/* lru_gen_age_node() called mem_cgroup_calculate_protection() */
  	if (mem_cgroup_below_min(NULL, memcg))
  		return MEMCG_LRU_YOUNG;
-@@ -6027,6 +6176,8 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
+@@ -6035,6 +6184,8 @@ static void shrink_node(pg_data_t *pgdat, struct scan_control *sc)
  
  	prepare_scan_control(pgdat, sc);
  
@@ -20904,7 +20872,7 @@ index 3783e45bfc92..75f48ea2b336 100644
  
  	flush_reclaim_state(sc);
 diff --git a/net/ipv4/inet_connection_sock.c b/net/ipv4/inet_connection_sock.c
-index dd5cf8914a28..b216088a6abd 100644
+index dd5cf8914..b216088a6 100644
 --- a/net/ipv4/inet_connection_sock.c
 +++ b/net/ipv4/inet_connection_sock.c
 @@ -632,7 +632,7 @@ static int inet_csk_wait_for_connect(struct sock *sk, long timeo)
@@ -20916,229 +20884,33 @@ index dd5cf8914a28..b216088a6abd 100644
  					  TASK_INTERRUPTIBLE);
  		release_sock(sk);
  		if (reqsk_queue_empty(&icsk->icsk_accept_queue))
-diff --git a/scripts/Makefile.build b/scripts/Makefile.build
-index eb0d27812aec..951ee1fdaa3c 100644
---- a/scripts/Makefile.build
-+++ b/scripts/Makefile.build
-@@ -50,18 +50,23 @@ endif
- 
- # ===========================================================================
- 
-+builtin_suffix := $(if $(filter %.a_thinlto_native, $(MAKECMDGOALS)),.a_thinlto_native,.a)
-+ifeq ($(thinlto_final_pass),1)
-+builtin_suffix :=.a_thinlto_native
-+endif
-+
- # subdir-builtin and subdir-modorder may contain duplications. Use $(sort ...)
--subdir-builtin := $(sort $(filter %/built-in.a, $(real-obj-y)))
-+subdir-builtin := $(sort $(filter %/built-in$(builtin_suffix), $(real-obj-y)))
- subdir-modorder := $(sort $(filter %/modules.order, $(obj-m)))
- 
- targets-for-builtin := $(extra-y)
- 
- ifneq ($(strip $(lib-y) $(lib-m) $(lib-)),)
--targets-for-builtin += $(obj)/lib.a
-+targets-for-builtin += $(obj)/lib$(builtin_suffix)
- endif
- 
- ifdef need-builtin
--targets-for-builtin += $(obj)/built-in.a
-+targets-for-builtin += $(obj)/built-in$(builtin_suffix)
- endif
- 
- targets-for-modules := $(foreach x, o mod, \
-@@ -337,6 +342,10 @@ $(obj)/%.o: $(obj)/%.S FORCE
- targets += $(filter-out $(subdir-builtin), $(real-obj-y))
- targets += $(filter-out $(subdir-modorder), $(real-obj-m))
- targets += $(lib-y) $(always-y)
-+ifeq ($(builtin_suffix),.a_thinlto_native)
-+native_targets = $(patsubst,%.o,%.o_thinlto_native,$(targets))
-+targets += $(native_targets)
-+endif
- 
- # Linker scripts preprocessor (.lds.S -> .lds)
- # ---------------------------------------------------------------------------
-@@ -347,6 +356,24 @@ quiet_cmd_cpp_lds_S = LDS     $@
- $(obj)/%.lds: $(src)/%.lds.S FORCE
- 	$(call if_changed_dep,cpp_lds_S)
- 
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+# Generate .o_thinlto_native (obj) from .o (bitcode) file
-+# ---------------------------------------------------------------------------
-+quiet_cmd_cc_o_bc = CC $(quiet_modtag) $@
-+
-+cmd_cc_o_bc      = $(if $(filter bitcode, $(shell file -b $<)),$(CC) \
-+		   $(filter-out -Wp% $(LINUXINCLUDE) %.h.gch %.h -D% \
-+		   -flto=thin, $(c_flags)) \
-+		   -Wno-unused-command-line-argument \
-+		   -x ir -fthinlto-index=$<.thinlto.bc -c -o $@ \
-+		   $(if $(findstring ../,$<), \
-+		   $$(realpath --relative-to=$(srcroot) $<), $<), \
-+		   cp $< $@)
-+
-+$(obj)/%.o_thinlto_native: $(obj)/%.o FORCE
-+	$(call if_changed,cc_o_bc)
-+endif
-+
- # ASN.1 grammar
- # ---------------------------------------------------------------------------
- quiet_cmd_asn1_compiler = ASN.1   $(basename $@).[ch]
-@@ -360,7 +387,7 @@ $(obj)/%.asn1.c $(obj)/%.asn1.h: $(src)/%.asn1 $(objtree)/scripts/asn1_compiler
- # ---------------------------------------------------------------------------
- 
- # To build objects in subdirs, we need to descend into the directories
--$(subdir-builtin): $(obj)/%/built-in.a: $(obj)/% ;
-+$(subdir-builtin): $(obj)/%/built-in$(builtin_suffix): $(obj)/% ;
- $(subdir-modorder): $(obj)/%/modules.order: $(obj)/% ;
- 
- #
-@@ -377,6 +404,12 @@ quiet_cmd_ar_builtin = AR      $@
- $(obj)/built-in.a: $(real-obj-y) FORCE
- 	$(call if_changed,ar_builtin)
- 
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+# Rule to compile a set of .o_thinlto_native files into one .a_thinlto_native file.
-+$(obj)/built-in.a_thinlto_native: $(patsubst %.o,%.o_thinlto_native,$(real-obj-y)) FORCE
-+	$(call if_changed,ar_builtin)
-+endif
-+
- # This is a list of build artifacts from the current Makefile and its
- # sub-directories. The timestamp should be updated when any of the member files.
- 
-@@ -394,6 +427,14 @@ $(obj)/modules.order: $(obj-m) FORCE
- $(obj)/lib.a: $(lib-y) FORCE
- 	$(call if_changed,ar)
- 
-+ifdef CONFIG_LTO_CLANG_THIN_DIST
-+quiet_cmd_ar_native = AR      $@
-+      cmd_ar_native = rm -f $@; $(AR) cDPrsT $@ $(patsubst %.o,%.o_thinlto_native,$(real-prereqs))
-+
-+$(obj)/lib.a_thinlto_native: $(patsubst %.o,%.o_thinlto_native,$(lib-y)) FORCE
-+	$(call if_changed,ar_native)
-+endif
-+
- quiet_cmd_ld_multi_m = LD [M]  $@
-       cmd_ld_multi_m = $(LD) $(ld_flags) -r -o $@ @$< $(cmd_objtool)
- 
-@@ -459,7 +500,8 @@ $(single-subdir-goals): $(single-subdirs)
- PHONY += $(subdir-ym)
- $(subdir-ym):
- 	$(Q)$(MAKE) $(build)=$@ \
--	need-builtin=$(if $(filter $@/built-in.a, $(subdir-builtin)),1) \
-+	need-builtin=$(if $(filter $@/built-in$(builtin_suffix), $(subdir-builtin)),1) \
-+	thinlto_final_pass=$(if $(filter .a_thinlto_native, $(builtin_suffix)),1) \
- 	need-modorder=$(if $(filter $@/modules.order, $(subdir-modorder)),1) \
- 	$(filter $@/%, $(single-subdir-goals))
- 
-diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 2fe73cda0bdd..9cfd23590334 100644
---- a/scripts/Makefile.lib
-+++ b/scripts/Makefile.lib
-@@ -34,8 +34,13 @@ else
- obj-m := $(filter-out %/, $(obj-m))
- endif
- 
-+builtin_suffix := $(if $(filter %.a_thinlto_native, $(MAKECMDGOALS)),.a_thinlto_native,.a)
-+ifeq ($(thinlto_final_pass),1)
-+        builtin_suffix :=.a_thinlto_native
-+endif
-+
- ifdef need-builtin
--obj-y		:= $(patsubst %/, %/built-in.a, $(obj-y))
-+obj-y		:= $(patsubst %/, %/built-in$(builtin_suffix), $(obj-y))
- else
- obj-y		:= $(filter-out %/, $(obj-y))
- endif
-diff --git a/scripts/Makefile.vmlinux_o b/scripts/Makefile.vmlinux_o
-index b024ffb3e201..f9abc45a68b3 100644
---- a/scripts/Makefile.vmlinux_o
-+++ b/scripts/Makefile.vmlinux_o
-@@ -9,6 +9,14 @@ include $(srctree)/scripts/Kbuild.include
- # for objtool
- include $(srctree)/scripts/Makefile.lib
- 
-+ifeq ($(thinlto_final_pass),1)
-+vmlinux_a := vmlinux.a_thinlto_native
-+vmlinux_libs := $(patsubst %.a,%.a_thinlto_native,$(KBUILD_VMLINUX_LIBS))
-+else
-+vmlinux_a := vmlinux.a
-+vmlinux_libs := $(KBUILD_VMLINUX_LIBS)
-+endif
-+
- # Generate a linker script to ensure correct ordering of initcalls for Clang LTO
- # ---------------------------------------------------------------------------
- 
-@@ -18,7 +26,7 @@ quiet_cmd_gen_initcalls_lds = GEN     $@
- 	$(PERL) $(real-prereqs) > $@
- 
- .tmp_initcalls.lds: $(srctree)/scripts/generate_initcall_order.pl \
--		vmlinux.a $(KBUILD_VMLINUX_LIBS) FORCE
-+		$(vmlinux_a) $(vmlinux_libs) FORCE
- 	$(call if_changed,gen_initcalls_lds)
- 
- targets := .tmp_initcalls.lds
-@@ -59,8 +67,8 @@ quiet_cmd_ld_vmlinux.o = LD      $@
- 	$(LD) ${KBUILD_LDFLAGS} -r -o $@ \
- 	$(vmlinux-o-ld-args-y) \
- 	$(addprefix -T , $(initcalls-lds)) \
--	--whole-archive vmlinux.a --no-whole-archive \
--	--start-group $(KBUILD_VMLINUX_LIBS) --end-group \
-+	--whole-archive $(vmlinux_a) --no-whole-archive \
-+	--start-group $(vmlinux_libs) --end-group \
- 	$(cmd_objtool)
- 
- define rule_ld_vmlinux.o
-@@ -68,7 +76,7 @@ define rule_ld_vmlinux.o
- 	$(call cmd,gen_objtooldep)
- endef
- 
--vmlinux.o: $(initcalls-lds) vmlinux.a $(KBUILD_VMLINUX_LIBS) FORCE
-+vmlinux.o: $(initcalls-lds) $(vmlinux_a) $(vmlinux_libs) FORCE
- 	$(call if_changed_rule,ld_vmlinux.o)
- 
- targets += vmlinux.o
-diff --git a/scripts/Makefile.vmlinux_thinlink b/scripts/Makefile.vmlinux_thinlink
+diff --git a/scripts/Makefile.thinlto b/scripts/Makefile.thinlto
 new file mode 100644
-index 000000000000..13e4026c7d45
+index 000000000..ec98fa2ea
 --- /dev/null
-+++ b/scripts/Makefile.vmlinux_thinlink
-@@ -0,0 +1,53 @@
-+# SPDX-License-Identifier: GPL-2.0-only
-+
++++ b/scripts/Makefile.thinlto
+@@ -0,0 +1,38 @@
 +PHONY := __default
-+__default: vmlinux.thinlink
++__default:
 +
 +include include/config/auto.conf
 +include $(srctree)/scripts/Kbuild.include
++include $(srctree)/scripts/Makefile.lib
 +
++native-objs := $(patsubst %.o,%.thinlto-native.o,$(call read-file, vmlinux.thinlto-index))
 +
-+# Generate a linker script to ensure correct ordering of initcalls for Clang LTO
++__default: $(native-objs)
++
++# Generate .thinlto-native.o (obj) from .o (bitcode) and .thinlto.bc (summary) files
 +# ---------------------------------------------------------------------------
++quiet_cmd_cc_o_bc = CC $(quiet_modtag)  $@
++      cmd_cc_o_bc = \
++      $(CC) $(_c_flags) -fno-lto -Wno-unused-command-line-argument \
++      -fthinlto-index=$(word 2, $^) -c -o $@ $<
 +
-+quiet_cmd_gen_initcalls_lds = GEN     $@
-+      cmd_gen_initcalls_lds = \
-+	$(PYTHON3) $(srctree)/scripts/jobserver-exec \
-+	$(PERL) $(real-prereqs) > $@
-+
-+.tmp_initcalls_thinlink.lds: $(srctree)/scripts/generate_initcall_order.pl \
-+		vmlinux.a FORCE
-+	$(call if_changed,gen_initcalls_lds)
-+
-+targets := .tmp_initcalls_thinlink.lds
-+
-+initcalls-lds := .tmp_initcalls_thinlink.lds
-+
-+quiet_cmd_ld_vmlinux.thinlink = LD      $@
-+      cmd_ld_vmlinux.thinlink = \
-+	$(AR) t vmlinux.a > .vmlinux_thinlto_bc_files; \
-+	$(LD) ${KBUILD_LDFLAGS} -r $(addprefix -T , $(initcalls-lds)) \
-+	--thinlto-index-only @.vmlinux_thinlto_bc_files; \
-+	touch vmlinux.thinlink
-+
-+vmlinux.thinlink: vmlinux.a $(initcalls-lds) FORCE
-+	$(call if_changed,ld_vmlinux.thinlink)
-+
-+targets += vmlinux.thinlink
++targets += $(native-objs)
++$(native-objs): %.thinlto-native.o: %.o %.o.thinlto.bc   FORCE
++	$(call if_changed,cc_o_bc)
 +
 +# Add FORCE to the prerequisites of a target to force it to be always rebuilt.
 +# ---------------------------------------------------------------------------
@@ -21156,25 +20928,129 @@ index 000000000000..13e4026c7d45
 +-include $(foreach f,$(existing-targets),$(dir $(f)).$(notdir $(f)).cmd)
 +
 +.PHONY: $(PHONY)
-diff --git a/scripts/head-object-list.txt b/scripts/head-object-list.txt
-index 7274dfc65af6..90710b87a387 100644
---- a/scripts/head-object-list.txt
-+++ b/scripts/head-object-list.txt
-@@ -18,6 +18,7 @@ arch/arm/kernel/head.o
- arch/csky/kernel/head.o
- arch/hexagon/kernel/head.o
- arch/loongarch/kernel/head.o
-+arch/loongarch/kernel/head.o_thinlto_native
- arch/m68k/68000/head.o
- arch/m68k/coldfire/head.o
- arch/m68k/kernel/head.o
--- 
-2.50.1
-
-From 8c46d2189dd9f554c00ed41da2d1b6dfa53b8b2a Mon Sep 17 00:00:00 2001
+diff --git a/scripts/Makefile.vmlinux_a b/scripts/Makefile.vmlinux_a
+new file mode 100644
+index 000000000..73c9545de
+--- /dev/null
++++ b/scripts/Makefile.vmlinux_a
+@@ -0,0 +1,83 @@
++# SPDX-License-Identifier: GPL-2.0-only
++
++PHONY := __default
++__default: vmlinux.a
++
++include include/config/auto.conf
++include $(srctree)/scripts/Kbuild.include
++include $(srctree)/scripts/Makefile.lib
++
++# Link of built-in-fixup.a
++# ---------------------------------------------------------------------------
++
++# '$(AR) mPi' needs 'T' to workaround the bug of llvm-ar <= 14
++quiet_cmd_ar_builtin_fixup = AR      $@
++      cmd_ar_builtin_fixup = \
++	rm -f $@; \
++	$(AR) cDPrST $@ $(KBUILD_VMLINUX_OBJS); \
++	$(AR) mPiT $$($(AR) t $@ | sed -n 1p) $@ $$($(AR) t $@ | grep -F -f $(srctree)/scripts/head-object-list.txt)
++
++targets += built-in-fixup.a
++built-in-fixup.a: $(KBUILD_VMLINUX_OBJS) scripts/head-object-list.txt FORCE
++	$(call if_changed,ar_builtin_fixup)
++
++ifdef CONFIG_LTO_CLANG_THIN_DIST
++
++quiet_cmd_builtin.order = GEN     $@
++      cmd_builtin.order = $(AR) t $< > $@
++
++targets += builtin.order
++builtin.order: built-in-fixup.a FORCE
++	$(call if_changed,builtin.order)
++
++quiet_cmd_ld_thinlto_index = LD      $@
++      cmd_ld_thinlto_index = \
++	$(LD) $(KBUILD_LDFLAGS) -r --thinlto-index-only=$@ @$<
++
++targets += vmlinux.thinlto-index
++vmlinux.thinlto-index: builtin.order FORCE
++	$(call if_changed,ld_thinlto_index)
++
++quiet_cmd_ar_vmlinux.a = GEN     $@
++      cmd_ar_vmlinux.a =					\
++	rm -f $@;						\
++	while read -r obj; do					\
++		if grep -q $${obj} $(word 2, $^); then		\
++			echo $${obj%.o}.thinlto-native.o;	\
++		else						\
++			echo $${obj};				\
++		fi;						\
++	done < $< | xargs $(AR) cDPrS $@
++
++targets += vmlinux.a
++vmlinux.a: builtin.order vmlinux.thinlto-index FORCE
++	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.thinlto
++	$(call if_changed,ar_vmlinux.a)
++
++else
++
++# vmlinux.a
++# ---------------------------------------------------------------------------
++
++targets += vmlinux.a
++vmlinux.a: built-in-fixup.a FORCE
++	$(call if_changed,copy)
++
++endif
++
++# Add FORCE to the prerequisites of a target to force it to be always rebuilt.
++# ---------------------------------------------------------------------------
++
++PHONY += FORCE
++FORCE:
++
++# Read all saved command lines and dependencies for the $(targets) we
++# may be building above, using $(if_changed{,_dep}). As an
++# optimization, we don't need to read them if the target does not
++# exist, we will rebuild anyway in that case.
++
++existing-targets := $(wildcard $(sort $(targets)))
++
++-include $(foreach f,$(existing-targets),$(dir $(f)).$(notdir $(f)).cmd)
++
++.PHONY: $(PHONY)
+diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
+index be89921d6..01717ed0d 100644
+--- a/scripts/mod/modpost.c
++++ b/scripts/mod/modpost.c
+@@ -1471,13 +1471,22 @@ static void extract_crcs_for_object(const char *object, struct module *mod)
+ 	char cmd_file[PATH_MAX];
+ 	char *buf, *p;
+ 	const char *base;
+-	int dirlen, ret;
++	int dirlen, baselen_without_suffix, ret;
+ 
+ 	base = get_basename(object);
+ 	dirlen = base - object;
+ 
+-	ret = snprintf(cmd_file, sizeof(cmd_file), "%.*s.%s.cmd",
+-		       dirlen, object, base);
++	baselen_without_suffix = strlen(object) - dirlen - strlen(".o");
++
++	/*
++	 * When CONFIG_LTO_CLANG_THIN_DIST=y, the ELF is *.thinlto-native.o
++	 * but the symbol CRCs are recorded in *.o.cmd file.
++	 */
++	if (strends(object, ".thinlto-native.o"))
++		baselen_without_suffix -= strlen(".thinlto-native");
++
++	ret = snprintf(cmd_file, sizeof(cmd_file), "%.*s.%.*s.o.cmd",
++		       dirlen, object, baselen_without_suffix, base);
+ 	if (ret >= sizeof(cmd_file)) {
+ 		error("%s: too long path was truncated\n", cmd_file);
+ 		return;
+From c4bb0154bfb5394712b248e5a5d2f8dadef6d63e Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:47 +0200
-Subject: [PATCH 5/6] fixes
+Subject: [PATCH 6/7] fixes
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -21184,7 +21060,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  Documentation/kbuild/makefiles.rst        |   3 +
  arch/x86/include/asm/amd/fch.h            |  13 +
  arch/x86/kernel/cpu/amd.c                 |  54 ++++
- drivers/bluetooth/btusb.c                 |   2 +
+ drivers/gpu/drm/drm_atomic_uapi.c         |  51 ++-
  drivers/gpu/drm/i915/display/intel_dsb.c  |   4 +
  drivers/hid/hid-quirks.c                  |   5 +-
  drivers/i2c/busses/Kconfig                |   2 +-
@@ -21195,13 +21071,13 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  scripts/Makefile.lib                      |   5 +
  scripts/checkpatch.pl                     |  14 +
  scripts/package/PKGBUILD                  |   5 +
- 17 files changed, 509 insertions(+), 12 deletions(-)
+ 17 files changed, 542 insertions(+), 28 deletions(-)
  create mode 100644 Documentation/arch/x86/amd-debugging.rst
  create mode 100644 arch/x86/include/asm/amd/fch.h
 
 diff --git a/Documentation/arch/x86/amd-debugging.rst b/Documentation/arch/x86/amd-debugging.rst
 new file mode 100644
-index 000000000000..d92bf59d62c7
+index 000000000..d92bf59d6
 --- /dev/null
 +++ b/Documentation/arch/x86/amd-debugging.rst
 @@ -0,0 +1,368 @@
@@ -21574,7 +21450,7 @@ index 000000000000..d92bf59d62c7
 +the syslog. When a random reboot occurs this message can be helpful
 +to determine the next component to debug.
 diff --git a/Documentation/arch/x86/index.rst b/Documentation/arch/x86/index.rst
-index 8ac64d7de4dc..58a006525ae8 100644
+index 8ac64d7de..58a006525 100644
 --- a/Documentation/arch/x86/index.rst
 +++ b/Documentation/arch/x86/index.rst
 @@ -25,6 +25,7 @@ x86-specific Documentation
@@ -21586,7 +21462,7 @@ index 8ac64d7de4dc..58a006525ae8 100644
     amd_hsmp
     tdx
 diff --git a/Documentation/dev-tools/checkpatch.rst b/Documentation/dev-tools/checkpatch.rst
-index 76bd0ddb0041..abb3ff682076 100644
+index 76bd0ddb0..abb3ff682 100644
 --- a/Documentation/dev-tools/checkpatch.rst
 +++ b/Documentation/dev-tools/checkpatch.rst
 @@ -342,6 +342,24 @@ API usage
@@ -21615,7 +21491,7 @@ index 76bd0ddb0041..abb3ff682076 100644
      The function names used in DEVICE_ATTR is unusual.
      Typically, the store and show functions are used with <attr>_store and
 diff --git a/Documentation/kbuild/makefiles.rst b/Documentation/kbuild/makefiles.rst
-index 3b9a8bc671e2..2608aa32c762 100644
+index 3b9a8bc67..2608aa32c 100644
 --- a/Documentation/kbuild/makefiles.rst
 +++ b/Documentation/kbuild/makefiles.rst
 @@ -318,6 +318,9 @@ ccflags-y, asflags-y and ldflags-y
@@ -21630,7 +21506,7 @@ index 3b9a8bc671e2..2608aa32c762 100644
  
 diff --git a/arch/x86/include/asm/amd/fch.h b/arch/x86/include/asm/amd/fch.h
 new file mode 100644
-index 000000000000..2cf5153edbc2
+index 000000000..2cf5153ed
 --- /dev/null
 +++ b/arch/x86/include/asm/amd/fch.h
 @@ -0,0 +1,13 @@
@@ -21648,7 +21524,7 @@ index 000000000000..2cf5153edbc2
 +
 +#endif /* _ASM_X86_AMD_FCH_H_ */
 diff --git a/arch/x86/kernel/cpu/amd.c b/arch/x86/kernel/cpu/amd.c
-index 6f9a6185df7f..5e14474a0698 100644
+index 6f9a6185d..5e14474a0 100644
 --- a/arch/x86/kernel/cpu/amd.c
 +++ b/arch/x86/kernel/cpu/amd.c
 @@ -9,6 +9,7 @@
@@ -21716,21 +21592,91 @@ index 6f9a6185df7f..5e14474a0698 100644
 +	return 0;
 +}
 +late_initcall(print_s5_reset_status_mmio);
-diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
-index 6f2fd043fd3f..0da7dc0cf8b0 100644
---- a/drivers/bluetooth/btusb.c
-+++ b/drivers/bluetooth/btusb.c
-@@ -705,6 +705,8 @@ static const struct usb_device_id quirks_table[] = {
- 						     BTUSB_WIDEBAND_SPEECH },
- 	{ USB_DEVICE(0x0489, 0xe139), .driver_info = BTUSB_MEDIATEK |
- 						     BTUSB_WIDEBAND_SPEECH },
-+	{ USB_DEVICE(0x0489, 0xe14e), .driver_info = BTUSB_MEDIATEK |
-+						     BTUSB_WIDEBAND_SPEECH },
- 	{ USB_DEVICE(0x0489, 0xe14f), .driver_info = BTUSB_MEDIATEK |
- 						     BTUSB_WIDEBAND_SPEECH },
- 	{ USB_DEVICE(0x0489, 0xe150), .driver_info = BTUSB_MEDIATEK |
+diff --git a/drivers/gpu/drm/drm_atomic_uapi.c b/drivers/gpu/drm/drm_atomic_uapi.c
+index c2726af66..2ae41a522 100644
+--- a/drivers/gpu/drm/drm_atomic_uapi.c
++++ b/drivers/gpu/drm/drm_atomic_uapi.c
+@@ -1068,7 +1068,6 @@ int drm_atomic_set_property(struct drm_atomic_state *state,
+ 		struct drm_plane *plane = obj_to_plane(obj);
+ 		struct drm_plane_state *plane_state;
+ 		struct drm_mode_config *config = &plane->dev->mode_config;
+-		const struct drm_plane_helper_funcs *plane_funcs = plane->helper_private;
+ 
+ 		plane_state = drm_atomic_get_plane_state(state, plane);
+ 		if (IS_ERR(plane_state)) {
+@@ -1084,21 +1083,8 @@ int drm_atomic_set_property(struct drm_atomic_state *state,
+ 				ret = drm_atomic_plane_get_property(plane, plane_state,
+ 								    prop, &old_val);
+ 				ret = drm_atomic_check_prop_changes(ret, old_val, prop_value, prop);
+-			}
+-
+-			/* ask the driver if this non-primary plane is supported */
+-			if (plane->type != DRM_PLANE_TYPE_PRIMARY) {
+-				ret = -EINVAL;
+-
+-				if (plane_funcs && plane_funcs->atomic_async_check)
+-					ret = plane_funcs->atomic_async_check(plane, state, true);
+-
+-				if (ret) {
+-					drm_dbg_atomic(prop->dev,
+-						       "[PLANE:%d:%s] does not support async flips\n",
+-						       obj->id, plane->name);
+-					break;
+-				}
++				if (ret)
++				    break;
+ 			}
+ 		}
+ 
+@@ -1394,6 +1380,10 @@ int drm_mode_atomic_ioctl(struct drm_device *dev,
+ 	int ret = 0;
+ 	unsigned int i, j, num_fences;
+ 	bool async_flip = false;
++	struct drm_plane *plane;
++	struct drm_plane_state *old_plane_state = NULL;
++	struct drm_plane_state *new_plane_state = NULL;
++	u64 fb_id = 0;
+ 
+ 	/* disallow for drivers not supporting atomic: */
+ 	if (!drm_core_check_feature(dev, DRIVER_ATOMIC))
+@@ -1521,6 +1511,35 @@ int drm_mode_atomic_ioctl(struct drm_device *dev,
+ 			copied_props++;
+ 		}
+ 
++		if (async_flip && obj->type == DRM_MODE_OBJECT_PLANE &&
++		    obj_to_plane(obj)->type != DRM_PLANE_TYPE_PRIMARY) {
++			/* need to ask the driver if this plane is supported */
++			plane = obj_to_plane(obj);
++			old_plane_state = drm_atomic_get_old_plane_state(state, plane);
++			new_plane_state = drm_atomic_get_new_plane_state(state, plane);
++			ret = drm_atomic_plane_get_property(plane, new_plane_state,
++							    dev->mode_config.prop_fb_id,
++							    &fb_id);
++			if (ret)
++				break;
++			/*
++			 * Only do the check if the plane was or is enabled.
++			 * Note that the new state doesn't have "visible" set yet,
++			 * so this uses fb_id instead.
++			 */
++			if (old_plane_state->visible || fb_id)
++				ret = -EINVAL;
++			if (ret && plane->helper_private &&
++			    plane->helper_private->atomic_async_check) {
++				ret = plane->helper_private->atomic_async_check(plane, state, true);
++			}
++			if (ret) {
++				drm_dbg_atomic(dev, "[PLANE:%d:%s] does not support async flips\n",
++						obj->id, plane->name);
++				break;
++			}
++		}
++
+ 		drm_mode_object_put(obj);
+ 	}
+ 
 diff --git a/drivers/gpu/drm/i915/display/intel_dsb.c b/drivers/gpu/drm/i915/display/intel_dsb.c
-index 9fc4003d1579..e5ece83a1df1 100644
+index 9fc4003d1..e5ece83a1 100644
 --- a/drivers/gpu/drm/i915/display/intel_dsb.c
 +++ b/drivers/gpu/drm/i915/display/intel_dsb.c
 @@ -806,6 +806,10 @@ struct intel_dsb *intel_dsb_prepare(struct intel_atomic_state *state,
@@ -21745,7 +21691,7 @@ index 9fc4003d1579..e5ece83a1df1 100644
  	if (!dsb)
  		goto out;
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index 06c27308e497..31508da93ba2 100644
+index 06c27308e..31508da93 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
 @@ -1066,7 +1066,7 @@ bool hid_ignore(struct hid_device *hdev)
@@ -21768,7 +21714,7 @@ index 06c27308e497..31508da93ba2 100644
  		quirks |= HID_QUIRK_HAVE_SPECIAL_DRIVER;
  
 diff --git a/drivers/i2c/busses/Kconfig b/drivers/i2c/busses/Kconfig
-index 83c88c79afe2..bbbd6240fa6e 100644
+index 83c88c79a..bbbd6240f 100644
 --- a/drivers/i2c/busses/Kconfig
 +++ b/drivers/i2c/busses/Kconfig
 @@ -200,7 +200,7 @@ config I2C_ISMT
@@ -21781,7 +21727,7 @@ index 83c88c79afe2..bbbd6240fa6e 100644
  	help
  	  If you say yes to this option, support will be included for the Intel
 diff --git a/drivers/i2c/busses/i2c-piix4.c b/drivers/i2c/busses/i2c-piix4.c
-index dd75916157f0..59ecaa990bce 100644
+index dd7591615..59ecaa990 100644
 --- a/drivers/i2c/busses/i2c-piix4.c
 +++ b/drivers/i2c/busses/i2c-piix4.c
 @@ -34,6 +34,7 @@
@@ -21842,7 +21788,7 @@ index dd75916157f0..59ecaa990bce 100644
  		return;
  	}
 diff --git a/drivers/platform/x86/amd/pmc/pmc-quirks.c b/drivers/platform/x86/amd/pmc/pmc-quirks.c
-index 7ed12c1d3b34..f292111bd065 100644
+index 04686ae1e..7bd0d5340 100644
 --- a/drivers/platform/x86/amd/pmc/pmc-quirks.c
 +++ b/drivers/platform/x86/amd/pmc/pmc-quirks.c
 @@ -11,6 +11,7 @@
@@ -21863,7 +21809,7 @@ index 7ed12c1d3b34..f292111bd065 100644
  
  static struct quirk_entry quirk_spurious_8042 = {
 diff --git a/include/linux/hid.h b/include/linux/hid.h
-index daae1d6d11a7..a1305210b2fd 100644
+index ada27535a..ababb7d41 100644
 --- a/include/linux/hid.h
 +++ b/include/linux/hid.h
 @@ -357,6 +357,7 @@ struct hid_item {
@@ -21883,7 +21829,7 @@ index daae1d6d11a7..a1305210b2fd 100644
  #define HID_QUIRK_SKIP_OUTPUT_REPORT_ID		BIT(17)
  #define HID_QUIRK_NO_OUTPUT_REPORTS_ON_INTR_EP	BIT(18)
 diff --git a/scripts/Makefile.build b/scripts/Makefile.build
-index 951ee1fdaa3c..e175942e1de8 100644
+index eb0d27812..f0319f4dd 100644
 --- a/scripts/Makefile.build
 +++ b/scripts/Makefile.build
 @@ -20,6 +20,10 @@ always-m :=
@@ -21898,7 +21844,7 @@ index 951ee1fdaa3c..e175942e1de8 100644
  ccflags-y  :=
  rustflags-y :=
 diff --git a/scripts/Makefile.lib b/scripts/Makefile.lib
-index 9cfd23590334..47d4c1808824 100644
+index 2fe73cda0..8b588a2d0 100644
 --- a/scripts/Makefile.lib
 +++ b/scripts/Makefile.lib
 @@ -1,4 +1,9 @@
@@ -21912,7 +21858,7 @@ index 9cfd23590334..47d4c1808824 100644
  # flags that take effect in current and sub directories
  KBUILD_AFLAGS += $(subdir-asflags-y)
 diff --git a/scripts/checkpatch.pl b/scripts/checkpatch.pl
-index 3d22bf863eec..784912f570e9 100755
+index 3d22bf863..784912f57 100755
 --- a/scripts/checkpatch.pl
 +++ b/scripts/checkpatch.pl
 @@ -3690,6 +3690,20 @@ sub process {
@@ -21937,7 +21883,7 @@ index 3d22bf863eec..784912f570e9 100755
  		if (defined $root &&
  			(($realfile =~ /\.dtsi?$/ && $line =~ /^\+\s*compatible\s*=\s*\"/) ||
 diff --git a/scripts/package/PKGBUILD b/scripts/package/PKGBUILD
-index 452374d63c24..08f80d7c5df0 100644
+index 452374d63..08f80d7c5 100644
 --- a/scripts/package/PKGBUILD
 +++ b/scripts/package/PKGBUILD
 @@ -90,6 +90,11 @@ _package-headers() {
@@ -21952,13 +21898,10 @@ index 452374d63c24..08f80d7c5df0 100644
  	echo "Installing System.map and config..."
  	mkdir -p "${builddir}"
  	cp System.map "${builddir}/System.map"
--- 
-2.50.1
-
-From 573474d7dca703a36e5e068bf07cbf422b890ea2 Mon Sep 17 00:00:00 2001
+From 7eeb33a77f82032610c68521313667f8b0f326dc Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:59 +0200
-Subject: [PATCH 6/6] t2
+Subject: [PATCH 7/7] t2
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -22069,7 +22012,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  create mode 100644 include/linux/soc/apple/dockchannel.h
 
 diff --git a/Documentation/core-api/printk-formats.rst b/Documentation/core-api/printk-formats.rst
-index 4bdc394e86af..f531873bb3c9 100644
+index 4bdc394e8..f531873bb 100644
 --- a/Documentation/core-api/printk-formats.rst
 +++ b/Documentation/core-api/printk-formats.rst
 @@ -648,6 +648,38 @@ Examples::
@@ -22112,7 +22055,7 @@ index 4bdc394e86af..f531873bb3c9 100644
  ----
  
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 6ef3fedc1233..59deaa42c062 100644
+index 6ef3fedc1..59deaa42c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 @@ -2281,6 +2281,9 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,
@@ -22126,7 +22069,7 @@ index 6ef3fedc1233..59deaa42c062 100644
  	    (pdev->class >> 8) == PCI_CLASS_DISPLAY_OTHER) {
  		if (drm_firmware_drivers_only() && amdgpu_modeset == -1)
 diff --git a/drivers/gpu/drm/i915/display/intel_ddi.c b/drivers/gpu/drm/i915/display/intel_ddi.c
-index f38c998935b9..1df3ddb366f4 100644
+index f38c99893..1df3ddb36 100644
 --- a/drivers/gpu/drm/i915/display/intel_ddi.c
 +++ b/drivers/gpu/drm/i915/display/intel_ddi.c
 @@ -4848,6 +4848,7 @@ static int intel_ddi_init_hdmi_connector(struct intel_digital_port *dig_port)
@@ -22148,7 +22091,7 @@ index f38c998935b9..1df3ddb366f4 100644
  	 *                     supported configuration
  	 */
 diff --git a/drivers/gpu/drm/i915/display/intel_fbdev.c b/drivers/gpu/drm/i915/display/intel_fbdev.c
-index adc19d5607de..64882765aa0a 100644
+index adc19d560..64882765a 100644
 --- a/drivers/gpu/drm/i915/display/intel_fbdev.c
 +++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
 @@ -224,10 +224,10 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
@@ -22166,7 +22109,7 @@ index adc19d5607de..64882765aa0a 100644
  			    fb->base.width, fb->base.height,
  			    sizes->fb_width, sizes->fb_height);
 diff --git a/drivers/gpu/drm/i915/display/intel_quirks.c b/drivers/gpu/drm/i915/display/intel_quirks.c
-index a32fae510ed2..662465733ddb 100644
+index a32fae510..662465733 100644
 --- a/drivers/gpu/drm/i915/display/intel_quirks.c
 +++ b/drivers/gpu/drm/i915/display/intel_quirks.c
 @@ -66,6 +66,18 @@ static void quirk_increase_ddi_disabled_time(struct intel_display *display)
@@ -22199,7 +22142,7 @@ index a32fae510ed2..662465733ddb 100644
  
  static const struct intel_dpcd_quirk intel_dpcd_quirks[] = {
 diff --git a/drivers/gpu/drm/i915/display/intel_quirks.h b/drivers/gpu/drm/i915/display/intel_quirks.h
-index cafdebda7535..a5296f82776e 100644
+index cafdebda7..a5296f827 100644
 --- a/drivers/gpu/drm/i915/display/intel_quirks.h
 +++ b/drivers/gpu/drm/i915/display/intel_quirks.h
 @@ -20,6 +20,7 @@ enum intel_quirk_id {
@@ -22211,7 +22154,7 @@ index cafdebda7535..a5296f82776e 100644
  
  void intel_init_quirks(struct intel_display *display);
 diff --git a/drivers/gpu/drm/tiny/appletbdrm.c b/drivers/gpu/drm/tiny/appletbdrm.c
-index 4370ba22dd88..8643216bad98 100644
+index 4370ba22d..8643216ba 100644
 --- a/drivers/gpu/drm/tiny/appletbdrm.c
 +++ b/drivers/gpu/drm/tiny/appletbdrm.c
 @@ -214,7 +214,7 @@ static int appletbdrm_read_response(struct appletbdrm_device *adev,
@@ -22233,7 +22176,7 @@ index 4370ba22dd88..8643216bad98 100644
  		goto free_info;
  	}
 diff --git a/drivers/gpu/vga/vga_switcheroo.c b/drivers/gpu/vga/vga_switcheroo.c
-index 18f2c92beff8..3de1bca45ed2 100644
+index 18f2c92be..3de1bca45 100644
 --- a/drivers/gpu/vga/vga_switcheroo.c
 +++ b/drivers/gpu/vga/vga_switcheroo.c
 @@ -438,12 +438,7 @@ find_active_client(struct list_head *head)
@@ -22251,7 +22194,7 @@ index 18f2c92beff8..3de1bca45ed2 100644
  	}
  
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index aeb4eabf3007..e7688c7fdc56 100644
+index 5bc1f086b..1c2522d95 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
 @@ -129,7 +129,7 @@ config HID_APPLE
@@ -22263,7 +22206,7 @@ index aeb4eabf3007..e7688c7fdc56 100644
  	help
  	Support for some Apple devices which less or more break
  	HID specification.
-@@ -717,11 +717,13 @@ config LOGIWHEELS_FF
+@@ -727,11 +727,13 @@ config LOGIWHEELS_FF
  
  config HID_MAGICMOUSE
  	tristate "Apple Magic Mouse/Trackpad multi-touch support"
@@ -22278,7 +22221,7 @@ index aeb4eabf3007..e7688c7fdc56 100644
  
  config HID_MALTRON
  	tristate "Maltron L90 keyboard"
-@@ -771,6 +773,7 @@ config HID_MULTITOUCH
+@@ -781,6 +783,7 @@ config HID_MULTITOUCH
  	  Say Y here if you have one of the following devices:
  	  - 3M PCT touch screens
  	  - ActionStar dual touch panels
@@ -22286,7 +22229,7 @@ index aeb4eabf3007..e7688c7fdc56 100644
  	  - Atmel panels
  	  - Cando dual touch panels
  	  - Chunghwa panels
-@@ -1437,4 +1440,8 @@ endif # HID
+@@ -1445,4 +1448,8 @@ endif # HID
  
  source "drivers/hid/usbhid/Kconfig"
  
@@ -22296,10 +22239,10 @@ index aeb4eabf3007..e7688c7fdc56 100644
 +
  endif # HID_SUPPORT
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index 85af5331ebd2..a0f58475434c 100644
+index 958f67193..f67db3d5d 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
-@@ -177,3 +177,7 @@ obj-$(CONFIG_ASUS_ALLY_HID)  += asus-ally-hid/
+@@ -176,3 +176,7 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
  obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
  
  obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
@@ -22309,7 +22252,7 @@ index 85af5331ebd2..a0f58475434c 100644
 +obj-$(CONFIG_HID_DOCKCHANNEL)   += dockchannel-hid/
 diff --git a/drivers/hid/dockchannel-hid/Kconfig b/drivers/hid/dockchannel-hid/Kconfig
 new file mode 100644
-index 000000000000..8a81d551a83d
+index 000000000..8a81d551a
 --- /dev/null
 +++ b/drivers/hid/dockchannel-hid/Kconfig
 @@ -0,0 +1,14 @@
@@ -22329,7 +22272,7 @@ index 000000000000..8a81d551a83d
 +endmenu
 diff --git a/drivers/hid/dockchannel-hid/Makefile b/drivers/hid/dockchannel-hid/Makefile
 new file mode 100644
-index 000000000000..7dba766b047f
+index 000000000..7dba766b0
 --- /dev/null
 +++ b/drivers/hid/dockchannel-hid/Makefile
 @@ -0,0 +1,6 @@
@@ -22341,7 +22284,7 @@ index 000000000000..7dba766b047f
 +obj-$(CONFIG_HID_DOCKCHANNEL)	+= dockchannel-hid.o
 diff --git a/drivers/hid/dockchannel-hid/dockchannel-hid.c b/drivers/hid/dockchannel-hid/dockchannel-hid.c
 new file mode 100644
-index 000000000000..a712a724ded3
+index 000000000..a712a724d
 --- /dev/null
 +++ b/drivers/hid/dockchannel-hid/dockchannel-hid.c
 @@ -0,0 +1,1213 @@
@@ -23559,7 +23502,7 @@ index 000000000000..a712a724ded3
 +MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
 +MODULE_LICENSE("Dual MIT/GPL");
 diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
-index ed34f5cd5a91..ed8b87f7556b 100644
+index a3405b1cc..35e41a6f9 100644
 --- a/drivers/hid/hid-apple.c
 +++ b/drivers/hid/hid-apple.c
 @@ -486,6 +486,7 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
@@ -23587,7 +23530,7 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  		else if (hid->product < 0x21d || hid->product >= 0x300)
  			table = powerbook_fn_keys;
  		else
-@@ -910,6 +921,13 @@ static int apple_probe(struct hid_device *hdev,
+@@ -911,6 +922,13 @@ static int apple_probe(struct hid_device *hdev,
  	struct apple_sc *asc;
  	int ret;
  
@@ -23601,7 +23544,7 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
  	if (asc == NULL) {
  		hid_err(hdev, "can't alloc apple descriptor\n");
-@@ -1127,21 +1145,28 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1133,21 +1151,28 @@ static const struct hid_device_id apple_devices[] = {
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS),
  		.driver_data = APPLE_HAS_FN | APPLE_RDESC_JIS },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K),
@@ -23638,7 +23581,7 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_ALU_WIRELESS_2009_ANSI),
  		.driver_data = APPLE_NUMLOCK_EMULATION | APPLE_HAS_FN },
  	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_ALU_WIRELESS_2009_ISO),
-@@ -1169,6 +1194,10 @@ static const struct hid_device_id apple_devices[] = {
+@@ -1175,6 +1200,10 @@ static const struct hid_device_id apple_devices[] = {
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_RDESC_BATTERY },
  	{ HID_BLUETOOTH_DEVICE(BT_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_MAGIC_KEYBOARD_NUMPAD_2021),
  		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
@@ -23650,10 +23593,10 @@ index ed34f5cd5a91..ed8b87f7556b 100644
  		.driver_data = APPLE_MAGIC_BACKLIGHT },
  
 diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
-index cd4215007d1a..4dd55546f446 100644
+index bd4b4cc78..ed6f23e41 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -464,7 +464,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
+@@ -468,7 +468,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
  
  	case HID_GLOBAL_ITEM_TAG_REPORT_SIZE:
  		parser->global.report_size = item_udata(item);
@@ -23665,7 +23608,7 @@ index cd4215007d1a..4dd55546f446 100644
  			hid_err(parser->device, "invalid report_size %d\n",
  					parser->global.report_size);
  			return -1;
-@@ -2303,6 +2306,12 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+@@ -2307,6 +2310,12 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
  	case BUS_I2C:
  		bus = "I2C";
  		break;
@@ -23679,7 +23622,7 @@ index cd4215007d1a..4dd55546f446 100644
  		bus = "VIRTUAL";
  		break;
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 965ee2da07d2..4af0fa7c8eee 100644
+index 82f39fa14..0e1f7c966 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -93,6 +93,8 @@
@@ -23729,7 +23672,7 @@ index 965ee2da07d2..4af0fa7c8eee 100644
  #define USB_VENDOR_ID_ASETEK			0x2433
  #define USB_DEVICE_ID_ASETEK_INVICTA		0xf300
 diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
-index adfa329e917b..0787581a25cc 100644
+index 6d916c6c7..9d8165f7b 100644
 --- a/drivers/hid/hid-magicmouse.c
 +++ b/drivers/hid/hid-magicmouse.c
 @@ -60,8 +60,14 @@ MODULE_PARM_DESC(report_undeciphered, "Report undeciphered multi-touch state fie
@@ -24575,10 +24518,10 @@ index adfa329e917b..0787581a25cc 100644
 -		hid_err(msc->hdev, "unable to request touch data (%d)\n", ret);
 -}
 -
- static int magicmouse_fetch_battery(struct hid_device *hdev)
+ static bool is_usb_magicmouse2(__u32 vendor, __u32 product)
  {
- #ifdef CONFIG_HID_BATTERY_STRENGTH
-@@ -825,12 +1448,62 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 	if (vendor != USB_VENDOR_ID_APPLE)
+@@ -839,12 +1462,62 @@ static int magicmouse_probe(struct hid_device *hdev,
  	struct hid_report *report;
  	int ret;
  
@@ -24641,7 +24584,7 @@ index adfa329e917b..0787581a25cc 100644
  	msc->scroll_accel = SCROLL_ACCEL_DEFAULT;
  	msc->hdev = hdev;
  	INIT_DEFERRABLE_WORK(&msc->work, magicmouse_enable_mt_work);
-@@ -868,25 +1541,51 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -883,25 +1556,51 @@ static int magicmouse_probe(struct hid_device *hdev,
  		goto err_stop_hw;
  	}
  
@@ -24710,7 +24653,7 @@ index adfa329e917b..0787581a25cc 100644
  	}
  
  	if (!report) {
-@@ -896,21 +1595,14 @@ static int magicmouse_probe(struct hid_device *hdev,
+@@ -911,21 +1610,14 @@ static int magicmouse_probe(struct hid_device *hdev,
  	}
  	report->size = 6;
  
@@ -24740,7 +24683,7 @@ index adfa329e917b..0787581a25cc 100644
  	}
  
  	return 0;
-@@ -981,10 +1673,42 @@ static const struct hid_device_id magic_mice[] = {
+@@ -999,10 +1691,42 @@ static const struct hid_device_id magic_mice[] = {
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
  	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
  		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
@@ -24783,7 +24726,7 @@ index adfa329e917b..0787581a25cc 100644
  static struct hid_driver magicmouse_driver = {
  	.name = "magicmouse",
  	.id_table = magic_mice,
-@@ -995,6 +1719,10 @@ static struct hid_driver magicmouse_driver = {
+@@ -1013,6 +1737,10 @@ static struct hid_driver magicmouse_driver = {
  	.event = magicmouse_event,
  	.input_mapping = magicmouse_input_mapping,
  	.input_configured = magicmouse_input_configured,
@@ -24795,7 +24738,7 @@ index adfa329e917b..0787581a25cc 100644
  module_hid_driver(magicmouse_driver);
  
 diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
-index 536a0a47518f..06afcce30119 100644
+index 536a0a475..06afcce30 100644
 --- a/drivers/hid/hid-multitouch.c
 +++ b/drivers/hid/hid-multitouch.c
 @@ -73,6 +73,7 @@ MODULE_LICENSE("GPL");
@@ -24944,7 +24887,7 @@ index 536a0a47518f..06afcce30119 100644
  	{ .driver_data = MT_CLS_GOOGLE,
  		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
 diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
-index 31508da93ba2..2cce36895a60 100644
+index 31508da93..2cce36895 100644
 --- a/drivers/hid/hid-quirks.c
 +++ b/drivers/hid/hid-quirks.c
 @@ -314,6 +314,7 @@ static const struct hid_device_id hid_have_special_driver[] = {
@@ -24972,7 +24915,7 @@ index 31508da93ba2..2cce36895a60 100644
  	{ }
 diff --git a/drivers/hid/spi-hid/Kconfig b/drivers/hid/spi-hid/Kconfig
 new file mode 100644
-index 000000000000..8e37f0fec28a
+index 000000000..8e37f0fec
 --- /dev/null
 +++ b/drivers/hid/spi-hid/Kconfig
 @@ -0,0 +1,26 @@
@@ -25004,7 +24947,7 @@ index 000000000000..8e37f0fec28a
 +	select CRC16
 diff --git a/drivers/hid/spi-hid/Makefile b/drivers/hid/spi-hid/Makefile
 new file mode 100644
-index 000000000000..f276ee12cb94
+index 000000000..f276ee12c
 --- /dev/null
 +++ b/drivers/hid/spi-hid/Makefile
 @@ -0,0 +1,10 @@
@@ -25020,7 +24963,7 @@ index 000000000000..f276ee12cb94
 +obj-$(CONFIG_SPI_HID_APPLE_OF)			+= spi-hid-apple-of.o
 diff --git a/drivers/hid/spi-hid/spi-hid-apple-core.c b/drivers/hid/spi-hid/spi-hid-apple-core.c
 new file mode 100644
-index 000000000000..1f8fa64d6d86
+index 000000000..1f8fa64d6
 --- /dev/null
 +++ b/drivers/hid/spi-hid/spi-hid-apple-core.c
 @@ -0,0 +1,1194 @@
@@ -26220,7 +26163,7 @@ index 000000000000..1f8fa64d6d86
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/spi-hid/spi-hid-apple-of.c b/drivers/hid/spi-hid/spi-hid-apple-of.c
 new file mode 100644
-index 000000000000..3f87b299351d
+index 000000000..3f87b2993
 --- /dev/null
 +++ b/drivers/hid/spi-hid/spi-hid-apple-of.c
 @@ -0,0 +1,151 @@
@@ -26377,7 +26320,7 @@ index 000000000000..3f87b299351d
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/spi-hid/spi-hid-apple.h b/drivers/hid/spi-hid/spi-hid-apple.h
 new file mode 100644
-index 000000000000..9abecd1ba780
+index 000000000..9abecd1ba
 --- /dev/null
 +++ b/drivers/hid/spi-hid/spi-hid-apple.h
 @@ -0,0 +1,35 @@
@@ -26417,7 +26360,7 @@ index 000000000000..9abecd1ba780
 +
 +#endif /* SPI_HID_APPLE_H */
 diff --git a/drivers/hwmon/applesmc.c b/drivers/hwmon/applesmc.c
-index fc6d6a9053ce..698f44794453 100644
+index fc6d6a905..698f44794 100644
 --- a/drivers/hwmon/applesmc.c
 +++ b/drivers/hwmon/applesmc.c
 @@ -6,6 +6,7 @@
@@ -28403,7 +28346,7 @@ index fc6d6a9053ce..698f44794453 100644
  MODULE_LICENSE("GPL v2");
  MODULE_DEVICE_TABLE(dmi, applesmc_whitelist);
 diff --git a/drivers/iommu/intel/dmar.c b/drivers/iommu/intel/dmar.c
-index e540092d664d..9e17e8e56308 100644
+index e540092d6..9e17e8e56 100644
 --- a/drivers/iommu/intel/dmar.c
 +++ b/drivers/iommu/intel/dmar.c
 @@ -1099,6 +1099,9 @@ static int alloc_iommu(struct dmar_drhd_unit *drhd)
@@ -28425,7 +28368,7 @@ index e540092d664d..9e17e8e56308 100644
  	kfree(iommu);
  }
 diff --git a/drivers/iommu/intel/iommu.c b/drivers/iommu/intel/iommu.c
-index ff07ee2940f5..a495aa76e5ee 100644
+index 91fe53d67..f80ca32f1 100644
 --- a/drivers/iommu/intel/iommu.c
 +++ b/drivers/iommu/intel/iommu.c
 @@ -1289,52 +1289,13 @@ static void iommu_disable_translation(struct intel_iommu *iommu)
@@ -28549,7 +28492,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  	kfree(info);
  	return ret;
  }
-@@ -1435,15 +1386,14 @@ void domain_detach_iommu(struct dmar_domain *domain, struct intel_iommu *iommu)
+@@ -1435,14 +1386,13 @@ void domain_detach_iommu(struct dmar_domain *domain, struct intel_iommu *iommu)
  	if (domain->domain.type == IOMMU_DOMAIN_SVA)
  		return;
  
@@ -28560,14 +28503,13 @@ index ff07ee2940f5..a495aa76e5ee 100644
 -		clear_bit(info->did, iommu->domain_ids);
 +		ida_free(&iommu->domain_ida, info->did);
  		xa_erase(&domain->iommu_array, iommu->seq_id);
- 		domain->nid = NUMA_NO_NODE;
  		kfree(info);
  	}
 -	spin_unlock(&iommu->lock);
  }
  
  static void domain_exit(struct dmar_domain *domain)
-@@ -1681,9 +1631,8 @@ __domain_mapping(struct dmar_domain *domain, unsigned long iov_pfn,
+@@ -1680,9 +1630,8 @@ __domain_mapping(struct dmar_domain *domain, unsigned long iov_pfn,
  	}
  
  	attr = prot & (DMA_PTE_READ | DMA_PTE_WRITE | DMA_PTE_SNP);
@@ -28578,7 +28520,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  		if (prot & DMA_PTE_WRITE)
  			attr |= DMA_FL_PTE_DIRTY;
  	}
-@@ -2043,7 +1992,7 @@ static int copy_context_table(struct intel_iommu *iommu,
+@@ -2056,7 +2005,7 @@ static int copy_context_table(struct intel_iommu *iommu,
  
  		did = context_domain_id(&ce);
  		if (did >= 0 && did < cap_ndoms(iommu->cap))
@@ -28587,7 +28529,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  
  		set_context_copied(iommu, bus, devfn);
  		new_ce[idx] = ce;
-@@ -2170,11 +2119,6 @@ static int __init init_dmars(void)
+@@ -2183,11 +2132,6 @@ static int __init init_dmars(void)
  		}
  
  		intel_iommu_init_qi(iommu);
@@ -28599,7 +28541,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  		init_translation_status(iommu);
  
  		if (translation_pre_enabled(iommu) && !is_kdump_kernel()) {
-@@ -2652,9 +2596,7 @@ static int intel_iommu_add(struct dmar_drhd_unit *dmaru)
+@@ -2665,9 +2609,7 @@ static int intel_iommu_add(struct dmar_drhd_unit *dmaru)
  	if (iommu->gcmd & DMA_GCMD_TE)
  		iommu_disable_translation(iommu);
  
@@ -28610,7 +28552,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  	if (ret)
  		goto out;
  
-@@ -2745,7 +2687,6 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
+@@ -2758,7 +2700,6 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
  	struct device *tmp;
  	int i;
  
@@ -28618,7 +28560,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  	rcu_read_lock();
  
  	list_for_each_entry_rcu(satcu, &dmar_satc_units, list) {
-@@ -2762,15 +2703,16 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
+@@ -2775,15 +2716,16 @@ static struct dmar_satc_unit *dmar_find_matched_satc_unit(struct pci_dev *dev)
  	return satcu;
  }
  
@@ -28640,7 +28582,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  
  	dev = pci_physfn(dev);
  	satcu = dmar_find_matched_satc_unit(dev);
-@@ -2788,11 +2730,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
+@@ -2801,11 +2743,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
  		bridge = bus->self;
  		/* If it's an integrated device, allow ATS */
  		if (!bridge)
@@ -28654,7 +28596,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  		/* If we found the root port, look it up in the ATSR */
  		if (pci_pcie_type(bridge) == PCI_EXP_TYPE_ROOT_PORT)
  			break;
-@@ -2811,11 +2753,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
+@@ -2824,11 +2766,11 @@ static int dmar_ats_supported(struct pci_dev *dev, struct intel_iommu *iommu)
  		if (atsru->include_all)
  			goto out;
  	}
@@ -28668,7 +28610,7 @@ index ff07ee2940f5..a495aa76e5ee 100644
  }
  
  int dmar_iommu_notify_scope_dev(struct dmar_pci_notify_info *info)
-@@ -2973,9 +2915,14 @@ static ssize_t domains_used_show(struct device *dev,
+@@ -2986,9 +2928,14 @@ static ssize_t domains_used_show(struct device *dev,
  				 struct device_attribute *attr, char *buf)
  {
  	struct intel_iommu *iommu = dev_to_intel_iommu(dev);
@@ -28687,10 +28629,10 @@ index ff07ee2940f5..a495aa76e5ee 100644
  static DEVICE_ATTR_RO(domains_used);
  
 diff --git a/drivers/iommu/intel/iommu.h b/drivers/iommu/intel/iommu.h
-index 814f5ed20018..a07a190c6d82 100644
+index 0f7cd96f1..910deecfe 100644
 --- a/drivers/iommu/intel/iommu.h
 +++ b/drivers/iommu/intel/iommu.h
-@@ -722,7 +722,9 @@ struct intel_iommu {
+@@ -725,7 +725,9 @@ struct intel_iommu {
  	unsigned char	name[16];    /* Device Name */
  
  #ifdef CONFIG_INTEL_IOMMU
@@ -28701,7 +28643,7 @@ index 814f5ed20018..a07a190c6d82 100644
  	unsigned long	*copied_tables; /* bitmap of copied tables */
  	spinlock_t	lock; /* protect context, domain ids */
  	struct root_entry *root_entry; /* virtual address */
-@@ -810,11 +812,22 @@ static inline struct dmar_domain *to_dmar_domain(struct iommu_domain *dom)
+@@ -813,11 +815,22 @@ static inline struct dmar_domain *to_dmar_domain(struct iommu_domain *dom)
  }
  
  /*
@@ -28728,7 +28670,7 @@ index 814f5ed20018..a07a190c6d82 100644
  /* Retrieve the domain ID which has allocated to the domain */
  static inline u16
 diff --git a/drivers/pci/vgaarb.c b/drivers/pci/vgaarb.c
-index 78748e8d2dba..2b2b558cebe6 100644
+index 78748e8d2..2b2b558ce 100644
 --- a/drivers/pci/vgaarb.c
 +++ b/drivers/pci/vgaarb.c
 @@ -143,6 +143,7 @@ void vga_set_default_device(struct pci_dev *pdev)
@@ -28740,7 +28682,7 @@ index 78748e8d2dba..2b2b558cebe6 100644
  /**
   * vga_remove_vgacon - deactivate VGA console
 diff --git a/drivers/platform/x86/apple-gmux.c b/drivers/platform/x86/apple-gmux.c
-index 1417e230edbd..e69785af8e1d 100644
+index 1417e230e..e69785af8 100644
 --- a/drivers/platform/x86/apple-gmux.c
 +++ b/drivers/platform/x86/apple-gmux.c
 @@ -21,6 +21,7 @@
@@ -28783,7 +28725,7 @@ index 1417e230edbd..e69785af8e1d 100644
  	 * Retina MacBook Pros cannot switch the panel's AUX separately
  	 * and need eDP pre-calibration. They are distinguishable from
 diff --git a/drivers/soc/apple/Kconfig b/drivers/soc/apple/Kconfig
-index 6388cbe1e56b..50f092732796 100644
+index 6388cbe1e..50f092732 100644
 --- a/drivers/soc/apple/Kconfig
 +++ b/drivers/soc/apple/Kconfig
 @@ -4,6 +4,16 @@ if ARCH_APPLE || COMPILE_TEST
@@ -28825,7 +28767,7 @@ index 6388cbe1e56b..50f092732796 100644
  	tristate "Apple SART DMA address filter"
  	depends on ARCH_APPLE || COMPILE_TEST
 diff --git a/drivers/soc/apple/Makefile b/drivers/soc/apple/Makefile
-index 4d9ab8f3037b..5e526a9edcf2 100644
+index 4d9ab8f30..5e526a9ed 100644
 --- a/drivers/soc/apple/Makefile
 +++ b/drivers/soc/apple/Makefile
 @@ -1,10 +1,16 @@
@@ -28847,7 +28789,7 @@ index 4d9ab8f3037b..5e526a9edcf2 100644
  apple-sart-y = sart.o
 diff --git a/drivers/soc/apple/dockchannel.c b/drivers/soc/apple/dockchannel.c
 new file mode 100644
-index 000000000000..3a0d7964007c
+index 000000000..3a0d79640
 --- /dev/null
 +++ b/drivers/soc/apple/dockchannel.c
 @@ -0,0 +1,406 @@
@@ -29259,7 +29201,7 @@ index 000000000000..3a0d7964007c
 +MODULE_DESCRIPTION("Apple DockChannel driver");
 diff --git a/drivers/soc/apple/rtkit-helper.c b/drivers/soc/apple/rtkit-helper.c
 new file mode 100644
-index 000000000000..080d083ed9bd
+index 000000000..080d083ed
 --- /dev/null
 +++ b/drivers/soc/apple/rtkit-helper.c
 @@ -0,0 +1,151 @@
@@ -29415,7 +29357,7 @@ index 000000000000..080d083ed9bd
 +MODULE_LICENSE("Dual MIT/GPL");
 +MODULE_DESCRIPTION("Apple RTKit helper driver");
 diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
-index 075e775d3868..e1cc0d60eeb6 100644
+index 075e775d3..e1cc0d60e 100644
 --- a/drivers/staging/Kconfig
 +++ b/drivers/staging/Kconfig
 @@ -50,4 +50,6 @@ source "drivers/staging/vme_user/Kconfig"
@@ -29426,7 +29368,7 @@ index 075e775d3868..e1cc0d60eeb6 100644
 +
  endif # STAGING
 diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
-index e681e403509c..4045c588b3b4 100644
+index e681e4035..4045c588b 100644
 --- a/drivers/staging/Makefile
 +++ b/drivers/staging/Makefile
 @@ -14,3 +14,4 @@ obj-$(CONFIG_GREYBUS)		+= greybus/
@@ -29436,7 +29378,7 @@ index e681e403509c..4045c588b3b4 100644
 +obj-$(CONFIG_APPLE_BCE)		+= apple-bce/
 diff --git a/drivers/staging/apple-bce/Kconfig b/drivers/staging/apple-bce/Kconfig
 new file mode 100644
-index 000000000000..fe92bc441e89
+index 000000000..fe92bc441
 --- /dev/null
 +++ b/drivers/staging/apple-bce/Kconfig
 @@ -0,0 +1,18 @@
@@ -29460,7 +29402,7 @@ index 000000000000..fe92bc441e89
 +	  If "M" is selected, the module will be called apple-bce.'
 diff --git a/drivers/staging/apple-bce/Makefile b/drivers/staging/apple-bce/Makefile
 new file mode 100644
-index 000000000000..8cfbd3f64af6
+index 000000000..8cfbd3f64
 --- /dev/null
 +++ b/drivers/staging/apple-bce/Makefile
 @@ -0,0 +1,28 @@
@@ -29494,7 +29436,7 @@ index 000000000000..8cfbd3f64af6
 +	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
 diff --git a/drivers/staging/apple-bce/apple_bce.c b/drivers/staging/apple-bce/apple_bce.c
 new file mode 100644
-index 000000000000..4fd2415d7028
+index 000000000..4fd2415d7
 --- /dev/null
 +++ b/drivers/staging/apple-bce/apple_bce.c
 @@ -0,0 +1,445 @@
@@ -29945,7 +29887,7 @@ index 000000000000..4fd2415d7028
 +module_exit(apple_bce_module_exit);
 diff --git a/drivers/staging/apple-bce/apple_bce.h b/drivers/staging/apple-bce/apple_bce.h
 new file mode 100644
-index 000000000000..58dbeff79e43
+index 000000000..58dbeff79
 --- /dev/null
 +++ b/drivers/staging/apple-bce/apple_bce.h
 @@ -0,0 +1,41 @@
@@ -29992,7 +29934,7 @@ index 000000000000..58dbeff79e43
 +#endif //APPLE_BCE_H
 diff --git a/drivers/staging/apple-bce/audio/audio.c b/drivers/staging/apple-bce/audio/audio.c
 new file mode 100644
-index 000000000000..bd16ddd16c1d
+index 000000000..bd16ddd16
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/audio.c
 @@ -0,0 +1,711 @@
@@ -30709,7 +30651,7 @@ index 000000000000..bd16ddd16c1d
 +MODULE_PARM_DESC(id, "ID string for Apple Internal Audio soundcard.");
 diff --git a/drivers/staging/apple-bce/audio/audio.h b/drivers/staging/apple-bce/audio/audio.h
 new file mode 100644
-index 000000000000..004bc1e22ea4
+index 000000000..004bc1e22
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/audio.h
 @@ -0,0 +1,125 @@
@@ -30840,7 +30782,7 @@ index 000000000000..004bc1e22ea4
 +#endif //AAUDIO_H
 diff --git a/drivers/staging/apple-bce/audio/description.h b/drivers/staging/apple-bce/audio/description.h
 new file mode 100644
-index 000000000000..dfef3ab68f27
+index 000000000..dfef3ab68
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/description.h
 @@ -0,0 +1,42 @@
@@ -30888,7 +30830,7 @@ index 000000000000..dfef3ab68f27
 +#endif //AAUDIO_DESCRIPTION_H
 diff --git a/drivers/staging/apple-bce/audio/pcm.c b/drivers/staging/apple-bce/audio/pcm.c
 new file mode 100644
-index 000000000000..1026e10a9ac5
+index 000000000..1026e10a9
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/pcm.c
 @@ -0,0 +1,308 @@
@@ -31202,7 +31144,7 @@ index 000000000000..1026e10a9ac5
 +}
 diff --git a/drivers/staging/apple-bce/audio/pcm.h b/drivers/staging/apple-bce/audio/pcm.h
 new file mode 100644
-index 000000000000..ea5f35fbe408
+index 000000000..ea5f35fbe
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/pcm.h
 @@ -0,0 +1,16 @@
@@ -31224,7 +31166,7 @@ index 000000000000..ea5f35fbe408
 +#endif //AAUDIO_PCM_H
 diff --git a/drivers/staging/apple-bce/audio/protocol.c b/drivers/staging/apple-bce/audio/protocol.c
 new file mode 100644
-index 000000000000..2314813aeead
+index 000000000..2314813ae
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol.c
 @@ -0,0 +1,347 @@
@@ -31578,7 +31520,7 @@ index 000000000000..2314813aeead
 \ No newline at end of file
 diff --git a/drivers/staging/apple-bce/audio/protocol.h b/drivers/staging/apple-bce/audio/protocol.h
 new file mode 100644
-index 000000000000..3427486f3f57
+index 000000000..3427486f3
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol.h
 @@ -0,0 +1,147 @@
@@ -31731,7 +31673,7 @@ index 000000000000..3427486f3f57
 +#endif //AAUDIO_PROTOCOL_H
 diff --git a/drivers/staging/apple-bce/audio/protocol_bce.c b/drivers/staging/apple-bce/audio/protocol_bce.c
 new file mode 100644
-index 000000000000..28f2dfd44d67
+index 000000000..28f2dfd44
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol_bce.c
 @@ -0,0 +1,226 @@
@@ -31963,7 +31905,7 @@ index 000000000000..28f2dfd44d67
 +}
 diff --git a/drivers/staging/apple-bce/audio/protocol_bce.h b/drivers/staging/apple-bce/audio/protocol_bce.h
 new file mode 100644
-index 000000000000..14d26c05ddf9
+index 000000000..14d26c05d
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/protocol_bce.h
 @@ -0,0 +1,72 @@
@@ -32041,7 +31983,7 @@ index 000000000000..14d26c05ddf9
 +#endif //AAUDIO_PROTOCOL_BCE_H
 diff --git a/drivers/staging/apple-bce/mailbox.c b/drivers/staging/apple-bce/mailbox.c
 new file mode 100644
-index 000000000000..07ce11928988
+index 000000000..07ce11928
 --- /dev/null
 +++ b/drivers/staging/apple-bce/mailbox.c
 @@ -0,0 +1,155 @@
@@ -32202,7 +32144,7 @@ index 000000000000..07ce11928988
 +}
 diff --git a/drivers/staging/apple-bce/mailbox.h b/drivers/staging/apple-bce/mailbox.h
 new file mode 100644
-index 000000000000..f3323f95ba51
+index 000000000..f3323f95b
 --- /dev/null
 +++ b/drivers/staging/apple-bce/mailbox.h
 @@ -0,0 +1,53 @@
@@ -32261,7 +32203,7 @@ index 000000000000..f3323f95ba51
 +#endif //BCEDRIVER_MAILBOX_H
 diff --git a/drivers/staging/apple-bce/queue.c b/drivers/staging/apple-bce/queue.c
 new file mode 100644
-index 000000000000..bc9cd3bc6f0c
+index 000000000..bc9cd3bc6
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue.c
 @@ -0,0 +1,390 @@
@@ -32658,7 +32600,7 @@ index 000000000000..bc9cd3bc6f0c
 \ No newline at end of file
 diff --git a/drivers/staging/apple-bce/queue.h b/drivers/staging/apple-bce/queue.h
 new file mode 100644
-index 000000000000..8368ac5dfca8
+index 000000000..8368ac5df
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue.h
 @@ -0,0 +1,177 @@
@@ -32841,7 +32783,7 @@ index 000000000000..8368ac5dfca8
 +#endif //BCEDRIVER_MAILBOX_H
 diff --git a/drivers/staging/apple-bce/queue_dma.c b/drivers/staging/apple-bce/queue_dma.c
 new file mode 100644
-index 000000000000..b236613285c0
+index 000000000..b23661328
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue_dma.c
 @@ -0,0 +1,220 @@
@@ -33068,7 +33010,7 @@ index 000000000000..b236613285c0
 \ No newline at end of file
 diff --git a/drivers/staging/apple-bce/queue_dma.h b/drivers/staging/apple-bce/queue_dma.h
 new file mode 100644
-index 000000000000..f8a57e50e7a3
+index 000000000..f8a57e50e
 --- /dev/null
 +++ b/drivers/staging/apple-bce/queue_dma.h
 @@ -0,0 +1,50 @@
@@ -33124,7 +33066,7 @@ index 000000000000..f8a57e50e7a3
 +#endif //BCE_QUEUE_DMA_H
 diff --git a/drivers/staging/apple-bce/vhci/command.h b/drivers/staging/apple-bce/vhci/command.h
 new file mode 100644
-index 000000000000..26619e0bccfa
+index 000000000..26619e0bc
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/command.h
 @@ -0,0 +1,204 @@
@@ -33334,7 +33276,7 @@ index 000000000000..26619e0bccfa
 +#endif //BCE_VHCI_COMMAND_H
 diff --git a/drivers/staging/apple-bce/vhci/queue.c b/drivers/staging/apple-bce/vhci/queue.c
 new file mode 100644
-index 000000000000..7b0b5027157b
+index 000000000..7b0b50271
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/queue.c
 @@ -0,0 +1,268 @@
@@ -33608,7 +33550,7 @@ index 000000000000..7b0b5027157b
 +}
 diff --git a/drivers/staging/apple-bce/vhci/queue.h b/drivers/staging/apple-bce/vhci/queue.h
 new file mode 100644
-index 000000000000..adb705b6ba1d
+index 000000000..adb705b6b
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/queue.h
 @@ -0,0 +1,76 @@
@@ -33690,7 +33632,7 @@ index 000000000000..adb705b6ba1d
 +#endif //BCE_VHCI_QUEUE_H
 diff --git a/drivers/staging/apple-bce/vhci/transfer.c b/drivers/staging/apple-bce/vhci/transfer.c
 new file mode 100644
-index 000000000000..d77220707492
+index 000000000..d77220707
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/transfer.c
 @@ -0,0 +1,673 @@
@@ -34369,7 +34311,7 @@ index 000000000000..d77220707492
 +}
 diff --git a/drivers/staging/apple-bce/vhci/transfer.h b/drivers/staging/apple-bce/vhci/transfer.h
 new file mode 100644
-index 000000000000..b5403d5703ed
+index 000000000..b5403d570
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/transfer.h
 @@ -0,0 +1,75 @@
@@ -34450,7 +34392,7 @@ index 000000000000..b5403d5703ed
 +#endif //BCEDRIVER_TRANSFER_H
 diff --git a/drivers/staging/apple-bce/vhci/vhci.c b/drivers/staging/apple-bce/vhci/vhci.c
 new file mode 100644
-index 000000000000..3394e0aa2eef
+index 000000000..3394e0aa2
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/vhci.c
 @@ -0,0 +1,763 @@
@@ -35219,7 +35161,7 @@ index 000000000000..3394e0aa2eef
 +MODULE_PARM_DESC(vhci_port_mask, "Specifies which VHCI ports are enabled");
 diff --git a/drivers/staging/apple-bce/vhci/vhci.h b/drivers/staging/apple-bce/vhci/vhci.h
 new file mode 100644
-index 000000000000..6c2e22622f4c
+index 000000000..6c2e22622
 --- /dev/null
 +++ b/drivers/staging/apple-bce/vhci/vhci.h
 @@ -0,0 +1,52 @@
@@ -35276,7 +35218,7 @@ index 000000000000..6c2e22622f4c
 +
 +#endif //BCE_VHCI_H
 diff --git a/include/linux/hid.h b/include/linux/hid.h
-index a1305210b2fd..98aad4880f84 100644
+index ababb7d41..82a849cdc 100644
 --- a/include/linux/hid.h
 +++ b/include/linux/hid.h
 @@ -594,7 +594,9 @@ struct hid_input {
@@ -35301,7 +35243,7 @@ index a1305210b2fd..98aad4880f84 100644
  	.report_type = (rep)
 diff --git a/include/linux/soc/apple/dockchannel.h b/include/linux/soc/apple/dockchannel.h
 new file mode 100644
-index 000000000000..0b7093935ddf
+index 000000000..0b7093935
 --- /dev/null
 +++ b/include/linux/soc/apple/dockchannel.h
 @@ -0,0 +1,26 @@
@@ -35332,7 +35274,7 @@ index 000000000000..0b7093935ddf
 +#endif
 +#endif
 diff --git a/lib/tests/printf_kunit.c b/lib/tests/printf_kunit.c
-index 2c9f6170bacd..bc54cca2d7a6 100644
+index 2c9f6170b..bc54cca2d 100644
 --- a/lib/tests/printf_kunit.c
 +++ b/lib/tests/printf_kunit.c
 @@ -701,21 +701,46 @@ static void fwnode_pointer(struct kunit *kunittest)
@@ -35390,7 +35332,7 @@ index 2c9f6170bacd..bc54cca2d7a6 100644
  
  static void
 diff --git a/lib/vsprintf.c b/lib/vsprintf.c
-index 01699852f30c..d8a2ec083ace 100644
+index 01699852f..d8a2ec083 100644
 --- a/lib/vsprintf.c
 +++ b/lib/vsprintf.c
 @@ -1793,27 +1793,49 @@ char *fourcc_string(char *buf, char *end, const u32 *fourcc,
@@ -35463,7 +35405,7 @@ index 01699852f30c..d8a2ec083ace 100644
   *            a certain separator (' ' by default):
   *              C colon
 diff --git a/scripts/checkpatch.pl b/scripts/checkpatch.pl
-index 784912f570e9..86adc23c851a 100755
+index 784912f57..86adc23c8 100755
 --- a/scripts/checkpatch.pl
 +++ b/scripts/checkpatch.pl
 @@ -6905,7 +6905,7 @@ sub process {
@@ -35475,6 +35417,3 @@ index 784912f570e9..86adc23c851a 100755
  						$bad_specifier = $specifier;
  						last;
  					}
--- 
-2.50.1
-

--- a/6.15/all/0001-cachyos-base-all.patch
+++ b/6.15/all/0001-cachyos-base-all.patch
@@ -1,7 +1,7 @@
-From 2d2b5a7fc5d45efd8066f9560dedfd57da82b0dc Mon Sep 17 00:00:00 2001
+From 9388ac844aa7a58ff39126c62a18b16f38535fa9 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:35 +0200
-Subject: [PATCH 1/7] amd-pstate
+Subject: [PATCH 1/6] amd-pstate
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
@@ -14,7 +14,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  6 files changed, 158 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/cpufreq/amd-pstate.c b/drivers/cpufreq/amd-pstate.c
-index b961f3a3b..12331e127 100644
+index b961f3a3b580..12331e127d96 100644
 --- a/drivers/cpufreq/amd-pstate.c
 +++ b/drivers/cpufreq/amd-pstate.c
 @@ -389,7 +389,8 @@ static inline int amd_pstate_cppc_enable(struct cpufreq_policy *policy)
@@ -247,7 +247,7 @@ index b961f3a3b..12331e127 100644
  	.update_limits	= amd_pstate_update_limits,
  	.set_boost	= amd_pstate_set_boost,
 diff --git a/drivers/cpufreq/amd-pstate.h b/drivers/cpufreq/amd-pstate.h
-index fbe1c08d3..2f7ae364d 100644
+index fbe1c08d3f06..2f7ae364d331 100644
 --- a/drivers/cpufreq/amd-pstate.h
 +++ b/drivers/cpufreq/amd-pstate.h
 @@ -30,6 +30,7 @@
@@ -267,7 +267,7 @@ index fbe1c08d3..2f7ae364d 100644
  	u64	val;
  };
 diff --git a/include/linux/sched/topology.h b/include/linux/sched/topology.h
-index 7b4301b72..198bb5cc1 100644
+index 7b4301b7235f..198bb5cc1774 100644
 --- a/include/linux/sched/topology.h
 +++ b/include/linux/sched/topology.h
 @@ -195,6 +195,8 @@ struct sched_domain_topology_level {
@@ -291,7 +291,7 @@ index 7b4301b72..198bb5cc1 100644
  
  #if defined(CONFIG_ENERGY_MODEL) && defined(CONFIG_CPU_FREQ_GOV_SCHEDUTIL)
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 56ae54e0c..557246880 100644
+index 56ae54e0ce6a..557246880a7e 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -588,6 +588,10 @@ static void register_sd(struct sched_domain *sd, struct dentry *parent)
@@ -306,7 +306,7 @@ index 56ae54e0c..557246880 100644
  
  void update_sched_domain_debugfs(void)
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 23264fe11..9bf6931c8 100644
+index 138d9f4658d5..1a1caae2b2f7 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -10267,7 +10267,7 @@ sched_group_asym(struct lb_env *env, struct sg_lb_stats *sgs, struct sched_group
@@ -329,7 +329,7 @@ index 23264fe11..9bf6931c8 100644
  	case group_misfit_task:
  		/*
 diff --git a/kernel/sched/topology.c b/kernel/sched/topology.c
-index f1ebc60d9..8426de317 100644
+index f1ebc60d967f..8426de317835 100644
 --- a/kernel/sched/topology.c
 +++ b/kernel/sched/topology.c
 @@ -1333,6 +1333,64 @@ static void init_sched_groups_capacity(int cpu, struct sched_domain *sd)
@@ -397,6 +397,9 @@ index f1ebc60d9..8426de317 100644
  /*
   * Set of available CPUs grouped by their corresponding capacities
   * Each list entry contains a CPU mask reflecting CPUs that share the same
+-- 
+2.50.1
+
 From dda5925222fd6d8f6236a3fb5d90b888c8dc3d67 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:22:48 +0200
@@ -11297,7 +11300,7 @@ index ed0e0f70f..ccfbd61bd 100644
  	}
  	spin_unlock(&dd->lock);
  
-From 121167381198a57897e6f2e408c7672835138ce6 Mon Sep 17 00:00:00 2001
+From 950ca5d450a2c5e8f0d4d829ddb26d69a3ae88ee Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:21 +0200
 Subject: [PATCH 5/7] cachy
@@ -11446,7 +11449,7 @@ index 76a34e0ae..186454e1c 100644
  				Safety option to keep boot IRQs enabled. This
  				should never be necessary.
 diff --git a/Documentation/admin-guide/sysctl/vm.rst b/Documentation/admin-guide/sysctl/vm.rst
-index 8290177b4..2a94faa5a 100644
+index 8290177b4..f2e601171 100644
 --- a/Documentation/admin-guide/sysctl/vm.rst
 +++ b/Documentation/admin-guide/sysctl/vm.rst
 @@ -25,6 +25,9 @@ files can be found in mm/swap.c.
@@ -11479,7 +11482,7 @@ index 8290177b4..2a94faa5a 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 1.
++The default value is 15.
 +
 +
 +clean_low_ratio
@@ -11500,7 +11503,7 @@ index 8290177b4..2a94faa5a 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 15.
++The default value is 0.
 +
 +
 +clean_min_ratio
@@ -11521,7 +11524,7 @@ index 8290177b4..2a94faa5a 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 4.
++The default value is 15.
 +
 +
  compact_memory
@@ -20379,7 +20382,7 @@ index 682f40d56..434a25f7b 100644
  static DEFINE_MUTEX(userns_state_mutex);
  
 diff --git a/mm/Kconfig b/mm/Kconfig
-index e113f713b..825b5932d 100644
+index e113f713b..5fc1934a3 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
 @@ -462,6 +462,69 @@ config ARCH_WANT_OPTIMIZE_HUGETLB_VMEMMAP
@@ -20390,7 +20393,7 @@ index e113f713b..825b5932d 100644
 +	int "Default value for vm.anon_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 1
++	default 15
 +	help
 +	  This option sets the default value for vm.anon_min_ratio sysctl knob.
 +
@@ -20408,7 +20411,7 @@ index e113f713b..825b5932d 100644
 +	int "Default value for vm.clean_low_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 15
++	default 0
 +	help
 +	  This option sets the default value for vm.clean_low_ratio sysctl knob.
 +
@@ -20430,7 +20433,7 @@ index e113f713b..825b5932d 100644
 +	int "Default value for vm.clean_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 4
++	default 15
 +	help
 +	  This option sets the default value for vm.clean_min_ratio sysctl knob.
 +
@@ -20494,14 +20497,14 @@ index 213780e73..b6278caf4 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index eedce9321..8201039f1 100644
+index eedce9321..4e5329337 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -2732,6 +2732,7 @@ static void __init mem_init_print_info(void)
  		, K(totalhigh_pages())
  #endif
  		);
-+	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15a by Masahito Suzuki (forked from hakavlad's original le9 patch)");
++	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15 by Masahito Suzuki (forked from hakavlad's original le9 patch)");
  }
  
  void __init __weak arch_mm_preinit(void)

--- a/6.15/all/0001-cachyos-base-all.patch
+++ b/6.15/all/0001-cachyos-base-all.patch
@@ -18838,17 +18838,17 @@ index 000000000..e70a381fe
 +	  will be called vhba.
 diff --git a/drivers/scsi/vhba/Makefile b/drivers/scsi/vhba/Makefile
 new file mode 100644
-index 000000000..2d7524b66
+index 000000000..560d24689
 --- /dev/null
 +++ b/drivers/scsi/vhba/Makefile
 @@ -0,0 +1,4 @@
-+VHBA_VERSION := 20240917
++VHBA_VERSION := 20250329
 +
 +obj-$(CONFIG_VHBA)		+= vhba.o
 +ccflags-y := -DVHBA_VERSION=\"$(VHBA_VERSION)\" -Werror
 diff --git a/drivers/scsi/vhba/vhba.c b/drivers/scsi/vhba/vhba.c
 new file mode 100644
-index 000000000..878a3be0b
+index 000000000..64b09ece2
 --- /dev/null
 +++ b/drivers/scsi/vhba/vhba.c
 @@ -0,0 +1,1132 @@
@@ -19391,10 +19391,10 @@ index 000000000..878a3be0b
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
 +    .slave_alloc = vhba_slave_alloc,
 +#endif
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
-+    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
-+#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 +    .tag_alloc_policy_rr = true,
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
++    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
 +#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
 +    .use_blk_tags = 1,
@@ -21047,7 +21047,7 @@ index be89921d6..01717ed0d 100644
  	if (ret >= sizeof(cmd_file)) {
  		error("%s: too long path was truncated\n", cmd_file);
  		return;
-From c4bb0154bfb5394712b248e5a5d2f8dadef6d63e Mon Sep 17 00:00:00 2001
+From e358ee87c12a5beb9aa99c4609fa35203bb38a2f Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Fri, 25 Jul 2025 20:24:47 +0200
 Subject: [PATCH 6/7] fixes
@@ -21066,12 +21066,13 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  drivers/i2c/busses/Kconfig                |   2 +-
  drivers/i2c/busses/i2c-piix4.c            |  18 +-
  drivers/platform/x86/amd/pmc/pmc-quirks.c |   3 +-
+ fs/proc/generic.c                         |  36 ++-
  include/linux/hid.h                       |   2 +
  scripts/Makefile.build                    |   4 +
  scripts/Makefile.lib                      |   5 +
  scripts/checkpatch.pl                     |  14 +
  scripts/package/PKGBUILD                  |   5 +
- 17 files changed, 542 insertions(+), 28 deletions(-)
+ 18 files changed, 561 insertions(+), 45 deletions(-)
  create mode 100644 Documentation/arch/x86/amd-debugging.rst
  create mode 100644 arch/x86/include/asm/amd/fch.h
 
@@ -21808,6 +21809,88 @@ index 04686ae1e..7bd0d5340 100644
  };
  
  static struct quirk_entry quirk_spurious_8042 = {
+diff --git a/fs/proc/generic.c b/fs/proc/generic.c
+index e0e50914a..8bc2b9606 100644
+--- a/fs/proc/generic.c
++++ b/fs/proc/generic.c
+@@ -364,6 +364,23 @@ static const struct inode_operations proc_dir_inode_operations = {
+ 	.setattr	= proc_notify_change,
+ };
+ 
++static void pde_set_flags(struct proc_dir_entry *pde)
++{
++	if (!pde->proc_ops)
++		return;
++
++	if (pde->proc_ops->proc_flags & PROC_ENTRY_PERMANENT)
++		pde->flags |= PROC_ENTRY_PERMANENT;
++	if (pde->proc_ops->proc_read_iter)
++		pde->flags |= PROC_ENTRY_proc_read_iter;
++#ifdef CONFIG_COMPAT
++	if (pde->proc_ops->proc_compat_ioctl)
++		pde->flags |= PROC_ENTRY_proc_compat_ioctl;
++#endif
++	if (pde->proc_ops->proc_lseek)
++		pde->flags |= PROC_ENTRY_proc_lseek;
++}
++
+ /* returns the registered entry, or frees dp and returns NULL on failure */
+ struct proc_dir_entry *proc_register(struct proc_dir_entry *dir,
+ 		struct proc_dir_entry *dp)
+@@ -371,6 +388,8 @@ struct proc_dir_entry *proc_register(struct proc_dir_entry *dir,
+ 	if (proc_alloc_inum(&dp->low_ino))
+ 		goto out_free_entry;
+ 
++	pde_set_flags(dp);
++
+ 	write_lock(&proc_subdir_lock);
+ 	dp->parent = dir;
+ 	if (pde_subdir_insert(dir, dp) == false) {
+@@ -559,20 +578,6 @@ struct proc_dir_entry *proc_create_reg(const char *name, umode_t mode,
+ 	return p;
+ }
+ 
+-static void pde_set_flags(struct proc_dir_entry *pde)
+-{
+-	if (pde->proc_ops->proc_flags & PROC_ENTRY_PERMANENT)
+-		pde->flags |= PROC_ENTRY_PERMANENT;
+-	if (pde->proc_ops->proc_read_iter)
+-		pde->flags |= PROC_ENTRY_proc_read_iter;
+-#ifdef CONFIG_COMPAT
+-	if (pde->proc_ops->proc_compat_ioctl)
+-		pde->flags |= PROC_ENTRY_proc_compat_ioctl;
+-#endif
+-	if (pde->proc_ops->proc_lseek)
+-		pde->flags |= PROC_ENTRY_proc_lseek;
+-}
+-
+ struct proc_dir_entry *proc_create_data(const char *name, umode_t mode,
+ 		struct proc_dir_entry *parent,
+ 		const struct proc_ops *proc_ops, void *data)
+@@ -583,7 +588,6 @@ struct proc_dir_entry *proc_create_data(const char *name, umode_t mode,
+ 	if (!p)
+ 		return NULL;
+ 	p->proc_ops = proc_ops;
+-	pde_set_flags(p);
+ 	return proc_register(parent, p);
+ }
+ EXPORT_SYMBOL(proc_create_data);
+@@ -634,7 +638,6 @@ struct proc_dir_entry *proc_create_seq_private(const char *name, umode_t mode,
+ 	p->proc_ops = &proc_seq_ops;
+ 	p->seq_ops = ops;
+ 	p->state_size = state_size;
+-	pde_set_flags(p);
+ 	return proc_register(parent, p);
+ }
+ EXPORT_SYMBOL(proc_create_seq_private);
+@@ -665,7 +668,6 @@ struct proc_dir_entry *proc_create_single_data(const char *name, umode_t mode,
+ 		return NULL;
+ 	p->proc_ops = &proc_single_ops;
+ 	p->single_show = show;
+-	pde_set_flags(p);
+ 	return proc_register(parent, p);
+ }
+ EXPORT_SYMBOL(proc_create_single_data);
 diff --git a/include/linux/hid.h b/include/linux/hid.h
 index ada27535a..ababb7d41 100644
 --- a/include/linux/hid.h

--- a/6.15/misc/0001-aufs-6.15-merge-v20250821.patch
+++ b/6.15/misc/0001-aufs-6.15-merge-v20250821.patch
@@ -1,6 +1,6 @@
-From 5f3c274dee3bed1dba152518dd4c9335ea686e11 Mon Sep 17 00:00:00 2001
-From: Yang Kun <193369907+nukyan@users.noreply.github.com>
-Date: Tue, 3 Jun 2025 08:36:51 +0200
+From a14e369299fc725e90462332c891d3b9b0454c2f Mon Sep 17 00:00:00 2001
+From: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Date: Mon, 16 Jun 2025 15:29:18 +0200
 Subject: [PATCH] aufs-6.15: merge v20250821
 
 ---
@@ -2009,7 +2009,7 @@ index dd844ac8d..845564059 100644
  M:	Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  R:	Dave Ertman <david.m.ertman@intel.com>
 diff --git a/drivers/block/loop.c b/drivers/block/loop.c
-index 399905687..7822a6ebb 100644
+index 8220521b9..b5d293b6c 100644
 --- a/drivers/block/loop.c
 +++ b/drivers/block/loop.c
 @@ -620,6 +620,26 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
@@ -37837,7 +37837,7 @@ index c6e7ebc63..d7ccfd909 100644
  		ino = inode->i_ino;
  	}
 diff --git a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
-index e57e32381..d0413f8e7 100644
+index 3b8eaa772..35ec92e6e 100644
 --- a/fs/proc/task_mmu.c
 +++ b/fs/proc/task_mmu.c
 @@ -264,7 +264,8 @@ static void get_vma_name(struct vm_area_struct *vma,
@@ -37860,7 +37860,7 @@ index e57e32381..d0413f8e7 100644
  
  		dev = inode->i_sb->s_dev;
  		ino = inode->i_ino;
-@@ -3034,7 +3036,7 @@ static int show_numa_map(struct seq_file *m, void *v)
+@@ -3038,7 +3040,7 @@ static int show_numa_map(struct seq_file *m, void *v)
  	struct proc_maps_private *proc_priv = &numa_priv->proc_maps;
  	struct vm_area_struct *vma = v;
  	struct numa_maps *md = &numa_priv->md;

--- a/6.15/misc/0001-aufs-6.15-merge-v20250821.patch
+++ b/6.15/misc/0001-aufs-6.15-merge-v20250821.patch
@@ -1,139 +1,128 @@
-From 53f868f9340f182f7ad3b457f23b895a9886cdd8 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
+From 5f3c274dee3bed1dba152518dd4c9335ea686e11 Mon Sep 17 00:00:00 2001
+From: Yang Kun <193369907+nukyan@users.noreply.github.com>
 Date: Tue, 3 Jun 2025 08:36:51 +0200
-Subject: [PATCH] aufs-6.15: merge v20250602
+Subject: [PATCH] aufs-6.15: merge v20250821
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  Documentation/ABI/testing/debugfs-aufs        |   55 +
  Documentation/ABI/testing/sysfs-aufs          |   31 +
  Documentation/filesystems/aufs/README         |  409 ++++
- .../filesystems/aufs/design/01intro.txt       |  171 ++
- .../filesystems/aufs/design/02struct.txt      |  258 +++
- .../filesystems/aufs/design/03atomic_open.txt |   85 +
- .../filesystems/aufs/design/03lookup.txt      |  113 +
- .../filesystems/aufs/design/04branch.txt      |   74 +
- .../filesystems/aufs/design/05wbr_policy.txt  |   64 +
- .../filesystems/aufs/design/06dirren.dot      |   44 +
- .../filesystems/aufs/design/06dirren.txt      |  102 +
- .../filesystems/aufs/design/06fhsm.txt        |  118 +
- .../filesystems/aufs/design/06mmap.txt        |   72 +
- .../filesystems/aufs/design/06xattr.txt       |   94 +
- .../filesystems/aufs/design/07export.txt      |   58 +
- .../filesystems/aufs/design/08shwh.txt        |   52 +
- .../filesystems/aufs/design/10dynop.txt       |   47 +
+ .../filesystems/aufs/design/01intro.txt       |  158 ++
+ .../filesystems/aufs/design/02struct.txt      |  245 +++
+ .../filesystems/aufs/design/03atomic_open.txt |   72 +
+ .../filesystems/aufs/design/03lookup.txt      |  100 +
+ .../filesystems/aufs/design/04branch.txt      |   61 +
+ .../filesystems/aufs/design/05wbr_policy.txt  |   51 +
+ .../filesystems/aufs/design/06dirren.dot      |   31 +
+ .../filesystems/aufs/design/06dirren.txt      |   89 +
+ .../filesystems/aufs/design/06fhsm.txt        |  105 +
+ .../filesystems/aufs/design/06mmap.txt        |   59 +
+ .../filesystems/aufs/design/06xattr.txt       |   81 +
+ .../filesystems/aufs/design/07export.txt      |   45 +
+ .../filesystems/aufs/design/08shwh.txt        |   39 +
+ .../filesystems/aufs/design/10dynop.txt       |   34 +
  MAINTAINERS                                   |   13 +
- drivers/block/loop.c                          |   62 +-
+ drivers/block/loop.c                          |   20 +
  fs/Kconfig                                    |    1 +
  fs/Makefile                                   |    1 +
  fs/aufs/Kconfig                               |  201 ++
- fs/aufs/Makefile                              |   47 +
- fs/aufs/aufs.h                                |   62 +
- fs/aufs/branch.c                              | 1427 ++++++++++++
- fs/aufs/branch.h                              |  375 ++++
- fs/aufs/conf.mk                               |   40 +
- fs/aufs/cpup.c                                | 1466 +++++++++++++
- fs/aufs/cpup.h                                |  101 +
- fs/aufs/dbgaufs.c                             |  525 +++++
- fs/aufs/dbgaufs.h                             |   53 +
- fs/aufs/dcsub.c                               |  225 ++
- fs/aufs/dcsub.h                               |  139 ++
- fs/aufs/debug.c                               |  448 ++++
- fs/aufs/debug.h                               |  226 ++
- fs/aufs/dentry.c                              | 1228 +++++++++++
- fs/aufs/dentry.h                              |  270 +++
- fs/aufs/dinfo.c                               |  555 +++++
- fs/aufs/dir.c                                 |  765 +++++++
- fs/aufs/dir.h                                 |  134 ++
- fs/aufs/dirren.c                              | 1315 +++++++++++
- fs/aufs/dirren.h                              |  140 ++
- fs/aufs/dynop.c                               |  365 ++++
- fs/aufs/dynop.h                               |   77 +
- fs/aufs/export.c                              |  846 ++++++++
- fs/aufs/f_op.c                                |  782 +++++++
- fs/aufs/fhsm.c                                |  426 ++++
- fs/aufs/file.c                                |  858 ++++++++
- fs/aufs/file.h                                |  342 +++
- fs/aufs/finfo.c                               |  147 ++
- fs/aufs/fsctx.c                               | 1244 +++++++++++
- fs/aufs/fstype.h                              |  419 ++++
- fs/aufs/hbl.h                                 |   65 +
- fs/aufs/hfsnotify.c                           |  290 +++
- fs/aufs/hfsplus.c                             |   60 +
- fs/aufs/hnotify.c                             |  715 ++++++
- fs/aufs/i_op.c                                | 1522 +++++++++++++
- fs/aufs/i_op_add.c                            |  979 +++++++++
- fs/aufs/i_op_del.c                            |  523 +++++
- fs/aufs/i_op_ren.c                            | 1264 +++++++++++
- fs/aufs/iinfo.c                               |  287 +++
- fs/aufs/inode.c                               |  532 +++++
- fs/aufs/inode.h                               |  727 +++++++
- fs/aufs/ioctl.c                               |  220 ++
- fs/aufs/lcnt.h                                |  186 ++
- fs/aufs/loop.c                                |  164 ++
- fs/aufs/loop.h                                |   59 +
+ fs/aufs/Makefile                              |   40 +
+ fs/aufs/aufs.h                                |   49 +
+ fs/aufs/branch.c                              | 1414 ++++++++++++
+ fs/aufs/branch.h                              |  362 ++++
+ fs/aufs/cpup.c                                | 1453 +++++++++++++
+ fs/aufs/cpup.h                                |   88 +
+ fs/aufs/dbgaufs.c                             |  512 +++++
+ fs/aufs/dbgaufs.h                             |   40 +
+ fs/aufs/dcsub.c                               |  212 ++
+ fs/aufs/dcsub.h                               |  126 ++
+ fs/aufs/debug.c                               |  435 ++++
+ fs/aufs/debug.h                               |  213 ++
+ fs/aufs/dentry.c                              | 1215 +++++++++++
+ fs/aufs/dentry.h                              |  257 +++
+ fs/aufs/dinfo.c                               |  542 +++++
+ fs/aufs/dir.c                                 |  752 +++++++
+ fs/aufs/dir.h                                 |  121 ++
+ fs/aufs/dirren.c                              | 1302 +++++++++++
+ fs/aufs/dirren.h                              |  127 ++
+ fs/aufs/dynop.c                               |  352 +++
+ fs/aufs/dynop.h                               |   64 +
+ fs/aufs/export.c                              |  833 +++++++
+ fs/aufs/f_op.c                                |  769 +++++++
+ fs/aufs/fhsm.c                                |  413 ++++
+ fs/aufs/file.c                                |  845 ++++++++
+ fs/aufs/file.h                                |  329 +++
+ fs/aufs/finfo.c                               |  134 ++
+ fs/aufs/fsctx.c                               | 1231 +++++++++++
+ fs/aufs/fstype.h                              |  406 ++++
+ fs/aufs/hbl.h                                 |   52 +
+ fs/aufs/hfsnotify.c                           |  277 +++
+ fs/aufs/hfsplus.c                             |   47 +
+ fs/aufs/hnotify.c                             |  702 ++++++
+ fs/aufs/i_op.c                                | 1509 +++++++++++++
+ fs/aufs/i_op_add.c                            |  966 +++++++++
+ fs/aufs/i_op_del.c                            |  510 +++++
+ fs/aufs/i_op_ren.c                            | 1251 +++++++++++
+ fs/aufs/iinfo.c                               |  274 +++
+ fs/aufs/inode.c                               |  519 +++++
+ fs/aufs/inode.h                               |  714 ++++++
+ fs/aufs/ioctl.c                               |  207 ++
+ fs/aufs/lcnt.h                                |  173 ++
+ fs/aufs/loop.c                                |  135 ++
+ fs/aufs/loop.h                                |   42 +
  fs/aufs/magic.mk                              |   31 +
- fs/aufs/module.c                              |  275 +++
- fs/aufs/module.h                              |  180 ++
- fs/aufs/mvdown.c                              |  714 ++++++
- fs/aufs/opts.c                                | 1030 +++++++++
- fs/aufs/opts.h                                |  264 +++
- fs/aufs/plink.c                               |  516 +++++
- fs/aufs/poll.c                                |   51 +
- fs/aufs/posix_acl.c                           |  108 +
- fs/aufs/procfs.c                              |  168 ++
- fs/aufs/rdu.c                                 |  384 ++++
- fs/aufs/rwsem.h                               |   89 +
- fs/aufs/sbinfo.c                              |  316 +++
- fs/aufs/super.c                               |  875 ++++++++
- fs/aufs/super.h                               |  618 ++++++
- fs/aufs/sysaufs.c                             |   94 +
- fs/aufs/sysaufs.h                             |  102 +
- fs/aufs/sysfs.c                               |  374 ++++
- fs/aufs/sysrq.c                               |  157 ++
- fs/aufs/vdir.c                                |  896 ++++++++
- fs/aufs/vfsub.c                               |  971 +++++++++
- fs/aufs/vfsub.h                               |  441 ++++
- fs/aufs/wbr_policy.c                          |  835 +++++++
- fs/aufs/whout.c                               | 1096 ++++++++++
- fs/aufs/whout.h                               |   87 +
- fs/aufs/wkq.c                                 |  370 ++++
- fs/aufs/wkq.h                                 |   89 +
- fs/aufs/xattr.c                               |  360 +++
- fs/aufs/xino.c                                | 1926 +++++++++++++++++
- fs/dcache.c                                   |    7 +-
- fs/exec.c                                     |    1 +
- fs/fcntl.c                                    |    5 +-
- fs/file_table.c                               |    1 +
- fs/namespace.c                                |   10 +
- fs/notify/fsnotify.c                          |    1 +
- fs/notify/group.c                             |    1 +
- fs/open.c                                     |    1 +
+ fs/aufs/module.c                              |  261 +++
+ fs/aufs/module.h                              |  167 ++
+ fs/aufs/mvdown.c                              |  701 ++++++
+ fs/aufs/opts.c                                | 1017 +++++++++
+ fs/aufs/opts.h                                |  251 +++
+ fs/aufs/plink.c                               |  503 +++++
+ fs/aufs/poll.c                                |   38 +
+ fs/aufs/posix_acl.c                           |   95 +
+ fs/aufs/procfs.c                              |  155 ++
+ fs/aufs/rdu.c                                 |  371 ++++
+ fs/aufs/rwsem.h                               |   76 +
+ fs/aufs/sbinfo.c                              |  303 +++
+ fs/aufs/super.c                               |  859 ++++++++
+ fs/aufs/super.h                               |  605 ++++++
+ fs/aufs/sysaufs.c                             |   81 +
+ fs/aufs/sysaufs.h                             |   89 +
+ fs/aufs/sysfs.c                               |  338 +++
+ fs/aufs/sysrq.c                               |  144 ++
+ fs/aufs/vdir.c                                |  883 ++++++++
+ fs/aufs/vfsub.c                               |  958 +++++++++
+ fs/aufs/vfsub.h                               |  428 ++++
+ fs/aufs/wbr_policy.c                          |  822 +++++++
+ fs/aufs/whout.c                               | 1083 ++++++++++
+ fs/aufs/whout.h                               |   74 +
+ fs/aufs/wkq.c                                 |  357 +++
+ fs/aufs/wkq.h                                 |   76 +
+ fs/aufs/xattr.c                               |  347 +++
+ fs/aufs/xino.c                                | 1913 +++++++++++++++++
+ fs/dcache.c                                   |    5 +-
+ fs/fcntl.c                                    |    4 +-
+ fs/namespace.c                                |    6 +
  fs/proc/base.c                                |    2 +-
  fs/proc/nommu.c                               |    5 +-
  fs/proc/task_mmu.c                            |    8 +-
  fs/proc/task_nommu.c                          |    5 +-
- fs/read_write.c                               |    2 +
- fs/splice.c                                   |    3 +-
- fs/xattr.c                                    |    1 +
- include/linux/fs.h                            |    7 +
+ fs/splice.c                                   |    2 +-
+ include/linux/fs.h                            |    2 +
  include/linux/lockdep.h                       |    2 +
  include/linux/mm.h                            |   48 +
  include/linux/mm_types.h                      |    6 +
  include/linux/mnt_namespace.h                 |    3 +
  include/linux/splice.h                        |    3 +
- include/uapi/linux/aufs_type.h                |  452 ++++
+ include/uapi/linux/aufs_type.h                |  439 ++++
  kernel/fork.c                                 |    3 +-
- kernel/locking/lockdep.c                      |    4 +-
- kernel/task_work.c                            |    1 +
+ kernel/locking/lockdep.c                      |    3 +-
  mm/Makefile                                   |    1 +
  mm/filemap.c                                  |    2 +-
  mm/mmap.c                                     |   27 +-
  mm/nommu.c                                    |   10 +-
  mm/prfile.c                                   |   86 +
  mm/vma.c                                      |   10 +-
- security/security.c                           |    8 +
- 128 files changed, 38882 insertions(+), 26 deletions(-)
+ 118 files changed, 37598 insertions(+), 25 deletions(-)
  create mode 100644 Documentation/ABI/testing/debugfs-aufs
  create mode 100644 Documentation/ABI/testing/sysfs-aufs
  create mode 100644 Documentation/filesystems/aufs/README
@@ -156,7 +145,6 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  create mode 100644 fs/aufs/aufs.h
  create mode 100644 fs/aufs/branch.c
  create mode 100644 fs/aufs/branch.h
- create mode 100644 fs/aufs/conf.mk
  create mode 100644 fs/aufs/cpup.c
  create mode 100644 fs/aufs/cpup.h
  create mode 100644 fs/aufs/dbgaufs.c
@@ -744,25 +732,12 @@ index 000000000..559fbe0d0
 +# End: ;
 diff --git a/Documentation/filesystems/aufs/design/01intro.txt b/Documentation/filesystems/aufs/design/01intro.txt
 new file mode 100644
-index 000000000..a22a37bad
+index 000000000..1627d9386
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/01intro.txt
-@@ -0,0 +1,171 @@
+@@ -0,0 +1,158 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Introduction
 +----------------------------------------
@@ -921,25 +896,12 @@ index 000000000..a22a37bad
 +about it. But currently I have implemented it in kernel space.
 diff --git a/Documentation/filesystems/aufs/design/02struct.txt b/Documentation/filesystems/aufs/design/02struct.txt
 new file mode 100644
-index 000000000..e89dc7122
+index 000000000..b6d3e6f87
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/02struct.txt
-@@ -0,0 +1,258 @@
+@@ -0,0 +1,245 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Basic Aufs Internal Structure
 +
@@ -1185,25 +1147,12 @@ index 000000000..e89dc7122
 +For this purpose, use "aumvdown" command in aufs-util.git.
 diff --git a/Documentation/filesystems/aufs/design/03atomic_open.txt b/Documentation/filesystems/aufs/design/03atomic_open.txt
 new file mode 100644
-index 000000000..0401e8923
+index 000000000..374d8c756
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/03atomic_open.txt
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,72 @@
 +
 +# Copyright (C) 2015-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Support for a branch who has its ->atomic_open()
 +----------------------------------------------------------------------
@@ -1276,25 +1225,12 @@ index 000000000..0401e8923
 +       be implemented in aufs, but not all I am afraid.
 diff --git a/Documentation/filesystems/aufs/design/03lookup.txt b/Documentation/filesystems/aufs/design/03lookup.txt
 new file mode 100644
-index 000000000..35efe7079
+index 000000000..dad7a4a27
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/03lookup.txt
-@@ -0,0 +1,113 @@
+@@ -0,0 +1,100 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Lookup in a Branch
 +----------------------------------------------------------------------
@@ -1395,25 +1331,12 @@ index 000000000..35efe7079
 +   by over-mounting something (or another method).
 diff --git a/Documentation/filesystems/aufs/design/04branch.txt b/Documentation/filesystems/aufs/design/04branch.txt
 new file mode 100644
-index 000000000..0286ccdfc
+index 000000000..a48a1adbb
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/04branch.txt
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,61 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Branch Manipulation
 +
@@ -1475,25 +1398,12 @@ index 000000000..0286ccdfc
 +    same named entry on the upper branch.
 diff --git a/Documentation/filesystems/aufs/design/05wbr_policy.txt b/Documentation/filesystems/aufs/design/05wbr_policy.txt
 new file mode 100644
-index 000000000..0eeb6ee21
+index 000000000..c04c62a8b
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/05wbr_policy.txt
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,51 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Policies to Select One among Multiple Writable Branches
 +----------------------------------------------------------------------
@@ -1545,25 +1455,12 @@ index 000000000..0eeb6ee21
 +  copyup policy.
 diff --git a/Documentation/filesystems/aufs/design/06dirren.dot b/Documentation/filesystems/aufs/design/06dirren.dot
 new file mode 100644
-index 000000000..4e6c7e7c2
+index 000000000..2d62bb6dd
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06dirren.dot
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,31 @@
 +
 +// to view this graph, run dot(1) command in GRAPHVIZ.
-+//
-+// This program is free software; you can redistribute it and/or modify
-+// it under the terms of the GNU General Public License as published by
-+// the Free Software Foundation; either version 2 of the License, or
-+// (at your option) any later version.
-+//
-+// This program is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+//
-+// You should have received a copy of the GNU General Public License
-+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +digraph G {
 +node [shape=box];
@@ -1595,25 +1492,12 @@ index 000000000..4e6c7e7c2
 +}
 diff --git a/Documentation/filesystems/aufs/design/06dirren.txt b/Documentation/filesystems/aufs/design/06dirren.txt
 new file mode 100644
-index 000000000..6b305def6
+index 000000000..cde6c2d6a
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06dirren.txt
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,89 @@
 +
 +# Copyright (C) 2017-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Special handling for renaming a directory (DIRREN)
 +----------------------------------------------------------------------
@@ -1703,25 +1587,12 @@ index 000000000..6b305def6
 +equivalen to udba=reval case.
 diff --git a/Documentation/filesystems/aufs/design/06fhsm.txt b/Documentation/filesystems/aufs/design/06fhsm.txt
 new file mode 100644
-index 000000000..edb1b765b
+index 000000000..be1fa5aee
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06fhsm.txt
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,105 @@
 +
 +# Copyright (C) 2011-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +File-based Hierarchical Storage Management (FHSM)
 +----------------------------------------------------------------------
@@ -1827,25 +1698,12 @@ index 000000000..edb1b765b
 +should restore the original file state after an error happens.
 diff --git a/Documentation/filesystems/aufs/design/06mmap.txt b/Documentation/filesystems/aufs/design/06mmap.txt
 new file mode 100644
-index 000000000..9b1c4806c
+index 000000000..4a294102c
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06mmap.txt
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,59 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +mmap(2) -- File Memory Mapping
 +----------------------------------------------------------------------
@@ -1905,25 +1763,12 @@ index 000000000..9b1c4806c
 +I have to give up this "looks-smater" approach.
 diff --git a/Documentation/filesystems/aufs/design/06xattr.txt b/Documentation/filesystems/aufs/design/06xattr.txt
 new file mode 100644
-index 000000000..354a8e28d
+index 000000000..974c323b1
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06xattr.txt
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,81 @@
 +
 +# Copyright (C) 2014-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Listing XATTR/EA and getting the value
 +----------------------------------------------------------------------
@@ -2005,25 +1850,12 @@ index 000000000..354a8e28d
 +now, aufs implements the branch attributes to ignore the error.
 diff --git a/Documentation/filesystems/aufs/design/07export.txt b/Documentation/filesystems/aufs/design/07export.txt
 new file mode 100644
-index 000000000..317f84e09
+index 000000000..34e45e4a9
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/07export.txt
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,45 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Export Aufs via NFS
 +----------------------------------------------------------------------
@@ -2069,25 +1901,12 @@ index 000000000..317f84e09
 +  lookup_one_len(), vfs_getattr(), encode_fh() and others.
 diff --git a/Documentation/filesystems/aufs/design/08shwh.txt b/Documentation/filesystems/aufs/design/08shwh.txt
 new file mode 100644
-index 000000000..4c7d0b4ab
+index 000000000..3cfb56884
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/08shwh.txt
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,39 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Show Whiteout Mode (shwh)
 +----------------------------------------------------------------------
@@ -2127,25 +1946,12 @@ index 000000000..4c7d0b4ab
 +initramfs will use it to replace the old one at the next boot.
 diff --git a/Documentation/filesystems/aufs/design/10dynop.txt b/Documentation/filesystems/aufs/design/10dynop.txt
 new file mode 100644
-index 000000000..973d8d190
+index 000000000..12a4f2ab4
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/10dynop.txt
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,34 @@
 +
 +# Copyright (C) 2010-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Dynamically customizable FS operations
 +----------------------------------------------------------------------
@@ -2203,88 +2009,10 @@ index dd844ac8d..845564059 100644
  M:	Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  R:	Dave Ertman <david.m.ertman@intel.com>
 diff --git a/drivers/block/loop.c b/drivers/block/loop.c
-index e2b1f377f..a16d0b2d7 100644
+index 399905687..7822a6ebb 100644
 --- a/drivers/block/loop.c
 +++ b/drivers/block/loop.c
-@@ -52,7 +52,7 @@ struct loop_device {
- 	int		lo_flags;
- 	char		lo_file_name[LO_NAME_SIZE];
- 
--	struct file	*lo_backing_file;
-+	struct file	*lo_backing_file, *lo_backing_virt_file;
- 	unsigned int	lo_min_dio_size;
- 	struct block_device *lo_device;
- 
-@@ -428,6 +428,15 @@ static int do_req_filebacked(struct loop_device *lo, struct request *rq)
- 	}
- }
- 
-+static struct file *loop_real_file(struct file *file)
-+{
-+	struct file *f = NULL;
-+
-+	if (file->f_path.dentry->d_sb->s_op->real_loop)
-+		f = file->f_path.dentry->d_sb->s_op->real_loop(file);
-+	return f;
-+}
-+
- static void loop_reread_partitions(struct loop_device *lo)
- {
- 	int rc;
-@@ -529,6 +538,7 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- {
- 	struct file *file = fget(arg);
- 	struct file *old_file;
-+	struct file *f, *virt_file = NULL, *old_virt_file;
- 	unsigned int memflags;
- 	int error;
- 	bool partscan;
-@@ -557,11 +567,19 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	if (!(lo->lo_flags & LO_FLAGS_READ_ONLY))
- 		goto out_err;
- 
-+	f = loop_real_file(file);
-+	if (f) {
-+		virt_file = file;
-+		file = f;
-+		get_file(file);
-+	}
-+
- 	error = loop_validate_file(file, bdev);
- 	if (error)
- 		goto out_err;
- 
- 	old_file = lo->lo_backing_file;
-+	old_virt_file = lo->lo_backing_virt_file;
- 
- 	error = -EINVAL;
- 
-@@ -581,6 +599,7 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	memflags = blk_mq_freeze_queue(lo->lo_queue);
- 	mapping_set_gfp_mask(old_file->f_mapping, lo->old_gfp_mask);
- 	loop_assign_backing_file(lo, file);
-+	lo->lo_backing_virt_file = virt_file;
- 	loop_update_dio(lo);
- 	blk_mq_unfreeze_queue(lo->lo_queue, memflags);
- 	partscan = lo->lo_flags & LO_FLAGS_PARTSCAN;
-@@ -600,6 +619,9 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	 * dependency.
- 	 */
- 	fput(old_file);
-+	if (old_virt_file)
-+		fput(old_virt_file);
-+
- 	dev_set_uevent_suppress(disk_to_dev(lo->lo_disk), 0);
- 	if (partscan)
- 		loop_reread_partitions(lo);
-@@ -613,10 +635,33 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	loop_global_unlock(lo, is_loop);
- out_putf:
- 	fput(file);
-+	if (virt_file)
-+		fput(virt_file);
-+
- 	dev_set_uevent_suppress(disk_to_dev(lo->lo_disk), 0);
+@@ -620,6 +620,26 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
  	goto done;
  }
  
@@ -2311,68 +2039,6 @@ index e2b1f377f..a16d0b2d7 100644
  /* loop sysfs attributes */
  
  static ssize_t loop_attr_show(struct device *dev, char *page,
-@@ -970,6 +1015,7 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 			  const struct loop_config *config)
- {
- 	struct file *file = fget(config->fd);
-+	struct file *f, *virt_file = NULL;
- 	struct queue_limits lim;
- 	int error;
- 	loff_t size;
-@@ -988,6 +1034,13 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 	/* This is safe, since we have a reference from open(). */
- 	__module_get(THIS_MODULE);
- 
-+	f = loop_real_file(file);
-+	if (f) {
-+		virt_file = file;
-+		file = f;
-+		get_file(file);
-+	}
-+
- 	/*
- 	 * If we don't hold exclusive handle for the device, upgrade to it
- 	 * here to avoid changing device under exclusive owner.
-@@ -1042,6 +1095,7 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 
- 	lo->lo_device = bdev;
- 	loop_assign_backing_file(lo, file);
-+	lo->lo_backing_virt_file = virt_file;
- 
- 	lim = queue_limits_start_update(lo->lo_queue);
- 	loop_update_limits(lo, &lim, config->block_size);
-@@ -1092,6 +1146,8 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 		bd_abort_claiming(bdev, loop_configure);
- out_putf:
- 	fput(file);
-+	if (virt_file)
-+		fput(virt_file);
- 	/* This is safe: open() is still holding a reference. */
- 	module_put(THIS_MODULE);
- 	return error;
-@@ -1101,11 +1157,13 @@ static void __loop_clr_fd(struct loop_device *lo)
- {
- 	struct queue_limits lim;
- 	struct file *filp;
-+	struct file *virt_filp = lo->lo_backing_virt_file;
- 	gfp_t gfp = lo->old_gfp_mask;
- 
- 	spin_lock_irq(&lo->lo_lock);
- 	filp = lo->lo_backing_file;
- 	lo->lo_backing_file = NULL;
-+	lo->lo_backing_virt_file = NULL;
- 	spin_unlock_irq(&lo->lo_lock);
- 
- 	lo->lo_device = NULL;
-@@ -1172,6 +1230,8 @@ static void __loop_clr_fd(struct loop_device *lo)
- 	 * fput can take open_mutex which is usually taken before lo_mutex.
- 	 */
- 	fput(filp);
-+	if (virt_filp)
-+		fput(virt_filp);
- }
- 
- static int loop_clr_fd(struct loop_device *lo)
 diff --git a/fs/Kconfig b/fs/Kconfig
 index 5b4847bd2..74a618a36 100644
 --- a/fs/Kconfig
@@ -2396,13 +2062,13 @@ index 77fd7f7b5..8a7485aad 100644
 +obj-$(CONFIG_AUFS_FS)           += aufs/
 diff --git a/fs/aufs/Kconfig b/fs/aufs/Kconfig
 new file mode 100644
-index 000000000..f6434a7da
+index 000000000..cfa5d0abf
 --- /dev/null
 +++ b/fs/aufs/Kconfig
 @@ -0,0 +1,201 @@
 +# SPDX-License-Identifier: GPL-2.0
 +config AUFS_FS
-+	tristate "Aufs (Advanced multi layered unification filesystem) support"
++	bool "Aufs (Advanced multi layered unification filesystem) support"
 +	help
 +	Aufs is a stackable unification filesystem such as Unionfs,
 +	which unifies several directories and provides a merged single
@@ -2476,7 +2142,7 @@ index 000000000..f6434a7da
 +
 +config AUFS_EXPORT
 +	bool "NFS-exportable aufs"
-+	depends on EXPORTFS
++	depends on EXPORTFS = y
 +	help
 +	If you want to export your mounted aufs via NFS, then enable this
 +	option. There are several requirements for this configuration.
@@ -2603,16 +2269,13 @@ index 000000000..f6434a7da
 +endif
 diff --git a/fs/aufs/Makefile b/fs/aufs/Makefile
 new file mode 100644
-index 000000000..3be9f879d
+index 000000000..fb72261a5
 --- /dev/null
 +++ b/fs/aufs/Makefile
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,40 @@
 +# SPDX-License-Identifier: GPL-2.0
 +
 +include ${src}/magic.mk
-+ifeq (${CONFIG_AUFS_FS},m)
-+include ${src}/conf.mk
-+endif
 +-include ${src}/priv_def.mk
 +
 +ccflags-y += ${EXTRA_CFLAGS}
@@ -2620,11 +2283,7 @@ index 000000000..3be9f879d
 +# enable pr_debug
 +ccflags-y += -DDEBUG
 +# sparse requires the full pathname
-+ifdef M
-+ccflags-y += -include ${M}/../../include/uapi/linux/aufs_type.h
-+else
 +ccflags-y += -include ${srctree}/include/uapi/linux/aufs_type.h
-+endif
 +
 +obj-$(CONFIG_AUFS_FS) += aufs.o
 +aufs-y := module.o sbinfo.o super.o branch.o xino.o sysaufs.o opts.o fsctx.o \
@@ -2656,26 +2315,13 @@ index 000000000..3be9f879d
 +aufs-$(CONFIG_AUFS_MAGIC_SYSRQ) += sysrq.o
 diff --git a/fs/aufs/aufs.h b/fs/aufs/aufs.h
 new file mode 100644
-index 000000000..3bee75b16
+index 000000000..912324f18
 --- /dev/null
 +++ b/fs/aufs/aufs.h
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,49 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -2724,26 +2370,13 @@ index 000000000..3bee75b16
 +#endif /* __AUFS_H__ */
 diff --git a/fs/aufs/branch.c b/fs/aufs/branch.c
 new file mode 100644
-index 000000000..2c61b267c
+index 000000000..41ac62fbe
 --- /dev/null
 +++ b/fs/aufs/branch.c
-@@ -0,0 +1,1427 @@
+@@ -0,0 +1,1414 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -4157,26 +3790,13 @@ index 000000000..2c61b267c
 +}
 diff --git a/fs/aufs/branch.h b/fs/aufs/branch.h
 new file mode 100644
-index 000000000..3f2c51613
+index 000000000..44dac4caf
 --- /dev/null
 +++ b/fs/aufs/branch.h
-@@ -0,0 +1,375 @@
+@@ -0,0 +1,362 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -4536,74 +4156,15 @@ index 000000000..3f2c51613
 +
 +#endif /* __KERNEL__ */
 +#endif /* __AUFS_BRANCH_H__ */
-diff --git a/fs/aufs/conf.mk b/fs/aufs/conf.mk
-new file mode 100644
-index 000000000..12782f8e0
---- /dev/null
-+++ b/fs/aufs/conf.mk
-@@ -0,0 +1,40 @@
-+# SPDX-License-Identifier: GPL-2.0
-+
-+AuConfStr = CONFIG_AUFS_FS=${CONFIG_AUFS_FS}
-+
-+define AuConf
-+ifdef ${1}
-+AuConfStr += ${1}=${${1}}
-+endif
-+endef
-+
-+AuConfAll = BRANCH_MAX_127 BRANCH_MAX_511 BRANCH_MAX_1023 BRANCH_MAX_32767 \
-+	SBILIST \
-+	HNOTIFY HFSNOTIFY \
-+	EXPORT INO_T_64 \
-+	XATTR \
-+	FHSM \
-+	RDU \
-+	DIRREN \
-+	SHWH \
-+	BR_RAMFS \
-+	BR_FUSE POLL \
-+	BR_HFSPLUS \
-+	BDEV_LOOP \
-+	DEBUG MAGIC_SYSRQ
-+$(foreach i, ${AuConfAll}, \
-+	$(eval $(call AuConf,CONFIG_AUFS_${i})))
-+
-+AuConfName = ${obj}/conf.str
-+${AuConfName}.tmp: FORCE
-+	@echo ${AuConfStr} | tr ' ' '\n' | sed -e 's/^/"/' -e 's/$$/\\n"/' > $@
-+${AuConfName}: ${AuConfName}.tmp
-+	@diff -q $< $@ > /dev/null 2>&1 || { \
-+	echo '  GEN    ' $@; \
-+	cp -p $< $@; \
-+	}
-+FORCE:
-+clean-files += ${AuConfName} ${AuConfName}.tmp
-+${obj}/sysfs.o: ${AuConfName}
-+
-+-include ${srctree}/${src}/conf_priv.mk
 diff --git a/fs/aufs/cpup.c b/fs/aufs/cpup.c
 new file mode 100644
-index 000000000..3ecf694c9
+index 000000000..e279c5080
 --- /dev/null
 +++ b/fs/aufs/cpup.c
-@@ -0,0 +1,1466 @@
+@@ -0,0 +1,1453 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6056,26 +5617,13 @@ index 000000000..3ecf694c9
 +}
 diff --git a/fs/aufs/cpup.h b/fs/aufs/cpup.h
 new file mode 100644
-index 000000000..b87aeacea
+index 000000000..6da20c60b
 --- /dev/null
 +++ b/fs/aufs/cpup.h
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,88 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6163,26 +5711,13 @@ index 000000000..b87aeacea
 +#endif /* __AUFS_CPUP_H__ */
 diff --git a/fs/aufs/dbgaufs.c b/fs/aufs/dbgaufs.c
 new file mode 100644
-index 000000000..007d67fdc
+index 000000000..c4bb48ceb
 --- /dev/null
 +++ b/fs/aufs/dbgaufs.c
-@@ -0,0 +1,525 @@
+@@ -0,0 +1,512 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6694,26 +6229,13 @@ index 000000000..007d67fdc
 +}
 diff --git a/fs/aufs/dbgaufs.h b/fs/aufs/dbgaufs.h
 new file mode 100644
-index 000000000..8ee442569
+index 000000000..abab8ebd7
 --- /dev/null
 +++ b/fs/aufs/dbgaufs.h
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,40 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6753,26 +6275,13 @@ index 000000000..8ee442569
 +#endif /* __DBGAUFS_H__ */
 diff --git a/fs/aufs/dcsub.c b/fs/aufs/dcsub.c
 new file mode 100644
-index 000000000..2c890b0fe
+index 000000000..794ea0eb0
 --- /dev/null
 +++ b/fs/aufs/dcsub.c
-@@ -0,0 +1,225 @@
+@@ -0,0 +1,212 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6984,26 +6493,13 @@ index 000000000..2c890b0fe
 +}
 diff --git a/fs/aufs/dcsub.h b/fs/aufs/dcsub.h
 new file mode 100644
-index 000000000..b001c6325
+index 000000000..8900c0749
 --- /dev/null
 +++ b/fs/aufs/dcsub.h
-@@ -0,0 +1,139 @@
+@@ -0,0 +1,126 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -7129,26 +6625,13 @@ index 000000000..b001c6325
 +#endif /* __AUFS_DCSUB_H__ */
 diff --git a/fs/aufs/debug.c b/fs/aufs/debug.c
 new file mode 100644
-index 000000000..fbf2ee8b8
+index 000000000..ac04136a1
 --- /dev/null
 +++ b/fs/aufs/debug.c
-@@ -0,0 +1,448 @@
+@@ -0,0 +1,435 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -7583,26 +7066,13 @@ index 000000000..fbf2ee8b8
 +}
 diff --git a/fs/aufs/debug.h b/fs/aufs/debug.h
 new file mode 100644
-index 000000000..65001ebe7
+index 000000000..caabe84b9
 --- /dev/null
 +++ b/fs/aufs/debug.h
-@@ -0,0 +1,226 @@
+@@ -0,0 +1,213 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -7815,26 +7285,13 @@ index 000000000..65001ebe7
 +#endif /* __AUFS_DEBUG_H__ */
 diff --git a/fs/aufs/dentry.c b/fs/aufs/dentry.c
 new file mode 100644
-index 000000000..ff43181f0
+index 000000000..fa2e16790
 --- /dev/null
 +++ b/fs/aufs/dentry.c
-@@ -0,0 +1,1228 @@
+@@ -0,0 +1,1215 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -9049,26 +8506,13 @@ index 000000000..ff43181f0
 +};
 diff --git a/fs/aufs/dentry.h b/fs/aufs/dentry.h
 new file mode 100644
-index 000000000..7d58888c2
+index 000000000..e0bddac22
 --- /dev/null
 +++ b/fs/aufs/dentry.h
-@@ -0,0 +1,270 @@
+@@ -0,0 +1,257 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -9325,26 +8769,13 @@ index 000000000..7d58888c2
 +#endif /* __AUFS_DENTRY_H__ */
 diff --git a/fs/aufs/dinfo.c b/fs/aufs/dinfo.c
 new file mode 100644
-index 000000000..c99a77cf6
+index 000000000..ab5e4485b
 --- /dev/null
 +++ b/fs/aufs/dinfo.c
-@@ -0,0 +1,555 @@
+@@ -0,0 +1,542 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -9886,26 +9317,13 @@ index 000000000..c99a77cf6
 +}
 diff --git a/fs/aufs/dir.c b/fs/aufs/dir.c
 new file mode 100644
-index 000000000..9fa63600f
+index 000000000..141a745df
 --- /dev/null
 +++ b/fs/aufs/dir.c
-@@ -0,0 +1,765 @@
+@@ -0,0 +1,752 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -10657,26 +10075,13 @@ index 000000000..9fa63600f
 +};
 diff --git a/fs/aufs/dir.h b/fs/aufs/dir.h
 new file mode 100644
-index 000000000..775419669
+index 000000000..cc38c8c8c
 --- /dev/null
 +++ b/fs/aufs/dir.h
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,121 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -10797,26 +10202,13 @@ index 000000000..775419669
 +#endif /* __AUFS_DIR_H__ */
 diff --git a/fs/aufs/dirren.c b/fs/aufs/dirren.c
 new file mode 100644
-index 000000000..e915d97d8
+index 000000000..82be36092
 --- /dev/null
 +++ b/fs/aufs/dirren.c
-@@ -0,0 +1,1315 @@
+@@ -0,0 +1,1302 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2017-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12118,26 +11510,13 @@ index 000000000..e915d97d8
 +}
 diff --git a/fs/aufs/dirren.h b/fs/aufs/dirren.h
 new file mode 100644
-index 000000000..1fc0345f2
+index 000000000..43f71c666
 --- /dev/null
 +++ b/fs/aufs/dirren.h
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,127 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2017-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12264,26 +11643,13 @@ index 000000000..1fc0345f2
 +#endif /* __AUFS_DIRREN_H__ */
 diff --git a/fs/aufs/dynop.c b/fs/aufs/dynop.c
 new file mode 100644
-index 000000000..9cf93d0ad
+index 000000000..3d6dca004
 --- /dev/null
 +++ b/fs/aufs/dynop.c
-@@ -0,0 +1,365 @@
+@@ -0,0 +1,352 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12635,26 +12001,13 @@ index 000000000..9cf93d0ad
 +}
 diff --git a/fs/aufs/dynop.h b/fs/aufs/dynop.h
 new file mode 100644
-index 000000000..22e1f7acf
+index 000000000..b5483452a
 --- /dev/null
 +++ b/fs/aufs/dynop.h
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,64 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12718,26 +12071,13 @@ index 000000000..22e1f7acf
 +#endif /* __AUFS_DYNOP_H__ */
 diff --git a/fs/aufs/export.c b/fs/aufs/export.c
 new file mode 100644
-index 000000000..022c3bc8f
+index 000000000..34c54e6b6
 --- /dev/null
 +++ b/fs/aufs/export.c
-@@ -0,0 +1,846 @@
+@@ -0,0 +1,833 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -13570,26 +12910,13 @@ index 000000000..022c3bc8f
 +}
 diff --git a/fs/aufs/f_op.c b/fs/aufs/f_op.c
 new file mode 100644
-index 000000000..8c0ec9339
+index 000000000..886b1d2fa
 --- /dev/null
 +++ b/fs/aufs/f_op.c
-@@ -0,0 +1,782 @@
+@@ -0,0 +1,769 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -13903,7 +13230,7 @@ index 000000000..8c0ec9339
 +	if (IS_ERR(h_file))
 +		goto out;
 +
-+	if (0 && au_test_loopback_kthread()) {
++	if (au_test_loopback_kthread()) {
 +		au_warn_loopback(h_file->f_path.dentry->d_sb);
 +		if (file->f_mapping != h_file->f_mapping) {
 +			file->f_mapping = h_file->f_mapping;
@@ -14358,26 +13685,13 @@ index 000000000..8c0ec9339
 +};
 diff --git a/fs/aufs/fhsm.c b/fs/aufs/fhsm.c
 new file mode 100644
-index 000000000..4d8810388
+index 000000000..92b8b6465
 --- /dev/null
 +++ b/fs/aufs/fhsm.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,413 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2011-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -14790,26 +14104,13 @@ index 000000000..4d8810388
 +}
 diff --git a/fs/aufs/file.c b/fs/aufs/file.c
 new file mode 100644
-index 000000000..56dbad027
+index 000000000..49703e199
 --- /dev/null
 +++ b/fs/aufs/file.c
-@@ -0,0 +1,858 @@
+@@ -0,0 +1,845 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -15654,26 +14955,13 @@ index 000000000..56dbad027
 +};
 diff --git a/fs/aufs/file.h b/fs/aufs/file.h
 new file mode 100644
-index 000000000..75035d791
+index 000000000..3e5de5887
 --- /dev/null
 +++ b/fs/aufs/file.h
-@@ -0,0 +1,342 @@
+@@ -0,0 +1,329 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -16002,26 +15290,13 @@ index 000000000..75035d791
 +#endif /* __AUFS_FILE_H__ */
 diff --git a/fs/aufs/finfo.c b/fs/aufs/finfo.c
 new file mode 100644
-index 000000000..ae2f801b1
+index 000000000..cbc2f42ff
 --- /dev/null
 +++ b/fs/aufs/finfo.c
-@@ -0,0 +1,147 @@
+@@ -0,0 +1,134 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -16155,26 +15430,13 @@ index 000000000..ae2f801b1
 +}
 diff --git a/fs/aufs/fsctx.c b/fs/aufs/fsctx.c
 new file mode 100644
-index 000000000..01d224a52
+index 000000000..048f81c2b
 --- /dev/null
 +++ b/fs/aufs/fsctx.c
-@@ -0,0 +1,1244 @@
+@@ -0,0 +1,1231 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2022-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -17405,26 +16667,13 @@ index 000000000..01d224a52
 +}
 diff --git a/fs/aufs/fstype.h b/fs/aufs/fstype.h
 new file mode 100644
-index 000000000..1c4d94511
+index 000000000..c3a098d94
 --- /dev/null
 +++ b/fs/aufs/fstype.h
-@@ -0,0 +1,419 @@
+@@ -0,0 +1,406 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -17830,26 +17079,13 @@ index 000000000..1c4d94511
 +#endif /* __AUFS_FSTYPE_H__ */
 diff --git a/fs/aufs/hbl.h b/fs/aufs/hbl.h
 new file mode 100644
-index 000000000..6be35b9ab
+index 000000000..710198d09
 --- /dev/null
 +++ b/fs/aufs/hbl.h
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,52 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2017-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -17901,26 +17137,13 @@ index 000000000..6be35b9ab
 +#endif /* __AUFS_HBL_H__ */
 diff --git a/fs/aufs/hfsnotify.c b/fs/aufs/hfsnotify.c
 new file mode 100644
-index 000000000..0984a7d39
+index 000000000..9ca21b356
 --- /dev/null
 +++ b/fs/aufs/hfsnotify.c
-@@ -0,0 +1,290 @@
+@@ -0,0 +1,277 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -18197,26 +17420,13 @@ index 000000000..0984a7d39
 +};
 diff --git a/fs/aufs/hfsplus.c b/fs/aufs/hfsplus.c
 new file mode 100644
-index 000000000..1f33dad7a
+index 000000000..8e2073976
 --- /dev/null
 +++ b/fs/aufs/hfsplus.c
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,47 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -18263,26 +17473,13 @@ index 000000000..1f33dad7a
 +}
 diff --git a/fs/aufs/hnotify.c b/fs/aufs/hnotify.c
 new file mode 100644
-index 000000000..fdebd41be
+index 000000000..2292e3d2d
 --- /dev/null
 +++ b/fs/aufs/hnotify.c
-@@ -0,0 +1,715 @@
+@@ -0,0 +1,702 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -18984,26 +18181,13 @@ index 000000000..fdebd41be
 +}
 diff --git a/fs/aufs/i_op.c b/fs/aufs/i_op.c
 new file mode 100644
-index 000000000..d948b77e7
+index 000000000..a043640ce
 --- /dev/null
 +++ b/fs/aufs/i_op.c
-@@ -0,0 +1,1522 @@
+@@ -0,0 +1,1509 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -20512,26 +19696,13 @@ index 000000000..d948b77e7
 +};
 diff --git a/fs/aufs/i_op_add.c b/fs/aufs/i_op_add.c
 new file mode 100644
-index 000000000..28fc3910f
+index 000000000..92b5c22d0
 --- /dev/null
 +++ b/fs/aufs/i_op_add.c
-@@ -0,0 +1,979 @@
+@@ -0,0 +1,966 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -21497,26 +20668,13 @@ index 000000000..28fc3910f
 +}
 diff --git a/fs/aufs/i_op_del.c b/fs/aufs/i_op_del.c
 new file mode 100644
-index 000000000..80943a5ba
+index 000000000..9a31b0e7f
 --- /dev/null
 +++ b/fs/aufs/i_op_del.c
-@@ -0,0 +1,523 @@
+@@ -0,0 +1,510 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -22026,26 +21184,13 @@ index 000000000..80943a5ba
 +}
 diff --git a/fs/aufs/i_op_ren.c b/fs/aufs/i_op_ren.c
 new file mode 100644
-index 000000000..939dcd050
+index 000000000..969262ac7
 --- /dev/null
 +++ b/fs/aufs/i_op_ren.c
-@@ -0,0 +1,1264 @@
+@@ -0,0 +1,1251 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -23296,26 +22441,13 @@ index 000000000..939dcd050
 +}
 diff --git a/fs/aufs/iinfo.c b/fs/aufs/iinfo.c
 new file mode 100644
-index 000000000..e82a63773
+index 000000000..bf8aea459
 --- /dev/null
 +++ b/fs/aufs/iinfo.c
-@@ -0,0 +1,287 @@
+@@ -0,0 +1,274 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -23589,26 +22721,13 @@ index 000000000..e82a63773
 +}
 diff --git a/fs/aufs/inode.c b/fs/aufs/inode.c
 new file mode 100644
-index 000000000..391de2ea1
+index 000000000..2a74ee2f8
 --- /dev/null
 +++ b/fs/aufs/inode.c
-@@ -0,0 +1,532 @@
+@@ -0,0 +1,519 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -24127,26 +23246,13 @@ index 000000000..391de2ea1
 +}
 diff --git a/fs/aufs/inode.h b/fs/aufs/inode.h
 new file mode 100644
-index 000000000..6f4f6a837
+index 000000000..5bca97110
 --- /dev/null
 +++ b/fs/aufs/inode.h
-@@ -0,0 +1,727 @@
+@@ -0,0 +1,714 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -24860,26 +23966,13 @@ index 000000000..6f4f6a837
 +#endif /* __AUFS_INODE_H__ */
 diff --git a/fs/aufs/ioctl.c b/fs/aufs/ioctl.c
 new file mode 100644
-index 000000000..807b133c4
+index 000000000..a175714ea
 --- /dev/null
 +++ b/fs/aufs/ioctl.c
-@@ -0,0 +1,220 @@
+@@ -0,0 +1,207 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25086,26 +24179,13 @@ index 000000000..807b133c4
 +#endif
 diff --git a/fs/aufs/lcnt.h b/fs/aufs/lcnt.h
 new file mode 100644
-index 000000000..95df0ac9b
+index 000000000..07aca1a7d
 --- /dev/null
 +++ b/fs/aufs/lcnt.h
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,173 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2018-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25278,26 +24358,13 @@ index 000000000..95df0ac9b
 +#endif /* __AUFS_LCNT_H__ */
 diff --git a/fs/aufs/loop.c b/fs/aufs/loop.c
 new file mode 100644
-index 000000000..38ed1393d
+index 000000000..69dea4cda
 --- /dev/null
 +++ b/fs/aufs/loop.c
-@@ -0,0 +1,164 @@
+@@ -0,0 +1,135 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25430,44 +24497,15 @@ index 000000000..38ed1393d
 +		symbol_put(loop_backing_file);
 +	au_kfree_try_rcu(au_warn_loopback_array);
 +}
-+
-+/* ---------------------------------------------------------------------- */
-+
-+/* support the loopback block device insude aufs */
-+
-+struct file *aufs_real_loop(struct file *file)
-+{
-+	struct file *f;
-+
-+	BUG_ON(!au_test_aufs(file->f_path.dentry->d_sb));
-+	fi_read_lock(file);
-+	f = au_hf_top(file);
-+	fi_read_unlock(file);
-+	AuDebugOn(!f);
-+	return f;
-+}
 diff --git a/fs/aufs/loop.h b/fs/aufs/loop.h
 new file mode 100644
-index 000000000..9d479fa1a
+index 000000000..519efba31
 --- /dev/null
 +++ b/fs/aufs/loop.h
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,42 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25493,8 +24531,6 @@ index 000000000..9d479fa1a
 +
 +int au_loopback_init(void);
 +void au_loopback_fin(void);
-+
-+struct file *aufs_real_loop(struct file *file);
 +#else
 +AuStub(struct file *, loop_backing_file, return NULL, struct super_block *sb)
 +
@@ -25505,8 +24541,6 @@ index 000000000..9d479fa1a
 +
 +AuStubInt0(au_loopback_init, void)
 +AuStubVoid(au_loopback_fin, void)
-+
-+AuStub(struct file *, aufs_real_loop, return NULL, struct file *file)
 +#endif /* BLK_DEV_LOOP */
 +
 +#endif /* __KERNEL__ */
@@ -25550,26 +24584,13 @@ index 000000000..7bc9eef3f
 +endif
 diff --git a/fs/aufs/module.c b/fs/aufs/module.c
 new file mode 100644
-index 000000000..bfd314893
+index 000000000..f66ccf60c
 --- /dev/null
 +++ b/fs/aufs/module.c
-@@ -0,0 +1,275 @@
+@@ -0,0 +1,261 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25702,7 +24723,6 @@ index 000000000..bfd314893
 +MODULE_DESCRIPTION(AUFS_NAME
 +	" -- Advanced multi layered unification filesystem");
 +MODULE_VERSION(AUFS_VERSION);
-+MODULE_ALIAS_FS(AUFS_NAME);
 +
 +/* this module parameter has no meaning when SYSFS is disabled */
 +int sysaufs_brs = 1;
@@ -25831,26 +24851,13 @@ index 000000000..bfd314893
 +module_exit(aufs_exit);
 diff --git a/fs/aufs/module.h b/fs/aufs/module.h
 new file mode 100644
-index 000000000..aad4f097e
+index 000000000..296fde588
 --- /dev/null
 +++ b/fs/aufs/module.h
-@@ -0,0 +1,180 @@
+@@ -0,0 +1,167 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -26017,26 +25024,13 @@ index 000000000..aad4f097e
 +#endif /* __AUFS_MODULE_H__ */
 diff --git a/fs/aufs/mvdown.c b/fs/aufs/mvdown.c
 new file mode 100644
-index 000000000..942736a99
+index 000000000..e314168b2
 --- /dev/null
 +++ b/fs/aufs/mvdown.c
-@@ -0,0 +1,714 @@
+@@ -0,0 +1,701 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2011-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -26737,26 +25731,13 @@ index 000000000..942736a99
 +}
 diff --git a/fs/aufs/opts.c b/fs/aufs/opts.c
 new file mode 100644
-index 000000000..533c87bda
+index 000000000..9df49bab0
 --- /dev/null
 +++ b/fs/aufs/opts.c
-@@ -0,0 +1,1030 @@
+@@ -0,0 +1,1017 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -27773,26 +26754,13 @@ index 000000000..533c87bda
 +}
 diff --git a/fs/aufs/opts.h b/fs/aufs/opts.h
 new file mode 100644
-index 000000000..62cc3c40b
+index 000000000..c633d1e16
 --- /dev/null
 +++ b/fs/aufs/opts.h
-@@ -0,0 +1,264 @@
+@@ -0,0 +1,251 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28043,26 +27011,13 @@ index 000000000..62cc3c40b
 +#endif /* __AUFS_OPTS_H__ */
 diff --git a/fs/aufs/plink.c b/fs/aufs/plink.c
 new file mode 100644
-index 000000000..6a47db86c
+index 000000000..365e8bc62
 --- /dev/null
 +++ b/fs/aufs/plink.c
-@@ -0,0 +1,516 @@
+@@ -0,0 +1,503 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28565,26 +27520,13 @@ index 000000000..6a47db86c
 +}
 diff --git a/fs/aufs/poll.c b/fs/aufs/poll.c
 new file mode 100644
-index 000000000..0b8b948fc
+index 000000000..4714bdf21
 --- /dev/null
 +++ b/fs/aufs/poll.c
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,38 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28622,26 +27564,13 @@ index 000000000..0b8b948fc
 +}
 diff --git a/fs/aufs/posix_acl.c b/fs/aufs/posix_acl.c
 new file mode 100644
-index 000000000..12ed81a59
+index 000000000..471e30d17
 --- /dev/null
 +++ b/fs/aufs/posix_acl.c
-@@ -0,0 +1,108 @@
+@@ -0,0 +1,95 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2014-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28736,26 +27665,13 @@ index 000000000..12ed81a59
 +}
 diff --git a/fs/aufs/procfs.c b/fs/aufs/procfs.c
 new file mode 100644
-index 000000000..2ed220449
+index 000000000..aafdba088
 --- /dev/null
 +++ b/fs/aufs/procfs.c
-@@ -0,0 +1,168 @@
+@@ -0,0 +1,155 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28910,26 +27826,13 @@ index 000000000..2ed220449
 +}
 diff --git a/fs/aufs/rdu.c b/fs/aufs/rdu.c
 new file mode 100644
-index 000000000..54ebca84a
+index 000000000..6e5d76228
 --- /dev/null
 +++ b/fs/aufs/rdu.c
-@@ -0,0 +1,384 @@
+@@ -0,0 +1,371 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -29300,26 +28203,13 @@ index 000000000..54ebca84a
 +#endif
 diff --git a/fs/aufs/rwsem.h b/fs/aufs/rwsem.h
 new file mode 100644
-index 000000000..c71f6542f
+index 000000000..302782f5b
 --- /dev/null
 +++ b/fs/aufs/rwsem.h
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,76 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -29395,26 +28285,13 @@ index 000000000..c71f6542f
 +#endif /* __AUFS_RWSEM_H__ */
 diff --git a/fs/aufs/sbinfo.c b/fs/aufs/sbinfo.c
 new file mode 100644
-index 000000000..9433b21b3
+index 000000000..bd7a50bc0
 --- /dev/null
 +++ b/fs/aufs/sbinfo.c
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,303 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -29717,26 +28594,13 @@ index 000000000..9433b21b3
 +}
 diff --git a/fs/aufs/super.c b/fs/aufs/super.c
 new file mode 100644
-index 000000000..cf6e08a0f
+index 000000000..e867aa6e7
 --- /dev/null
 +++ b/fs/aufs/super.c
-@@ -0,0 +1,875 @@
+@@ -0,0 +1,859 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -30494,10 +29358,7 @@ index 000000000..cf6e08a0f
 +	.show_options	= aufs_show_options,
 +	.statfs		= aufs_statfs,
 +	.put_super	= aufs_put_super,
-+	.sync_fs	= aufs_sync_fs,
-+#ifdef CONFIG_AUFS_BDEV_LOOP
-+	.real_loop	= aufs_real_loop
-+#endif
++	.sync_fs	= aufs_sync_fs
 +};
 +
 +/* ---------------------------------------------------------------------- */
@@ -30598,26 +29459,13 @@ index 000000000..cf6e08a0f
 +};
 diff --git a/fs/aufs/super.h b/fs/aufs/super.h
 new file mode 100644
-index 000000000..039d507aa
+index 000000000..afabf38a6
 --- /dev/null
 +++ b/fs/aufs/super.h
-@@ -0,0 +1,618 @@
+@@ -0,0 +1,605 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31222,26 +30070,13 @@ index 000000000..039d507aa
 +#endif /* __AUFS_SUPER_H__ */
 diff --git a/fs/aufs/sysaufs.c b/fs/aufs/sysaufs.c
 new file mode 100644
-index 000000000..2c28abfd5
+index 000000000..5c01ea8dd
 --- /dev/null
 +++ b/fs/aufs/sysaufs.c
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,81 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31322,26 +30157,13 @@ index 000000000..2c28abfd5
 +}
 diff --git a/fs/aufs/sysaufs.h b/fs/aufs/sysaufs.h
 new file mode 100644
-index 000000000..224895b10
+index 000000000..66cec0acb
 --- /dev/null
 +++ b/fs/aufs/sysaufs.h
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,89 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31430,26 +30252,13 @@ index 000000000..224895b10
 +#endif /* __SYSAUFS_H__ */
 diff --git a/fs/aufs/sysfs.c b/fs/aufs/sysfs.c
 new file mode 100644
-index 000000000..9d68cf89e
+index 000000000..904a91c1b
 --- /dev/null
 +++ b/fs/aufs/sysfs.c
-@@ -0,0 +1,374 @@
+@@ -0,0 +1,338 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31460,30 +30269,7 @@ index 000000000..9d68cf89e
 +#include <linux/seq_file.h>
 +#include "aufs.h"
 +
-+#ifdef CONFIG_AUFS_FS_MODULE
-+/* this entry violates the "one line per file" policy of sysfs */
-+static ssize_t config_show(struct kobject *kobj, struct kobj_attribute *attr,
-+			   char *buf)
-+{
-+	ssize_t err;
-+	static char *conf =
-+/* this file is generated at compiling */
-+#include "conf.str"
-+		;
-+
-+	err = snprintf(buf, PAGE_SIZE, conf);
-+	if (unlikely(err >= PAGE_SIZE))
-+		err = -EFBIG;
-+	return err;
-+}
-+
-+static struct kobj_attribute au_config_attr = __ATTR_RO(config);
-+#endif
-+
 +static struct attribute *au_attr[] = {
-+#ifdef CONFIG_AUFS_FS_MODULE
-+	&au_config_attr.attr,
-+#endif
 +	NULL,	/* need to NULL terminate the list of attributes */
 +};
 +
@@ -31810,26 +30596,13 @@ index 000000000..9d68cf89e
 +}
 diff --git a/fs/aufs/sysrq.c b/fs/aufs/sysrq.c
 new file mode 100644
-index 000000000..57fa54ce5
+index 000000000..1a8be2e5e
 --- /dev/null
 +++ b/fs/aufs/sysrq.c
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,144 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31973,26 +30746,13 @@ index 000000000..57fa54ce5
 +}
 diff --git a/fs/aufs/vdir.c b/fs/aufs/vdir.c
 new file mode 100644
-index 000000000..eb6bd9fb1
+index 000000000..e42740b72
 --- /dev/null
 +++ b/fs/aufs/vdir.c
-@@ -0,0 +1,896 @@
+@@ -0,0 +1,883 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -32875,26 +31635,13 @@ index 000000000..eb6bd9fb1
 +}
 diff --git a/fs/aufs/vfsub.c b/fs/aufs/vfsub.c
 new file mode 100644
-index 000000000..e1fe4ac87
+index 000000000..33c0bc381
 --- /dev/null
 +++ b/fs/aufs/vfsub.c
-@@ -0,0 +1,971 @@
+@@ -0,0 +1,958 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -33852,26 +32599,13 @@ index 000000000..e1fe4ac87
 +}
 diff --git a/fs/aufs/vfsub.h b/fs/aufs/vfsub.h
 new file mode 100644
-index 000000000..5f2a363b2
+index 000000000..35450f242
 --- /dev/null
 +++ b/fs/aufs/vfsub.h
-@@ -0,0 +1,441 @@
+@@ -0,0 +1,428 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -34299,26 +33033,13 @@ index 000000000..5f2a363b2
 +#endif /* __AUFS_VFSUB_H__ */
 diff --git a/fs/aufs/wbr_policy.c b/fs/aufs/wbr_policy.c
 new file mode 100644
-index 000000000..d8b5f1288
+index 000000000..4a7763999
 --- /dev/null
 +++ b/fs/aufs/wbr_policy.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,822 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -35140,26 +33861,13 @@ index 000000000..d8b5f1288
 +};
 diff --git a/fs/aufs/whout.c b/fs/aufs/whout.c
 new file mode 100644
-index 000000000..61f1ea856
+index 000000000..a62bbe3f4
 --- /dev/null
 +++ b/fs/aufs/whout.c
-@@ -0,0 +1,1096 @@
+@@ -0,0 +1,1083 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36242,26 +34950,13 @@ index 000000000..61f1ea856
 +}
 diff --git a/fs/aufs/whout.h b/fs/aufs/whout.h
 new file mode 100644
-index 000000000..ae2ef1cf4
+index 000000000..95345cf34
 --- /dev/null
 +++ b/fs/aufs/whout.h
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,74 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36335,26 +35030,13 @@ index 000000000..ae2ef1cf4
 +#endif /* __AUFS_WHOUT_H__ */
 diff --git a/fs/aufs/wkq.c b/fs/aufs/wkq.c
 new file mode 100644
-index 000000000..869f3ff57
+index 000000000..bf34327ee
 --- /dev/null
 +++ b/fs/aufs/wkq.c
-@@ -0,0 +1,370 @@
+@@ -0,0 +1,357 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36711,26 +35393,13 @@ index 000000000..869f3ff57
 +}
 diff --git a/fs/aufs/wkq.h b/fs/aufs/wkq.h
 new file mode 100644
-index 000000000..9132cfeae
+index 000000000..490621359
 --- /dev/null
 +++ b/fs/aufs/wkq.h
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,76 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36806,26 +35475,13 @@ index 000000000..9132cfeae
 +#endif /* __AUFS_WKQ_H__ */
 diff --git a/fs/aufs/xattr.c b/fs/aufs/xattr.c
 new file mode 100644
-index 000000000..261510b24
+index 000000000..bf651e781
 --- /dev/null
 +++ b/fs/aufs/xattr.c
-@@ -0,0 +1,360 @@
+@@ -0,0 +1,347 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2014-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -37172,26 +35828,13 @@ index 000000000..261510b24
 +}
 diff --git a/fs/aufs/xino.c b/fs/aufs/xino.c
 new file mode 100644
-index 000000000..e6ffdfdb1
+index 000000000..c202f91aa
 --- /dev/null
 +++ b/fs/aufs/xino.c
-@@ -0,0 +1,1926 @@
+@@ -0,0 +1,1913 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -39103,7 +37746,7 @@ index 000000000..e6ffdfdb1
 +	return err;
 +}
 diff --git a/fs/dcache.c b/fs/dcache.c
-index bd5aa1361..d711c216b 100644
+index bd5aa1361..f27934816 100644
 --- a/fs/dcache.c
 +++ b/fs/dcache.c
 @@ -1268,6 +1268,9 @@ enum d_walk_ret {
@@ -39125,36 +37768,8 @@ index bd5aa1361..d711c216b 100644
  		   enum d_walk_ret (*enter)(void *, struct dentry *))
  {
  	struct dentry *this_parent, *dentry;
-@@ -1375,6 +1378,7 @@ static void d_walk(struct dentry *parent, void *data,
- 	seq = 1;
- 	goto again;
- }
-+EXPORT_SYMBOL_GPL(d_walk);
- 
- struct check_mount {
- 	struct vfsmount *mnt;
-@@ -2891,6 +2895,7 @@ void d_exchange(struct dentry *dentry1, struct dentry *dentry2)
- 
- 	write_sequnlock(&rename_lock);
- }
-+EXPORT_SYMBOL_GPL(d_exchange);
- 
- /**
-  * d_ancestor - search for an ancestor
-diff --git a/fs/exec.c b/fs/exec.c
-index 8e4ea5f1e..fcdda54dd 100644
---- a/fs/exec.c
-+++ b/fs/exec.c
-@@ -114,6 +114,7 @@ bool path_noexec(const struct path *path)
- 	return (path->mnt->mnt_flags & MNT_NOEXEC) ||
- 	       (path->mnt->mnt_sb->s_iflags & SB_I_NOEXEC);
- }
-+EXPORT_SYMBOL_GPL(path_noexec);
- 
- #ifdef CONFIG_USELIB
- /*
 diff --git a/fs/fcntl.c b/fs/fcntl.c
-index 5598e4d57..7d4eaaff1 100644
+index 5598e4d57..90af6a47f 100644
 --- a/fs/fcntl.c
 +++ b/fs/fcntl.c
 @@ -36,7 +36,7 @@
@@ -39175,31 +37790,11 @@ index 5598e4d57..7d4eaaff1 100644
  	if (error)
  		return error;
  
-@@ -87,6 +89,7 @@ static int setfl(int fd, struct file * filp, unsigned int arg)
-  out:
- 	return error;
- }
-+EXPORT_SYMBOL_GPL(setfl);
- 
- /*
-  * Allocate an file->f_owner struct if it doesn't exist, handling racing
-diff --git a/fs/file_table.c b/fs/file_table.c
-index c04ed94cd..2b464937a 100644
---- a/fs/file_table.c
-+++ b/fs/file_table.c
-@@ -253,6 +253,7 @@ struct file *alloc_empty_file(int flags, const struct cred *cred)
- 	}
- 	return ERR_PTR(-ENFILE);
- }
-+EXPORT_SYMBOL_GPL(alloc_empty_file);
- 
- /*
-  * Variant of alloc_empty_file() that doesn't check and modify nr_files.
 diff --git a/fs/namespace.c b/fs/namespace.c
-index 1b466c54a..c72ef1258 100644
+index dfb72f827..b03431844 100644
 --- a/fs/namespace.c
 +++ b/fs/namespace.c
-@@ -1003,6 +1003,13 @@ static inline int check_mnt(struct mount *mnt)
+@@ -1003,6 +1003,12 @@ static inline int check_mnt(struct mount *mnt)
  	return mnt->mnt_ns == current->nsproxy->mnt_ns;
  }
  
@@ -39208,71 +37803,10 @@ index 1b466c54a..c72ef1258 100644
 +{
 +	return check_mnt(real_mount(mnt));
 +}
-+EXPORT_SYMBOL_GPL(is_current_mnt_ns);
 +
  static inline bool check_anonymous_mnt(struct mount *mnt)
  {
  	u64 seq;
-@@ -2340,6 +2347,7 @@ struct vfsmount *collect_mounts(const struct path *path)
- 		return ERR_CAST(tree);
- 	return &tree->mnt;
- }
-+EXPORT_SYMBOL_GPL(collect_mounts);
- 
- static void free_mnt_ns(struct mnt_namespace *);
- static struct mnt_namespace *alloc_mnt_ns(struct user_namespace *, bool);
-@@ -2423,6 +2431,7 @@ void drop_collected_mounts(struct vfsmount *mnt)
- 	unlock_mount_hash();
- 	namespace_unlock();
- }
-+EXPORT_SYMBOL_GPL(drop_collected_mounts);
- 
- bool has_locked_children(struct mount *mnt, struct dentry *dentry)
- {
-@@ -2525,6 +2534,7 @@ int iterate_mounts(int (*f)(struct vfsmount *, void *), void *arg,
- 	}
- 	return 0;
- }
-+EXPORT_SYMBOL_GPL(iterate_mounts);
- 
- static void lock_mnt_tree(struct mount *mnt)
- {
-diff --git a/fs/notify/fsnotify.c b/fs/notify/fsnotify.c
-index e2b4f17a4..7a411ea72 100644
---- a/fs/notify/fsnotify.c
-+++ b/fs/notify/fsnotify.c
-@@ -225,6 +225,7 @@ int fsnotify_pre_content(const struct path *path, const loff_t *ppos,
- 	return fsnotify_parent(path->dentry, FS_PRE_ACCESS, &range,
- 			       FSNOTIFY_EVENT_FILE_RANGE);
- }
-+EXPORT_SYMBOL_GPL(fsnotify_pre_content);
- 
- /*
-  * Notify this dentry's parent about a child's events with child name info
-diff --git a/fs/notify/group.c b/fs/notify/group.c
-index 18446b7b0..09138e0b8 100644
---- a/fs/notify/group.c
-+++ b/fs/notify/group.c
-@@ -100,6 +100,7 @@ void fsnotify_get_group(struct fsnotify_group *group)
- {
- 	refcount_inc(&group->refcnt);
- }
-+EXPORT_SYMBOL_GPL(fsnotify_get_group);
- 
- /*
-  * Drop a reference to a group.  Free it if it's through.
-diff --git a/fs/open.c b/fs/open.c
-index a9063cca9..e0bfa20a1 100644
---- a/fs/open.c
-+++ b/fs/open.c
-@@ -66,6 +66,7 @@ int do_truncate(struct mnt_idmap *idmap, struct dentry *dentry,
- 	inode_unlock(dentry->d_inode);
- 	return ret;
- }
-+EXPORT_SYMBOL_GPL(do_truncate);
- 
- int vfs_truncate(const struct path *path, loff_t length)
- {
 diff --git a/fs/proc/base.c b/fs/proc/base.c
 index b0d4e1908..312a7d32a 100644
 --- a/fs/proc/base.c
@@ -39303,7 +37837,7 @@ index c6e7ebc63..d7ccfd909 100644
  		ino = inode->i_ino;
  	}
 diff --git a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
-index 994cde10e..de38c04f7 100644
+index e57e32381..d0413f8e7 100644
 --- a/fs/proc/task_mmu.c
 +++ b/fs/proc/task_mmu.c
 @@ -264,7 +264,8 @@ static void get_vma_name(struct vm_area_struct *vma,
@@ -39351,31 +37885,11 @@ index bce674533..b12b5a75c 100644
  		dev = inode->i_sb->s_dev;
  		ino = inode->i_ino;
  		pgoff = (loff_t)vma->vm_pgoff << PAGE_SHIFT;
-diff --git a/fs/read_write.c b/fs/read_write.c
-index bb0ed26a0..2fe0b1f9b 100644
---- a/fs/read_write.c
-+++ b/fs/read_write.c
-@@ -577,6 +577,7 @@ ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
- 	inc_syscr(current);
- 	return ret;
- }
-+EXPORT_SYMBOL_GPL(vfs_read);
- 
- static ssize_t new_sync_write(struct file *filp, const char __user *buf, size_t len, loff_t *ppos)
- {
-@@ -692,6 +693,7 @@ ssize_t vfs_write(struct file *file, const char __user *buf, size_t count, loff_
- 	file_end_write(file);
- 	return ret;
- }
-+EXPORT_SYMBOL_GPL(vfs_write);
- 
- /* file_ppos returns &file->f_pos or NULL if file is stream */
- static inline loff_t *file_ppos(struct file *file)
 diff --git a/fs/splice.c b/fs/splice.c
-index 4d6df083e..eb7b4d93a 100644
+index 4d6df083e..73cd917c8 100644
 --- a/fs/splice.c
 +++ b/fs/splice.c
-@@ -927,13 +927,14 @@ static int warn_unsupported(struct file *file, const char *op)
+@@ -927,7 +927,7 @@ static int warn_unsupported(struct file *file, const char *op)
  /*
   * Attempt to initiate a splice from pipe to file.
   */
@@ -39384,27 +37898,8 @@ index 4d6df083e..eb7b4d93a 100644
  			      loff_t *ppos, size_t len, unsigned int flags)
  {
  	if (unlikely(!out->f_op->splice_write))
- 		return warn_unsupported(out, "write");
- 	return out->f_op->splice_write(pipe, out, ppos, len, flags);
- }
-+EXPORT_SYMBOL_GPL(do_splice_from);
- 
- /*
-  * Indicate to the caller that there was a premature EOF when reading from the
-diff --git a/fs/xattr.c b/fs/xattr.c
-index 8ec5b0204..29b754a86 100644
---- a/fs/xattr.c
-+++ b/fs/xattr.c
-@@ -405,6 +405,7 @@ vfs_getxattr_alloc(struct mnt_idmap *idmap, struct dentry *dentry,
- 	*xattr_value = value;
- 	return error;
- }
-+EXPORT_SYMBOL_GPL(vfs_getxattr_alloc);
- 
- ssize_t
- __vfs_getxattr(struct dentry *dentry, struct inode *inode, const char *name,
 diff --git a/include/linux/fs.h b/include/linux/fs.h
-index a4fd649e2..d6f09e381 100644
+index 1fe7bf10d..6a5a8a4ed 100644
 --- a/include/linux/fs.h
 +++ b/include/linux/fs.h
 @@ -1211,6 +1211,7 @@ extern void fasync_free(struct fasync_struct *);
@@ -39423,18 +37918,6 @@ index a4fd649e2..d6f09e381 100644
  	int (*flock) (struct file *, int, struct file_lock *);
  	ssize_t (*splice_write)(struct pipe_inode_info *, struct file *, loff_t *, size_t, unsigned int);
  	ssize_t (*splice_read)(struct file *, loff_t *, struct pipe_inode_info *, size_t, unsigned int);
-@@ -2317,6 +2319,11 @@ struct super_operations {
- 	long (*free_cached_objects)(struct super_block *,
- 				    struct shrink_control *);
- 	void (*shutdown)(struct super_block *sb);
-+
-+#if IS_ENABLED(CONFIG_BLK_DEV_LOOP) || IS_ENABLED(CONFIG_BLK_DEV_LOOP_MODULE)
-+	/* and aufs */
-+	struct file *(*real_loop)(struct file *);
-+#endif
- };
- 
- /*
 diff --git a/include/linux/lockdep.h b/include/linux/lockdep.h
 index 67964dc4d..517ef3ea8 100644
 --- a/include/linux/lockdep.h
@@ -39449,14 +37932,14 @@ index 67964dc4d..517ef3ea8 100644
   * Acquire a lock.
   *
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index fdda6b162..f82d034fe 100644
+index 9daa7444d..fbc9b94ec 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
-@@ -2578,6 +2578,54 @@ static inline void unmap_shared_mapping_range(struct address_space *mapping,
+@@ -2616,6 +2616,54 @@ static inline void unmap_shared_mapping_range(struct address_space *mapping,
  static inline struct vm_area_struct *vma_lookup(struct mm_struct *mm,
  						unsigned long addr);
  
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +static inline struct file *vma_prfile_value(struct vm_area_struct *vma)
 +{
 +	return vma->vm_prfile;
@@ -39508,14 +37991,14 @@ index fdda6b162..f82d034fe 100644
  		void *buf, int len, unsigned int gup_flags);
  extern int access_remote_vm(struct mm_struct *mm, unsigned long addr,
 diff --git a/include/linux/mm_types.h b/include/linux/mm_types.h
-index 56d07edd0..d80a493dc 100644
+index 56d07edd0..d5a8bd5e1 100644
 --- a/include/linux/mm_types.h
 +++ b/include/linux/mm_types.h
 @@ -682,6 +682,9 @@ struct vm_region {
  	unsigned long	vm_top;		/* region allocated to here */
  	unsigned long	vm_pgoff;	/* the offset in vm_file corresponding to vm_start */
  	struct file	*vm_file;	/* the backing file or NULL */
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +	struct file	*vm_prfile;	/* the virtual backing file or NULL */
 +#endif
  
@@ -39525,7 +38008,7 @@ index 56d07edd0..d80a493dc 100644
  	unsigned long vm_pgoff;		/* Offset (within vm_file) in PAGE_SIZE
  					   units */
  	struct file * vm_file;		/* File we map to (can be NULL). */
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +	struct file *vm_prfile;		/* shadow of vm_file */
 +#endif
  	void * vm_private_data;		/* was vm_pte (shared mem) */
@@ -39566,26 +38049,13 @@ index 9dec4861d..14583d846 100644
  #endif
 diff --git a/include/uapi/linux/aufs_type.h b/include/uapi/linux/aufs_type.h
 new file mode 100644
-index 000000000..9c4ba527b
+index 000000000..9f1bf8cb4
 --- /dev/null
 +++ b/include/uapi/linux/aufs_type.h
-@@ -0,0 +1,452 @@
+@@ -0,0 +1,439 @@
 +/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +#ifndef __AUFS_TYPE_H__
@@ -39612,7 +38082,7 @@ index 000000000..9c4ba527b
 +#include <limits.h>
 +#endif /* __KERNEL__ */
 +
-+#define AUFS_VERSION	"6.15-20250602"
++#define AUFS_VERSION	"6.15"
 +
 +/* todo? move this to linux-2.6.19/include/magic.h */
 +#define AUFS_SUPER_MAGIC	('a' << 24 | 'u' << 16 | 'f' << 8 | 's')
@@ -40023,10 +38493,10 @@ index 000000000..9c4ba527b
 +
 +#endif /* __AUFS_TYPE_H__ */
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 168681fc4..cf8e0f7ee 100644
+index 39e47bfae..d82a6f7df 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
-@@ -457,6 +457,7 @@ static void vm_area_init_from(const struct vm_area_struct *src,
+@@ -461,6 +461,7 @@ static void vm_area_init_from(const struct vm_area_struct *src,
  	dest->anon_vma = src->anon_vma;
  	dest->vm_pgoff = src->vm_pgoff;
  	dest->vm_file = src->vm_file;
@@ -40034,7 +38504,7 @@ index 168681fc4..cf8e0f7ee 100644
  	dest->vm_private_data = src->vm_private_data;
  	vm_flags_init(dest, src->vm_flags);
  	memcpy(&dest->vm_page_prot, &src->vm_page_prot,
-@@ -711,7 +712,7 @@ static __latent_entropy int dup_mmap(struct mm_struct *mm,
+@@ -715,7 +716,7 @@ static __latent_entropy int dup_mmap(struct mm_struct *mm,
  		if (file) {
  			struct address_space *mapping = file->f_mapping;
  
@@ -40044,7 +38514,7 @@ index 168681fc4..cf8e0f7ee 100644
  			if (vma_is_shared_maywrite(tmp))
  				mapping_allow_writable(mapping);
 diff --git a/kernel/locking/lockdep.c b/kernel/locking/lockdep.c
-index 58d78a33a..0eba3fe81 100644
+index 58d78a33a..2dbd6fe56 100644
 --- a/kernel/locking/lockdep.c
 +++ b/kernel/locking/lockdep.c
 @@ -223,7 +223,7 @@ unsigned long max_lock_class_idx;
@@ -40056,38 +38526,28 @@ index 58d78a33a..0eba3fe81 100644
  {
  	unsigned int class_idx = hlock->class_idx;
  
-@@ -244,6 +244,8 @@ static inline struct lock_class *hlock_class(struct held_lock *hlock)
+@@ -244,6 +244,7 @@ static inline struct lock_class *hlock_class(struct held_lock *hlock)
  	 */
  	return lock_classes + class_idx;
  }
-+EXPORT_SYMBOL_GPL(lockdep_hlock_class);
 +#define hlock_class(hlock) lockdep_hlock_class(hlock)
  
  #ifdef CONFIG_LOCK_STAT
  static DEFINE_PER_CPU(struct lock_class_stats[MAX_LOCKDEP_KEYS], cpu_lock_stats);
-diff --git a/kernel/task_work.c b/kernel/task_work.c
-index d1efec571..eed18cc26 100644
---- a/kernel/task_work.c
-+++ b/kernel/task_work.c
-@@ -230,3 +230,4 @@ void task_work_run(void)
- 		} while (work);
- 	}
- }
-+EXPORT_SYMBOL_GPL(task_work_run);
 diff --git a/mm/Makefile b/mm/Makefile
-index e7f6bbf8a..d47eddf06 100644
+index e7f6bbf8a..aba3d710b 100644
 --- a/mm/Makefile
 +++ b/mm/Makefile
 @@ -148,3 +148,4 @@ obj-$(CONFIG_SHRINKER_DEBUG) += shrinker_debug.o
  obj-$(CONFIG_EXECMEM) += execmem.o
  obj-$(CONFIG_TMPFS_QUOTA) += shmem_quota.o
  obj-$(CONFIG_PT_RECLAIM) += pt_reclaim.o
-+obj-y += prfile.o
++obj-$(CONFIG_AUFS_FS:m=y) += prfile.o
 diff --git a/mm/filemap.c b/mm/filemap.c
-index 7b90cbeb4..eff54887b 100644
+index 6af6d8f29..a38c05dda 100644
 --- a/mm/filemap.c
 +++ b/mm/filemap.c
-@@ -3767,7 +3767,7 @@ vm_fault_t filemap_page_mkwrite(struct vm_fault *vmf)
+@@ -3775,7 +3775,7 @@ vm_fault_t filemap_page_mkwrite(struct vm_fault *vmf)
  	vm_fault_t ret = VM_FAULT_LOCKED;
  
  	sb_start_pagefault(mapping->host->i_sb);
@@ -40097,7 +38557,7 @@ index 7b90cbeb4..eff54887b 100644
  	if (folio->mapping != mapping) {
  		folio_unlock(folio);
 diff --git a/mm/mmap.c b/mm/mmap.c
-index bd210aaf7..58b29e67b 100644
+index bd210aaf7..a1af5fb2e 100644
 --- a/mm/mmap.c
 +++ b/mm/mmap.c
 @@ -1098,6 +1098,7 @@ SYSCALL_DEFINE5(remap_file_pages, unsigned long, start, unsigned long, size,
@@ -40140,7 +38600,7 @@ index bd210aaf7..58b29e67b 100644
  
  	ret = do_mmap(vma->vm_file, start, size,
  			prot, flags, 0, pgoff, &populate, NULL);
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +	if (!IS_ERR_VALUE(ret) && file && prfile) {
 +		struct vm_area_struct *new_vma;
 +
@@ -40301,10 +38761,10 @@ index 000000000..b034d160a
 +}
 +#endif /* !CONFIG_MMU */
 diff --git a/mm/vma.c b/mm/vma.c
-index a468d4c29..aef6d4781 100644
+index 81df9487c..75b986c7e 100644
 --- a/mm/vma.c
 +++ b/mm/vma.c
-@@ -345,7 +345,7 @@ static void vma_complete(struct vma_prepare *vp, struct vma_iterator *vmi,
+@@ -351,7 +351,7 @@ static void vma_complete(struct vma_prepare *vp, struct vma_iterator *vmi,
  		if (vp->file) {
  			uprobe_munmap(vp->remove, vp->remove->vm_start,
  				      vp->remove->vm_end);
@@ -40313,7 +38773,7 @@ index a468d4c29..aef6d4781 100644
  		}
  		if (vp->remove->anon_vma)
  			anon_vma_merge(vp->vma, vp->remove);
-@@ -425,7 +425,7 @@ void remove_vma(struct vm_area_struct *vma)
+@@ -431,7 +431,7 @@ void remove_vma(struct vm_area_struct *vma)
  	might_sleep();
  	vma_close(vma);
  	if (vma->vm_file)
@@ -40322,7 +38782,7 @@ index a468d4c29..aef6d4781 100644
  	mpol_put(vma_policy(vma));
  	vm_area_free(vma);
  }
-@@ -499,7 +499,7 @@ __split_vma(struct vma_iterator *vmi, struct vm_area_struct *vma,
+@@ -505,7 +505,7 @@ __split_vma(struct vma_iterator *vmi, struct vm_area_struct *vma,
  		goto out_free_mpol;
  
  	if (new->vm_file)
@@ -40331,7 +38791,7 @@ index a468d4c29..aef6d4781 100644
  
  	if (new->vm_ops && new->vm_ops->open)
  		new->vm_ops->open(new);
-@@ -1824,7 +1824,7 @@ struct vm_area_struct *copy_vma(struct vm_area_struct **vmap,
+@@ -1831,7 +1831,7 @@ struct vm_area_struct *copy_vma(struct vm_area_struct **vmap,
  		if (anon_vma_clone(new_vma, vma))
  			goto out_free_mempol;
  		if (new_vma->vm_file)
@@ -40340,7 +38800,7 @@ index a468d4c29..aef6d4781 100644
  		if (new_vma->vm_ops && new_vma->vm_ops->open)
  			new_vma->vm_ops->open(new_vma);
  		if (vma_link(mm, new_vma))
-@@ -1838,7 +1838,7 @@ struct vm_area_struct *copy_vma(struct vm_area_struct **vmap,
+@@ -1845,7 +1845,7 @@ struct vm_area_struct *copy_vma(struct vm_area_struct **vmap,
  	vma_close(new_vma);
  
  	if (new_vma->vm_file)
@@ -40349,74 +38809,3 @@ index a468d4c29..aef6d4781 100644
  
  	unlink_anon_vmas(new_vma);
  out_free_mempol:
-diff --git a/security/security.c b/security/security.c
-index fb57e8fdd..bb46cbe40 100644
---- a/security/security.c
-+++ b/security/security.c
-@@ -1948,6 +1948,7 @@ int security_path_rmdir(const struct path *dir, struct dentry *dentry)
- 		return 0;
- 	return call_int_hook(path_rmdir, dir, dentry);
- }
-+EXPORT_SYMBOL_GPL(security_path_rmdir);
- 
- /**
-  * security_path_unlink() - Check if removing a hard link is allowed
-@@ -1983,6 +1984,7 @@ int security_path_symlink(const struct path *dir, struct dentry *dentry,
- 		return 0;
- 	return call_int_hook(path_symlink, dir, dentry, old_name);
- }
-+EXPORT_SYMBOL_GPL(security_path_symlink);
- 
- /**
-  * security_path_link - Check if creating a hard link is allowed
-@@ -2001,6 +2003,7 @@ int security_path_link(struct dentry *old_dentry, const struct path *new_dir,
- 		return 0;
- 	return call_int_hook(path_link, old_dentry, new_dir, new_dentry);
- }
-+EXPORT_SYMBOL_GPL(security_path_link);
- 
- /**
-  * security_path_rename() - Check if renaming a file is allowed
-@@ -2062,6 +2065,7 @@ int security_path_chmod(const struct path *path, umode_t mode)
- 		return 0;
- 	return call_int_hook(path_chmod, path, mode);
- }
-+EXPORT_SYMBOL_GPL(security_path_chmod);
- 
- /**
-  * security_path_chown() - Check if changing the file's owner/group is allowed
-@@ -2079,6 +2083,7 @@ int security_path_chown(const struct path *path, kuid_t uid, kgid_t gid)
- 		return 0;
- 	return call_int_hook(path_chown, path, uid, gid);
- }
-+EXPORT_SYMBOL_GPL(security_path_chown);
- 
- /**
-  * security_path_chroot() - Check if changing the root directory is allowed
-@@ -2323,6 +2328,7 @@ int security_inode_permission(struct inode *inode, int mask)
- 		return 0;
- 	return call_int_hook(inode_permission, inode, mask);
- }
-+EXPORT_SYMBOL_GPL(security_inode_permission);
- 
- /**
-  * security_inode_setattr() - Check if setting file attributes is allowed
-@@ -2843,6 +2849,7 @@ int security_file_permission(struct file *file, int mask)
- {
- 	return call_int_hook(file_permission, file, mask);
- }
-+EXPORT_SYMBOL_GPL(security_file_permission);
- 
- /**
-  * security_file_alloc() - Allocate and init a file's LSM blob
-@@ -3145,6 +3152,7 @@ int security_file_truncate(struct file *file)
- {
- 	return call_int_hook(file_truncate, file);
- }
-+EXPORT_SYMBOL_GPL(security_file_truncate);
- 
- /**
-  * security_task_alloc() - Allocate a task's LSM blob
--- 
-2.49.0
-

--- a/6.15/misc/0001-handheld.patch
+++ b/6.15/misc/0001-handheld.patch
@@ -1,6 +1,6 @@
-From f6d8f6b0166819f536040ccafa655f166523423b Mon Sep 17 00:00:00 2001
+From 680188f95b7db812cadffd613f15539f6091aad7 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
-Date: Sun, 6 Jul 2025 12:04:35 +0200
+Date: Sun, 17 Aug 2025 21:45:07 +0800
 Subject: [PATCH] handheld
 
 Signed-off-by: Peter Jung <admin@ptr1337.dev>
@@ -107,7 +107,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
 
 diff --git a/Documentation/wmi/devices/lenovo-wmi-gamezone.rst b/Documentation/wmi/devices/lenovo-wmi-gamezone.rst
 new file mode 100644
-index 000000000000..997263e51a7d
+index 000000000..997263e51
 --- /dev/null
 +++ b/Documentation/wmi/devices/lenovo-wmi-gamezone.rst
 @@ -0,0 +1,203 @@
@@ -316,7 +316,7 @@ index 000000000000..997263e51a7d
 +  };
 diff --git a/Documentation/wmi/devices/lenovo-wmi-other.rst b/Documentation/wmi/devices/lenovo-wmi-other.rst
 new file mode 100644
-index 000000000000..d7928b8dfb4b
+index 000000000..d7928b8df
 --- /dev/null
 +++ b/Documentation/wmi/devices/lenovo-wmi-other.rst
 @@ -0,0 +1,108 @@
@@ -429,7 +429,7 @@ index 000000000000..d7928b8dfb4b
 +    [WmiDataId(4), read, Description("Default Value"), WmiSizeIs("DataSize")] uint8 DefaultValue[];
 +  };
 diff --git a/Documentation/wmi/devices/msi-wmi-platform.rst b/Documentation/wmi/devices/msi-wmi-platform.rst
-index 73197b31926a..704bfdac5203 100644
+index 73197b319..704bfdac5 100644
 --- a/Documentation/wmi/devices/msi-wmi-platform.rst
 +++ b/Documentation/wmi/devices/msi-wmi-platform.rst
 @@ -169,6 +169,32 @@ The fan RPM readings can be calculated with the following formula:
@@ -466,10 +466,10 @@ index 73197b31926a..704bfdac5203 100644
  --------------------
  
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 4feb3b9f8f73..eae65abb447e 100644
+index dd844ac8d..a6ee1dd59 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -13479,12 +13479,35 @@ S:	Maintained
+@@ -13474,12 +13474,35 @@ S:	Maintained
  W:	http://legousb.sourceforge.net/
  F:	drivers/usb/misc/legousbtower.c
  
@@ -506,7 +506,7 @@ index 4feb3b9f8f73..eae65abb447e 100644
  M:	Hans de Goede <hdegoede@redhat.com>
  L:	linux-input@vger.kernel.org
 diff --git a/drivers/acpi/acpica/acinterp.h b/drivers/acpi/acpica/acinterp.h
-index 955114c926bd..d02779ee9210 100644
+index 955114c92..d02779ee9 100644
 --- a/drivers/acpi/acpica/acinterp.h
 +++ b/drivers/acpi/acpica/acinterp.h
 @@ -120,6 +120,9 @@ void
@@ -520,7 +520,7 @@ index 955114c926bd..d02779ee9210 100644
   * exfield - ACPI AML (p-code) execution - field manipulation
   */
 diff --git a/drivers/acpi/acpica/dsmthdat.c b/drivers/acpi/acpica/dsmthdat.c
-index eca50517ad82..5393de4dbc4c 100644
+index eca50517a..5393de4db 100644
 --- a/drivers/acpi/acpica/dsmthdat.c
 +++ b/drivers/acpi/acpica/dsmthdat.c
 @@ -188,6 +188,7 @@ acpi_ds_method_data_init_args(union acpi_operand_object **params,
@@ -532,7 +532,7 @@ index eca50517ad82..5393de4dbc4c 100644
  	ACPI_DEBUG_PRINT((ACPI_DB_EXEC, "%u args passed to method\n", index));
  	return_ACPI_STATUS(AE_OK);
 diff --git a/drivers/acpi/acpica/extrace.c b/drivers/acpi/acpica/extrace.c
-index f1730221ff13..08fb94eb7870 100644
+index f1730221f..08fb94eb7 100644
 --- a/drivers/acpi/acpica/extrace.c
 +++ b/drivers/acpi/acpica/extrace.c
 @@ -147,6 +147,57 @@ acpi_ex_trace_point(acpi_trace_event_type type,
@@ -594,7 +594,7 @@ index f1730221ff13..08fb94eb7870 100644
   *
   * FUNCTION:    acpi_ex_start_trace_method
 diff --git a/drivers/extcon/Kconfig b/drivers/extcon/Kconfig
-index a6f6d467aacf..4adec844c4b4 100644
+index a6f6d467a..4adec844c 100644
 --- a/drivers/extcon/Kconfig
 +++ b/drivers/extcon/Kconfig
 @@ -214,4 +214,11 @@ config EXTCON_RTK_TYPE_C
@@ -610,7 +610,7 @@ index a6f6d467aacf..4adec844c4b4 100644
 +
  endif
 diff --git a/drivers/extcon/Makefile b/drivers/extcon/Makefile
-index 0d6d23faf748..6eb613e0bcba 100644
+index 0d6d23faf..6eb613e0b 100644
 --- a/drivers/extcon/Makefile
 +++ b/drivers/extcon/Makefile
 @@ -27,3 +27,4 @@ obj-$(CONFIG_EXTCON_USB_GPIO)	+= extcon-usb-gpio.o
@@ -620,7 +620,7 @@ index 0d6d23faf748..6eb613e0bcba 100644
 +obj-$(CONFIG_EXTCON_STEAMDECK)  += extcon-steamdeck.o
 diff --git a/drivers/extcon/extcon-steamdeck.c b/drivers/extcon/extcon-steamdeck.c
 new file mode 100644
-index 000000000000..49cb5d30bf6b
+index 000000000..49cb5d30b
 --- /dev/null
 +++ b/drivers/extcon/extcon-steamdeck.c
 @@ -0,0 +1,180 @@
@@ -805,7 +805,7 @@ index 000000000000..49cb5d30bf6b
 +MODULE_DESCRIPTION("Steam Deck extcon driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h b/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
-index 6da4f946cac0..5b639276939d 100644
+index 6da4f946c..5b6392769 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
 @@ -435,8 +435,6 @@ struct amdgpu_mode_info {
@@ -818,7 +818,7 @@ index 6da4f946cac0..5b639276939d 100644
  	struct amdgpu_encoder *encoder;
  	uint8_t negative;
 diff --git a/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c b/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
-index a51f3414b65d..bc0f9759c5c5 100644
+index a51f3414b..bc0f9759c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
 +++ b/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
 @@ -39,6 +39,10 @@
@@ -853,7 +853,7 @@ index a51f3414b65d..bc0f9759c5c5 100644
  	snprintf(bl_name, sizeof(bl_name),
  		 "amdgpu_bl%d", dev->primary->index);
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
-index 927fb4992a6a..2f8193a5c803 100644
+index 82e847bf0..0a926f409 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
 @@ -166,6 +166,9 @@ MODULE_FIRMWARE(FIRMWARE_DCN_401_DMUB);
@@ -866,7 +866,7 @@ index 927fb4992a6a..2f8193a5c803 100644
  /**
   * DOC: overview
   *
-@@ -9171,7 +9174,7 @@ static void amdgpu_dm_commit_planes(struct drm_atomic_state *state,
+@@ -9173,7 +9176,7 @@ static void amdgpu_dm_commit_planes(struct drm_atomic_state *state,
  	int planes_count = 0, vpos, hpos;
  	unsigned long flags;
  	u32 target_vblank, last_flip_vblank;
@@ -876,7 +876,7 @@ index 927fb4992a6a..2f8193a5c803 100644
  	bool pflip_present = false;
  	bool dirty_rects_changed = false;
 diff --git a/drivers/gpu/drm/amd/display/dc/dc.h b/drivers/gpu/drm/amd/display/dc/dc.h
-index 0761fc95a158..2081f0f5b907 100644
+index 0761fc95a..2081f0f5b 100644
 --- a/drivers/gpu/drm/amd/display/dc/dc.h
 +++ b/drivers/gpu/drm/amd/display/dc/dc.h
 @@ -58,7 +58,7 @@ struct dmub_notification;
@@ -889,7 +889,7 @@ index 0761fc95a158..2081f0f5b907 100644
   * MAX_PLANES - representative of the upper bound of planes that are supported by the HW
   */
 diff --git a/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c b/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
-index a998c498a477..f4ef774e07e0 100644
+index a998c498a..f4ef774e0 100644
 --- a/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
 +++ b/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
 @@ -96,6 +96,8 @@
@@ -916,7 +916,7 @@ index a998c498a477..f4ef774e07e0 100644
  	/*
  	 * Add the logic to extract BOTH power up and power down sequences
 diff --git a/drivers/gpu/drm/amd/display/dc/link/link_validation.c b/drivers/gpu/drm/amd/display/dc/link/link_validation.c
-index 29606fda029d..ff127f8a405b 100644
+index 29606fda0..ff127f8a4 100644
 --- a/drivers/gpu/drm/amd/display/dc/link/link_validation.c
 +++ b/drivers/gpu/drm/amd/display/dc/link/link_validation.c
 @@ -35,6 +35,8 @@
@@ -945,7 +945,7 @@ index 29606fda029d..ff127f8a405b 100644
  
  	/* TODO: DYNAMIC_VALIDATION needs to be implemented */
 diff --git a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
-index 121a86a59833..60ab2e3a5921 100644
+index 121a86a59..60ab2e3a5 100644
 --- a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
 +++ b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
 @@ -1437,9 +1437,9 @@ static bool dcn301_resource_construct(
@@ -962,7 +962,7 @@ index 121a86a59833..60ab2e3a5921 100644
  	dc->caps.post_blend_color_processing = true;
  	dc->caps.force_dp_tps4_for_cp2520 = true;
 diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
-index 7ac0fd5391fe..323dd636352b 100644
+index 7ac0fd539..323dd6363 100644
 --- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
 +++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
 @@ -485,6 +485,42 @@ static const struct dmi_system_id orientation_data[] = {
@@ -1009,10 +1009,10 @@ index 7ac0fd5391fe..323dd636352b 100644
  		.matches = {
  		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "OrangePi"),
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index e7688c7fdc56..4f7feaac983c 100644
+index e2fb06ece..908ec9f15 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
-@@ -1418,6 +1418,10 @@ config HID_KUNIT_TEST
+@@ -1427,6 +1427,10 @@ config HID_KUNIT_TEST
  
  	  If in doubt, say "N".
  
@@ -1023,7 +1023,7 @@ index e7688c7fdc56..4f7feaac983c 100644
  endmenu
  
  source "drivers/hid/bpf/Kconfig"
-@@ -1444,4 +1448,8 @@ source "drivers/hid/spi-hid/Kconfig"
+@@ -1451,4 +1455,8 @@ source "drivers/hid/spi-hid/Kconfig"
  
  source "drivers/hid/dockchannel-hid/Kconfig"
  
@@ -1033,12 +1033,12 @@ index e7688c7fdc56..4f7feaac983c 100644
 +
  endif # HID_SUPPORT
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index a0f58475434c..137fc917a174 100644
+index f67db3d5d..cdca02dc4 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
-@@ -174,10 +174,16 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
+@@ -173,10 +173,16 @@ obj-$(CONFIG_INTEL_ISH_HID)	+= intel-ish-hid/
  
- obj-$(CONFIG_ASUS_ALLY_HID)  += asus-ally-hid/
+ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
  
 +obj-$(CONFIG_ZOTAC_ZONE_HID)  += zotac-zone-hid/
 +
@@ -1054,10 +1054,10 @@ index a0f58475434c..137fc917a174 100644
  
  obj-$(CONFIG_HID_DOCKCHANNEL)   += dockchannel-hid/
 diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
-index b991ed962366..a589f9c9b661 100644
+index 4cd85b46d..9959dee01 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2838,6 +2838,17 @@ static int hid_uevent(const struct device *dev, struct kobj_uevent_env *env)
+@@ -2851,6 +2851,17 @@ static int hid_uevent(const struct device *dev, struct kobj_uevent_env *env)
  	if (add_uevent_var(env, "MODALIAS=hid:b%04Xg%04Xv%08Xp%08X",
  			   hdev->bus, hdev->group, hdev->vendor, hdev->product))
  		return -ENOMEM;
@@ -1076,10 +1076,10 @@ index b991ed962366..a589f9c9b661 100644
  	return 0;
  }
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index 70efd28b6bc3..69f6368d3f71 100644
+index 4af0fa7c8..0c173e592 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
-@@ -720,6 +720,10 @@
+@@ -722,6 +722,10 @@
  #define USB_DEVICE_ID_ITE8595		0x8595
  #define USB_DEVICE_ID_ITE_MEDION_E1239T	0xce50
  
@@ -1090,7 +1090,7 @@ index 70efd28b6bc3..69f6368d3f71 100644
  #define USB_VENDOR_ID_JABRA		0x0b0e
  #define USB_DEVICE_ID_JABRA_SPEAK_410	0x0412
  #define USB_DEVICE_ID_JABRA_SPEAK_510	0x0420
-@@ -1049,6 +1053,7 @@
+@@ -1052,6 +1056,7 @@
  #define USB_VENDOR_ID_NOVATEK		0x0603
  #define USB_DEVICE_ID_NOVATEK_PCT	0x0600
  #define USB_DEVICE_ID_NOVATEK_MOUSE	0x1602
@@ -1098,7 +1098,7 @@ index 70efd28b6bc3..69f6368d3f71 100644
  
  #define USB_VENDOR_ID_NTI               0x0757
  #define USB_DEVICE_ID_USB_SUN           0x0a00
-@@ -1502,6 +1507,10 @@
+@@ -1505,6 +1510,10 @@
  #define USB_VENDOR_ID_ZYTRONIC		0x14c8
  #define USB_DEVICE_ID_ZYTRONIC_ZXY100	0x0005
  
@@ -1110,7 +1110,7 @@ index 70efd28b6bc3..69f6368d3f71 100644
  #define USB_DEVICE_ID_PRIMAX_MOUSE_4D22	0x4d22
  #define USB_DEVICE_ID_PRIMAX_MOUSE_4E2A	0x4e2a
 diff --git a/drivers/hid/hid-input.c b/drivers/hid/hid-input.c
-index 9d80635a91eb..08e87577feef 100644
+index 9d80635a9..08e87577f 100644
 --- a/drivers/hid/hid-input.c
 +++ b/drivers/hid/hid-input.c
 @@ -390,6 +390,8 @@ static const struct hid_device_id hid_battery_quirks[] = {
@@ -1124,7 +1124,7 @@ index 9d80635a91eb..08e87577feef 100644
  
 diff --git a/drivers/hid/hid-msi-claw.c b/drivers/hid/hid-msi-claw.c
 new file mode 100644
-index 000000000000..2d009bc5f85b
+index 000000000..2d009bc5f
 --- /dev/null
 +++ b/drivers/hid/hid-msi-claw.c
 @@ -0,0 +1,484 @@
@@ -1614,7 +1614,7 @@ index 000000000000..2d009bc5f85b
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/lenovo-legos-hid/Kconfig b/drivers/hid/lenovo-legos-hid/Kconfig
 new file mode 100644
-index 000000000000..6918b25e191c
+index 000000000..6918b25e1
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/Kconfig
 @@ -0,0 +1,11 @@
@@ -1631,7 +1631,7 @@ index 000000000000..6918b25e191c
 +	  be called lenovo-legos-hid.
 diff --git a/drivers/hid/lenovo-legos-hid/Makefile b/drivers/hid/lenovo-legos-hid/Makefile
 new file mode 100644
-index 000000000000..e346f70f78ae
+index 000000000..e346f70f7
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/Makefile
 @@ -0,0 +1,6 @@
@@ -1643,7 +1643,7 @@ index 000000000000..e346f70f78ae
 +obj-$(CONFIG_LENOVO_LEGOS_HID)	:= lenovo-legos-hid.o
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.c b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.c
 new file mode 100644
-index 000000000000..7a42cf5bfd2b
+index 000000000..7a42cf5bf
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.c
 @@ -0,0 +1,1571 @@
@@ -3220,7 +3220,7 @@ index 000000000000..7a42cf5bfd2b
 +}
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.h b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.h
 new file mode 100644
-index 000000000000..3d13744e2692
+index 000000000..3d13744e2
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.h
 @@ -0,0 +1,19 @@
@@ -3245,7 +3245,7 @@ index 000000000000..3d13744e2692
 +#endif /* !_LENOVO_LEGOS_HID_CONFIG_*/
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.c b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.c
 new file mode 100644
-index 000000000000..751f4addabd8
+index 000000000..751f4adda
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.c
 @@ -0,0 +1,122 @@
@@ -3373,7 +3373,7 @@ index 000000000000..751f4addabd8
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.h b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.h
 new file mode 100644
-index 000000000000..efbc50896536
+index 000000000..efbc50896
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.h
 @@ -0,0 +1,25 @@
@@ -3404,7 +3404,7 @@ index 000000000000..efbc50896536
 +#endif /* !_LENOVO_LEGOS_HID_CORE_*/
 diff --git a/drivers/hid/zotac-zone-hid/Kconfig b/drivers/hid/zotac-zone-hid/Kconfig
 new file mode 100644
-index 000000000000..89fb2ac080bb
+index 000000000..89fb2ac08
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/Kconfig
 @@ -0,0 +1,8 @@
@@ -3418,7 +3418,7 @@ index 000000000000..89fb2ac080bb
 +	Support for the Zotac Zone handheld gaming console.
 diff --git a/drivers/hid/zotac-zone-hid/Makefile b/drivers/hid/zotac-zone-hid/Makefile
 new file mode 100644
-index 000000000000..2f7053b981ac
+index 000000000..2f7053b98
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/Makefile
 @@ -0,0 +1,6 @@
@@ -3430,7 +3430,7 @@ index 000000000000..2f7053b981ac
 +obj-$(CONFIG_ZOTAC_ZONE_HID) := zotac-zone-hid.o
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-config.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-config.c
 new file mode 100644
-index 000000000000..049615194392
+index 000000000..049615194
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-config.c
 @@ -0,0 +1,2231 @@
@@ -5667,7 +5667,7 @@ index 000000000000..049615194392
 +}
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-core.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-core.c
 new file mode 100644
-index 000000000000..6f80ea2f9aad
+index 000000000..6f80ea2f9
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-core.c
 @@ -0,0 +1,597 @@
@@ -6270,7 +6270,7 @@ index 000000000000..6f80ea2f9aad
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-input.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-input.c
 new file mode 100644
-index 000000000000..571eec2df446
+index 000000000..571eec2df
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-input.c
 @@ -0,0 +1,522 @@
@@ -6798,7 +6798,7 @@ index 000000000000..571eec2df446
 +}
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-rgb.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-rgb.c
 new file mode 100644
-index 000000000000..0305de2bd549
+index 000000000..0305de2bd
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-rgb.c
 @@ -0,0 +1,717 @@
@@ -7521,7 +7521,7 @@ index 000000000000..0305de2bd549
 +}
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone.h b/drivers/hid/zotac-zone-hid/zotac-zone.h
 new file mode 100644
-index 000000000000..31188cee80f8
+index 000000000..31188cee8
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone.h
 @@ -0,0 +1,214 @@
@@ -7740,7 +7740,7 @@ index 000000000000..31188cee80f8
 +
 +#endif /* __HID_ZOTAC_ZONE_H */
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index f91f713b0105..4d645de56bec 100644
+index f91f713b0..4d645de56 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -2110,6 +2110,17 @@ config SENSORS_SCH5636
@@ -7762,7 +7762,7 @@ index f91f713b0105..4d645de56bec 100644
  	tristate "ST Microelectronics STTS751"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index 766c652ef22b..d669fb4a8218 100644
+index 766c652ef..d669fb4a8 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -212,6 +212,7 @@ obj-$(CONFIG_SENSORS_SMSC47B397)+= smsc47b397.o
@@ -7775,7 +7775,7 @@ index 766c652ef22b..d669fb4a8218 100644
  obj-$(CONFIG_SENSORS_SURFACE_FAN)+= surface_fan.o
 diff --git a/drivers/hwmon/steamdeck-hwmon.c b/drivers/hwmon/steamdeck-hwmon.c
 new file mode 100644
-index 000000000000..9d0a5471b181
+index 000000000..9d0a5471b
 --- /dev/null
 +++ b/drivers/hwmon/steamdeck-hwmon.c
 @@ -0,0 +1,294 @@
@@ -8074,10 +8074,10 @@ index 000000000000..9d0a5471b181
 +MODULE_DESCRIPTION("Steam Deck EC sensors driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/input/joystick/xpad.c b/drivers/input/joystick/xpad.c
-index 1008858f78e2..8e3cf2a55bea 100644
+index c963aac4d..1101aa28e 100644
 --- a/drivers/input/joystick/xpad.c
 +++ b/drivers/input/joystick/xpad.c
-@@ -353,7 +353,9 @@ static const struct xpad_device {
+@@ -354,7 +354,9 @@ static const struct xpad_device {
  	{ 0x1bad, 0xfa01, "MadCatz GamePad", 0, XTYPE_XBOX360 },
  	{ 0x1bad, 0xfd00, "Razer Onza TE", 0, XTYPE_XBOX360 },
  	{ 0x1bad, 0xfd01, "Razer Onza", 0, XTYPE_XBOX360 },
@@ -8087,7 +8087,7 @@ index 1008858f78e2..8e3cf2a55bea 100644
  	{ 0x20d6, 0x2001, "BDA Xbox Series X Wired Controller", 0, XTYPE_XBOXONE },
  	{ 0x20d6, 0x2009, "PowerA Enhanced Wired Controller for Xbox Series X|S", 0, XTYPE_XBOXONE },
  	{ 0x20d6, 0x2064, "PowerA Wired Controller for Xbox", MAP_SHARE_BUTTON, XTYPE_XBOXONE },
-@@ -550,7 +552,9 @@ static const struct usb_device_id xpad_table[] = {
+@@ -552,7 +554,9 @@ static const struct usb_device_id xpad_table[] = {
  	XPAD_XBOX360_VENDOR(0x1949),		/* Amazon controllers */
  	XPAD_XBOX360_VENDOR(0x1a86),		/* Nanjing Qinheng Microelectronics (WCH) */
  	XPAD_XBOX360_VENDOR(0x1bad),		/* Harmonix Rock Band guitar and drums */
@@ -8098,7 +8098,7 @@ index 1008858f78e2..8e3cf2a55bea 100644
  	XPAD_XBOXONE_VENDOR(0x20d6),		/* PowerA controllers */
  	XPAD_XBOX360_VENDOR(0x2345),		/* Machenike Controllers */
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index a104cbb0a001..6fd7921006f9 100644
+index a104cbb0a..6fd792100 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -1013,6 +1013,13 @@ config LEDS_ACER_A500
@@ -8116,7 +8116,7 @@ index a104cbb0a001..6fd7921006f9 100644
  
  comment "Flash and Torch LED drivers"
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 2f170d69dcbf..10bf84080e28 100644
+index 2f170d69d..10bf84080 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -85,6 +85,7 @@ obj-$(CONFIG_LEDS_QNAP_MCU)		+= leds-qnap-mcu.o
@@ -8129,7 +8129,7 @@ index 2f170d69dcbf..10bf84080e28 100644
  obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
 diff --git a/drivers/leds/leds-steamdeck.c b/drivers/leds/leds-steamdeck.c
 new file mode 100644
-index 000000000000..3d56ec4403cd
+index 000000000..3d56ec440
 --- /dev/null
 +++ b/drivers/leds/leds-steamdeck.c
 @@ -0,0 +1,123 @@
@@ -8257,7 +8257,7 @@ index 000000000000..3d56ec4403cd
 +MODULE_DESCRIPTION("Steam Deck LEDs driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 22b936310039..a788bb645c95 100644
+index 22b936310..a788bb645 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2422,5 +2422,16 @@ config MFD_UPBOARD_FPGA
@@ -8278,7 +8278,7 @@ index 22b936310039..a788bb645c95 100644
  endmenu
  endif
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 948cbdf42a18..e14823b233e3 100644
+index 948cbdf42..e14823b23 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -289,4 +289,6 @@ obj-$(CONFIG_MFD_QNAP_MCU)	+= qnap-mcu.o
@@ -8290,7 +8290,7 @@ index 948cbdf42a18..e14823b233e3 100644
  obj-$(CONFIG_MFD_UPBOARD_FPGA)	+= upboard-fpga.o
 diff --git a/drivers/mfd/steamdeck.c b/drivers/mfd/steamdeck.c
 new file mode 100644
-index 000000000000..a60fa7db9141
+index 000000000..a60fa7db9
 --- /dev/null
 +++ b/drivers/mfd/steamdeck.c
 @@ -0,0 +1,147 @@
@@ -8442,7 +8442,7 @@ index 000000000000..a60fa7db9141
 +MODULE_DESCRIPTION("Steam Deck EC MFD core driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/net/wireless/ath/ath11k/core.c b/drivers/net/wireless/ath/ath11k/core.c
-index 0281ce6fb717..e76a020d4fbb 100644
+index 0281ce6fb..e76a020d4 100644
 --- a/drivers/net/wireless/ath/ath11k/core.c
 +++ b/drivers/net/wireless/ath/ath11k/core.c
 @@ -732,7 +732,7 @@ static const struct ath11k_hw_params ath11k_hw_params[] = {
@@ -8455,7 +8455,7 @@ index 0281ce6fb717..e76a020d4fbb 100644
  			.cal_offset = 128 * 1024,
  		},
 diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
-index 731d18308cb6..6507dffc2aa4 100644
+index 731d18308..6507dffc2 100644
 --- a/drivers/platform/x86/Kconfig
 +++ b/drivers/platform/x86/Kconfig
 @@ -482,6 +482,47 @@ config IBM_RTL
@@ -8536,10 +8536,10 @@ index 731d18308cb6..6507dffc2aa4 100644
  
  config P2SB
 diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index 3a0085f941d9..14f22d19bda0 100644
+index c2461ca2e..357025559 100644
 --- a/drivers/platform/x86/Makefile
 +++ b/drivers/platform/x86/Makefile
-@@ -70,6 +70,11 @@ obj-$(CONFIG_THINKPAD_LMI)	+= think-lmi.o
+@@ -72,6 +72,11 @@ obj-$(CONFIG_THINKPAD_LMI)	+= think-lmi.o
  obj-$(CONFIG_YOGABOOK)		+= lenovo-yogabook.o
  obj-$(CONFIG_YT2_1380)		+= lenovo-yoga-tab2-pro-1380-fastcharger.o
  obj-$(CONFIG_LENOVO_WMI_CAMERA)	+= lenovo-wmi-camera.o
@@ -8551,7 +8551,7 @@ index 3a0085f941d9..14f22d19bda0 100644
  
  # Intel
  obj-y				+= intel/
-@@ -155,3 +160,5 @@ obj-$(CONFIG_WINMATE_FM07_KEYS)		+= winmate-fm07-keys.o
+@@ -156,3 +161,5 @@ obj-$(CONFIG_WINMATE_FM07_KEYS)		+= winmate-fm07-keys.o
  
  # SEL
  obj-$(CONFIG_SEL3350_PLATFORM)		+= sel3350-platform.o
@@ -8559,7 +8559,7 @@ index 3a0085f941d9..14f22d19bda0 100644
 +obj-$(CONFIG_ZOTAC_ZONE_PLATFORM)		+= zotac-zone-platform.o
 diff --git a/drivers/platform/x86/lenovo-wmi-capdata01.c b/drivers/platform/x86/lenovo-wmi-capdata01.c
 new file mode 100644
-index 000000000000..2bd862a75c71
+index 000000000..2bd862a75
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-capdata01.c
 @@ -0,0 +1,302 @@
@@ -8867,7 +8867,7 @@ index 000000000000..2bd862a75c71
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-capdata01.h b/drivers/platform/x86/lenovo-wmi-capdata01.h
 new file mode 100644
-index 000000000000..bd06c5751f68
+index 000000000..bd06c5751
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-capdata01.h
 @@ -0,0 +1,25 @@
@@ -8898,7 +8898,7 @@ index 000000000000..bd06c5751f68
 +#endif /* !_LENOVO_WMI_CAPDATA01_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-events.c b/drivers/platform/x86/lenovo-wmi-events.c
 new file mode 100644
-index 000000000000..2e0bbda5b976
+index 000000000..2e0bbda5b
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-events.c
 @@ -0,0 +1,196 @@
@@ -9100,7 +9100,7 @@ index 000000000000..2e0bbda5b976
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-events.h b/drivers/platform/x86/lenovo-wmi-events.h
 new file mode 100644
-index 000000000000..cd34e886912c
+index 000000000..cd34e8869
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-events.h
 @@ -0,0 +1,20 @@
@@ -9126,7 +9126,7 @@ index 000000000000..cd34e886912c
 +#endif /* !_LENOVO_WMI_EVENTS_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-gamezone.c b/drivers/platform/x86/lenovo-wmi-gamezone.c
 new file mode 100644
-index 000000000000..261284de22b6
+index 000000000..261284de2
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-gamezone.c
 @@ -0,0 +1,407 @@
@@ -9539,7 +9539,7 @@ index 000000000000..261284de22b6
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-gamezone.h b/drivers/platform/x86/lenovo-wmi-gamezone.h
 new file mode 100644
-index 000000000000..6b163a5eeb95
+index 000000000..6b163a5ee
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-gamezone.h
 @@ -0,0 +1,20 @@
@@ -9565,7 +9565,7 @@ index 000000000000..6b163a5eeb95
 +#endif /* !_LENOVO_WMI_GAMEZONE_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-helpers.c b/drivers/platform/x86/lenovo-wmi-helpers.c
 new file mode 100644
-index 000000000000..4a194aad1ed0
+index 000000000..4a194aad1
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-helpers.c
 @@ -0,0 +1,74 @@
@@ -9645,7 +9645,7 @@ index 000000000000..4a194aad1ed0
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-helpers.h b/drivers/platform/x86/lenovo-wmi-helpers.h
 new file mode 100644
-index 000000000000..20fd21749803
+index 000000000..20fd21749
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-helpers.h
 @@ -0,0 +1,20 @@
@@ -9671,7 +9671,7 @@ index 000000000000..20fd21749803
 +#endif /* !_LENOVO_WMI_HELPERS_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-other.c b/drivers/platform/x86/lenovo-wmi-other.c
 new file mode 100644
-index 000000000000..299fc87189ec
+index 000000000..299fc8718
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-other.c
 @@ -0,0 +1,665 @@
@@ -10342,7 +10342,7 @@ index 000000000000..299fc87189ec
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-other.h b/drivers/platform/x86/lenovo-wmi-other.h
 new file mode 100644
-index 000000000000..8ebf5602bb99
+index 000000000..8ebf5602b
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-other.h
 @@ -0,0 +1,16 @@
@@ -10363,7 +10363,7 @@ index 000000000000..8ebf5602bb99
 +
 +#endif /* !_LENOVO_WMI_OTHER_H_ */
 diff --git a/drivers/platform/x86/msi-wmi-platform.c b/drivers/platform/x86/msi-wmi-platform.c
-index dc5e9878cb68..b00b2b52e0f2 100644
+index dc5e9878c..b00b2b52e 100644
 --- a/drivers/platform/x86/msi-wmi-platform.c
 +++ b/drivers/platform/x86/msi-wmi-platform.c
 @@ -1,8 +1,9 @@
@@ -11775,7 +11775,7 @@ index dc5e9878cb68..b00b2b52e0f2 100644
  module_wmi_driver(msi_wmi_platform_driver);
 diff --git a/drivers/platform/x86/zotac-zone-platform.c b/drivers/platform/x86/zotac-zone-platform.c
 new file mode 100644
-index 000000000000..d097f7b9c5a0
+index 000000000..d097f7b9c
 --- /dev/null
 +++ b/drivers/platform/x86/zotac-zone-platform.c
 @@ -0,0 +1,1122 @@
@@ -12902,7 +12902,7 @@ index 000000000000..d097f7b9c5a0
 +MODULE_DESCRIPTION("Zotac Handheld Platform Driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/usb/usbip/vhci_hcd.c b/drivers/usb/usbip/vhci_hcd.c
-index e70fba9f55d6..7297d790b664 100644
+index e70fba9f5..7297d790b 100644
 --- a/drivers/usb/usbip/vhci_hcd.c
 +++ b/drivers/usb/usbip/vhci_hcd.c
 @@ -765,6 +765,7 @@ static int vhci_urb_enqueue(struct usb_hcd *hcd, struct urb *urb, gfp_t mem_flag
@@ -12970,7 +12970,7 @@ index e70fba9f55d6..7297d790b664 100644
  
  static int vhci_hcd_resume(struct platform_device *pdev)
 diff --git a/drivers/video/backlight/backlight.c b/drivers/video/backlight/backlight.c
-index f699e5827ccb..99e86b983c77 100644
+index f699e5827..99e86b983 100644
 --- a/drivers/video/backlight/backlight.c
 +++ b/drivers/video/backlight/backlight.c
 @@ -161,6 +161,7 @@ static inline void backlight_unregister_fb(struct backlight_device *bd)
@@ -12990,7 +12990,7 @@ index f699e5827ccb..99e86b983c77 100644
  }
  
 diff --git a/include/linux/hid.h b/include/linux/hid.h
-index 98aad4880f84..d3793f9b196b 100644
+index 98aad4880..d3793f9b1 100644
 --- a/include/linux/hid.h
 +++ b/include/linux/hid.h
 @@ -669,6 +669,7 @@ struct hid_device {
@@ -13010,7 +13010,7 @@ index 98aad4880f84..d3793f9b196b 100644
  	/* debugging support via debugfs */
  	unsigned short debug;
 diff --git a/sound/soc/amd/acp/acp-mach.h b/sound/soc/amd/acp/acp-mach.h
-index f94c30c20f20..c3b3f047969c 100644
+index f94c30c20..c3b3f0479 100644
 --- a/sound/soc/amd/acp/acp-mach.h
 +++ b/sound/soc/amd/acp/acp-mach.h
 @@ -29,8 +29,8 @@
@@ -13024,7 +13024,7 @@ index f94c30c20f20..c3b3f047969c 100644
  
  enum cpu_endpoints {
 diff --git a/sound/soc/codecs/max98388.c b/sound/soc/codecs/max98388.c
-index 99986090b4a6..e259be44ce8f 100644
+index 99986090b..e259be44c 100644
 --- a/sound/soc/codecs/max98388.c
 +++ b/sound/soc/codecs/max98388.c
 @@ -390,27 +390,43 @@ static void max98388_reset(struct max98388_priv *max98388, struct device *dev)
@@ -13105,6 +13105,3 @@ index 99986090b4a6..e259be44ce8f 100644
  	regcache_sync(max98388->regmap);
  
  	return 0;
--- 
-2.50.0.145.g83014dc05f
-

--- a/6.15/misc/0001-hardened.patch
+++ b/6.15/misc/0001-hardened.patch
@@ -1,4 +1,4 @@
-From b3b79d58516f2f61ced850c34a81b739e15aa75f Mon Sep 17 00:00:00 2001
+From 4b88e7a81d3a6f260202fdd5b6600aa6cfb4ec33 Mon Sep 17 00:00:00 2001
 From: Peter Jung <admin@ptr1337.dev>
 Date: Sat, 2 Aug 2025 15:53:07 +0200
 Subject: [PATCH] hardened
@@ -55,7 +55,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  kernel/bpf/core.c                             |   2 +-
  kernel/capability.c                           |   6 +
  kernel/events/core.c                          |   7 +-
- kernel/fork.c                                 |   5 +-
+ kernel/fork.c                                 |  11 +
  kernel/printk/sysctl.c                        |   9 -
  kernel/softirq.c                              |   4 +-
  kernel/sysctl.c                               |  40 +++-
@@ -89,11 +89,11 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  security/yama/Kconfig                         |   2 +-
  tools/perf/Documentation/security.txt         |   1 +
  tools/perf/util/evsel.c                       |   1 +
- 84 files changed, 746 insertions(+), 150 deletions(-)
+ 84 files changed, 756 insertions(+), 146 deletions(-)
  create mode 100644 drivers/usb/core/sysctl.c
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index 186454e1c55b..4c1d63b9b401 100644
+index 186454e1c..4c1d63b9b 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -640,17 +640,6 @@
@@ -127,7 +127,7 @@ index 186454e1c55b..4c1d63b9b401 100644
  
  	pci=option[,option...]	[PCI,EARLY] various PCI subsystem options.
 diff --git a/Documentation/admin-guide/sysctl/kernel.rst b/Documentation/admin-guide/sysctl/kernel.rst
-index dd49a89a62d3..39b550f33c49 100644
+index dd49a89a6..39b550f33 100644
 --- a/Documentation/admin-guide/sysctl/kernel.rst
 +++ b/Documentation/admin-guide/sysctl/kernel.rst
 @@ -972,6 +972,8 @@ with respect to CAP_PERFMON use cases.
@@ -167,7 +167,7 @@ index dd49a89a62d3..39b550f33c49 100644
  ===================
  
 diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/ip-sysctl.rst
-index 5c63ab928b97..a371a778b966 100644
+index 5c63ab928..a371a778b 100644
 --- a/Documentation/networking/ip-sysctl.rst
 +++ b/Documentation/networking/ip-sysctl.rst
 @@ -768,6 +768,24 @@ tcp_backlog_ack_defer - BOOLEAN
@@ -196,7 +196,7 @@ index 5c63ab928b97..a371a778b966 100644
  	If set, provide RFC2861 behavior and time out the congestion
  	window after an idle period.  An idle period is defined at
 diff --git a/arch/Kconfig b/arch/Kconfig
-index 30dccda07c67..cceb0ee0d2b5 100644
+index 1c2ddb1b7..9988d111f 100644
 --- a/arch/Kconfig
 +++ b/arch/Kconfig
 @@ -1156,7 +1156,7 @@ config ARCH_MMAP_RND_BITS
@@ -226,7 +226,7 @@ index 30dccda07c67..cceb0ee0d2b5 100644
  	  Kernel stack offset randomization is controlled by kernel boot param
  	  "randomize_kstack_offset=on/off", and this config chooses the default
 diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
-index 6527d0d5656a..6bfe021ea63b 100644
+index 6527d0d56..6bfe021ea 100644
 --- a/arch/arm64/Kconfig
 +++ b/arch/arm64/Kconfig
 @@ -1697,6 +1697,7 @@ config ARM64_SW_TTBR0_PAN
@@ -246,7 +246,7 @@ index 6527d0d5656a..6bfe021ea63b 100644
  	  Randomizes the virtual address at which the kernel image is
  	  loaded, as a security feature that deters exploit attempts
 diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
-index 8e5d4dbd74e5..6d4178c6fce0 100644
+index 8e5d4dbd7..6d4178c6f 100644
 --- a/arch/arm64/configs/defconfig
 +++ b/arch/arm64/configs/defconfig
 @@ -1,4 +1,3 @@
@@ -255,7 +255,7 @@ index 8e5d4dbd74e5..6d4178c6fce0 100644
  CONFIG_AUDIT=y
  CONFIG_NO_HZ_IDLE=y
 diff --git a/arch/arm64/include/asm/elf.h b/arch/arm64/include/asm/elf.h
-index 3f93f4eef953..ac3805f359de 100644
+index 3f93f4eef..ac3805f35 100644
 --- a/arch/arm64/include/asm/elf.h
 +++ b/arch/arm64/include/asm/elf.h
 @@ -124,14 +124,10 @@
@@ -290,7 +290,7 @@ index 3f93f4eef953..ac3805f359de 100644
  
  #ifdef __AARCH64EB__
 diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index 5d4857b476a6..e5f75c76982a 100644
+index 5d4857b47..e5f75c769 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
 @@ -1239,8 +1239,7 @@ config VM86
@@ -323,7 +323,7 @@ index 5d4857b476a6..e5f75c76982a 100644
  	  Linux can allow user programs to install a per-process x86
  	  Local Descriptor Table (LDT) using the modify_ldt(2) system
 diff --git a/arch/x86/configs/x86_64_defconfig b/arch/x86/configs/x86_64_defconfig
-index 61e25f6209ed..c95144785660 100644
+index 61e25f620..c95144785 100644
 --- a/arch/x86/configs/x86_64_defconfig
 +++ b/arch/x86/configs/x86_64_defconfig
 @@ -1,5 +1,4 @@
@@ -333,7 +333,7 @@ index 61e25f6209ed..c95144785660 100644
  CONFIG_AUDIT=y
  CONFIG_NO_HZ=y
 diff --git a/arch/x86/include/asm/elf.h b/arch/x86/include/asm/elf.h
-index 128602612eca..0443cbde1557 100644
+index 128602612..0443cbde1 100644
 --- a/arch/x86/include/asm/elf.h
 +++ b/arch/x86/include/asm/elf.h
 @@ -233,11 +233,11 @@ extern int force_personality32;
@@ -375,7 +375,7 @@ index 128602612eca..0443cbde1557 100644
  
  #define ARCH_DLINFO							\
 diff --git a/arch/x86/include/asm/tlbflush.h b/arch/x86/include/asm/tlbflush.h
-index e9b81876ebe4..3a56108600c4 100644
+index e9b81876e..3a5610860 100644
 --- a/arch/x86/include/asm/tlbflush.h
 +++ b/arch/x86/include/asm/tlbflush.h
 @@ -490,6 +490,7 @@ static inline void cpu_tlbstate_update_lam(unsigned long lam, u64 untag_mask)
@@ -387,7 +387,7 @@ index e9b81876ebe4..3a56108600c4 100644
  	native_write_cr4(cr4);
  }
 diff --git a/arch/x86/kernel/cpu/common.c b/arch/x86/kernel/cpu/common.c
-index c39c5c37f4e8..74e6a7998515 100644
+index bab44900b..5ac704501 100644
 --- a/arch/x86/kernel/cpu/common.c
 +++ b/arch/x86/kernel/cpu/common.c
 @@ -449,6 +449,7 @@ EXPORT_SYMBOL_GPL(native_write_cr4);
@@ -399,7 +399,7 @@ index c39c5c37f4e8..74e6a7998515 100644
  	lockdep_assert_irqs_disabled();
  
 diff --git a/arch/x86/kernel/process.c b/arch/x86/kernel/process.c
-index bc61a09b5a66..d79d44e77405 100644
+index bc61a09b5..d79d44e77 100644
 --- a/arch/x86/kernel/process.c
 +++ b/arch/x86/kernel/process.c
 @@ -693,6 +693,7 @@ void speculation_ctrl_update_current(void)
@@ -423,7 +423,7 @@ index bc61a09b5a66..d79d44e77405 100644
  
  /*
 diff --git a/arch/x86/mm/init_32.c b/arch/x86/mm/init_32.c
-index 148eba50265a..086b2cc8308a 100644
+index 148eba502..086b2cc83 100644
 --- a/arch/x86/mm/init_32.c
 +++ b/arch/x86/mm/init_32.c
 @@ -499,9 +499,9 @@ static void __init pagetable_init(void)
@@ -439,7 +439,7 @@ index 148eba50265a..086b2cc8308a 100644
  /* Used in PAGE_KERNEL_* macros which are reasonably used out-of-tree: */
  EXPORT_SYMBOL(__default_kernel_pte_mask);
 diff --git a/arch/x86/mm/init_64.c b/arch/x86/mm/init_64.c
-index 7c4f6f591f2b..e578c8294721 100644
+index 7c4f6f591..e578c8294 100644
 --- a/arch/x86/mm/init_64.c
 +++ b/arch/x86/mm/init_64.c
 @@ -104,9 +104,9 @@ static inline pgprot_t prot_sethuge(pgprot_t prot)
@@ -455,7 +455,7 @@ index 7c4f6f591f2b..e578c8294721 100644
  /* Used in PAGE_KERNEL_* macros which are reasonably used out-of-tree: */
  EXPORT_SYMBOL(__default_kernel_pte_mask);
 diff --git a/drivers/ata/libata-core.c b/drivers/ata/libata-core.c
-index 773799cfd443..43d8f5e472ce 100644
+index 773799cfd..43d8f5e47 100644
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
 @@ -4749,6 +4749,7 @@ void __ata_qc_complete(struct ata_queued_cmd *qc)
@@ -467,7 +467,7 @@ index 773799cfd443..43d8f5e472ce 100644
  		return;
  
 diff --git a/drivers/char/Kconfig b/drivers/char/Kconfig
-index ae6196760556..54811ea891eb 100644
+index ae6196760..54811ea89 100644
 --- a/drivers/char/Kconfig
 +++ b/drivers/char/Kconfig
 @@ -310,7 +310,6 @@ config NSC_GPIO
@@ -487,7 +487,7 @@ index ae6196760556..54811ea891eb 100644
  	  Say Y here if you want to support the /dev/port device. The /dev/port
  	  device is similar to /dev/mem, but for I/O ports.
 diff --git a/drivers/tty/Kconfig b/drivers/tty/Kconfig
-index 149f3d53b760..a3e62d52ebcf 100644
+index 149f3d53b..a3e62d52e 100644
 --- a/drivers/tty/Kconfig
 +++ b/drivers/tty/Kconfig
 @@ -116,7 +116,6 @@ config UNIX98_PTYS
@@ -507,7 +507,7 @@ index 149f3d53b760..a3e62d52ebcf 100644
  	  Historically the kernel has allowed TIOCSTI, which will push
  	  characters into a controlling TTY. This continues to be used
 diff --git a/drivers/tty/tty_io.c b/drivers/tty/tty_io.c
-index ca9b7d7bad2b..edd6f03b45cb 100644
+index ca9b7d7ba..edd6f03b4 100644
 --- a/drivers/tty/tty_io.c
 +++ b/drivers/tty/tty_io.c
 @@ -171,6 +171,7 @@ static void free_tty_struct(struct tty_struct *tty)
@@ -564,7 +564,7 @@ index ca9b7d7bad2b..edd6f03b45cb 100644
  
  /*
 diff --git a/drivers/usb/core/Makefile b/drivers/usb/core/Makefile
-index ac006abd13b3..9228b9d4b60d 100644
+index ac006abd1..9228b9d4b 100644
 --- a/drivers/usb/core/Makefile
 +++ b/drivers/usb/core/Makefile
 @@ -11,6 +11,7 @@ usbcore-y += phy.o port.o
@@ -576,7 +576,7 @@ index ac006abd13b3..9228b9d4b60d 100644
  ifdef CONFIG_USB_ONBOARD_DEV
  usbcore-y			+= ../misc/onboard_usb_dev_pdevs.o
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 1e0be266e9b2..4a2d35a499f6 100644
+index 1e0be266e..4a2d35a49 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -5443,6 +5443,12 @@ static void hub_port_connect(struct usb_hub *hub, int port1, u16 portstatus,
@@ -594,7 +594,7 @@ index 1e0be266e9b2..4a2d35a499f6 100644
  	else
 diff --git a/drivers/usb/core/sysctl.c b/drivers/usb/core/sysctl.c
 new file mode 100644
-index 000000000000..813db3f0b1cb
+index 000000000..813db3f0b
 --- /dev/null
 +++ b/drivers/usb/core/sysctl.c
 @@ -0,0 +1,35 @@
@@ -634,7 +634,7 @@ index 000000000000..813db3f0b1cb
 +	usb_sysctl_table = NULL;
 +}
 diff --git a/drivers/usb/core/usb.c b/drivers/usb/core/usb.c
-index 118fa4c93a79..ab81a219c2de 100644
+index 118fa4c93..ab81a219c 100644
 --- a/drivers/usb/core/usb.c
 +++ b/drivers/usb/core/usb.c
 @@ -72,6 +72,9 @@ MODULE_PARM_DESC(autosuspend, "default autosuspend delay");
@@ -675,7 +675,7 @@ index 118fa4c93a79..ab81a219c2de 100644
  	usb_debugfs_cleanup();
  	idr_destroy(&usb_bus_idr);
 diff --git a/fs/exec.c b/fs/exec.c
-index a18d5875c8d9..e60df4568a0b 100644
+index a18d5875c..e60df4568 100644
 --- a/fs/exec.c
 +++ b/fs/exec.c
 @@ -68,6 +68,7 @@
@@ -696,7 +696,7 @@ index a18d5875c8d9..e60df4568a0b 100644
  err:
  	ksm_exit(mm);
 diff --git a/fs/inode.c b/fs/inode.c
-index 99318b157a9a..fc1dee66a6b1 100644
+index 99318b157..fc1dee66a 100644
 --- a/fs/inode.c
 +++ b/fs/inode.c
 @@ -167,6 +167,10 @@ late_initcall(mg_debugfs_init);
@@ -727,7 +727,7 @@ index 99318b157a9a..fc1dee66a6b1 100644
  
  static int __init init_fs_inode_sysctls(void)
 diff --git a/fs/namei.c b/fs/namei.c
-index 8e165c99feee..319044c53c95 100644
+index 8e165c99f..319044c53 100644
 --- a/fs/namei.c
 +++ b/fs/namei.c
 @@ -1095,10 +1095,10 @@ static inline void put_link(struct nameidata *nd)
@@ -746,7 +746,7 @@ index 8e165c99feee..319044c53c95 100644
  #ifdef CONFIG_SYSCTL
  static const struct ctl_table namei_sysctls[] = {
 diff --git a/fs/nfs/Kconfig b/fs/nfs/Kconfig
-index 07932ce9246c..c6754a2a6448 100644
+index 07932ce92..c6754a2a6 100644
 --- a/fs/nfs/Kconfig
 +++ b/fs/nfs/Kconfig
 @@ -197,7 +197,6 @@ config NFS_USE_KERNEL_DNS
@@ -758,7 +758,7 @@ index 07932ce9246c..c6754a2a6448 100644
  config NFS_DISABLE_UDP_SUPPORT
         bool "NFS: Disable NFS UDP protocol support"
 diff --git a/fs/overlayfs/Kconfig b/fs/overlayfs/Kconfig
-index 2ac67e04a6fb..3340e13c959c 100644
+index 2ac67e04a..3340e13c9 100644
 --- a/fs/overlayfs/Kconfig
 +++ b/fs/overlayfs/Kconfig
 @@ -134,3 +134,19 @@ config OVERLAY_FS_DEBUG
@@ -782,7 +782,7 @@ index 2ac67e04a6fb..3340e13c959c 100644
 +
 +	  If unsure, say N.
 diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
-index e19940d649ca..ad982ec08940 100644
+index e19940d64..ad982ec08 100644
 --- a/fs/overlayfs/super.c
 +++ b/fs/overlayfs/super.c
 @@ -1516,7 +1516,9 @@ struct file_system_type ovl_fs_type = {
@@ -796,7 +796,7 @@ index e19940d649ca..ad982ec08940 100644
  };
  MODULE_ALIAS_FS("overlay");
 diff --git a/fs/proc/Kconfig b/fs/proc/Kconfig
-index 6ae966c561e7..27d78d669f95 100644
+index 6ae966c56..27d78d669 100644
 --- a/fs/proc/Kconfig
 +++ b/fs/proc/Kconfig
 @@ -41,7 +41,6 @@ config PROC_KCORE
@@ -808,7 +808,7 @@ index 6ae966c561e7..27d78d669f95 100644
  	  Exports the dump image of crashed kernel in ELF format.
  
 diff --git a/fs/proc/proc_sysctl.c b/fs/proc/proc_sysctl.c
-index 08b78150cdde..df2e229fd756 100644
+index 08b78150c..df2e229fd 100644
 --- a/fs/proc/proc_sysctl.c
 +++ b/fs/proc/proc_sysctl.c
 @@ -1155,6 +1155,7 @@ static int sysctl_check_table(const char *path, struct ctl_table_header *header)
@@ -820,7 +820,7 @@ index 08b78150cdde..df2e229fd756 100644
  		    (entry->proc_handler == proc_dointvec_jiffies) ||
  		    (entry->proc_handler == proc_dointvec_userhz_jiffies) ||
 diff --git a/fs/stat.c b/fs/stat.c
-index 3d9222807214..c90e3ba0323a 100644
+index 3d9222807..c90e3ba03 100644
 --- a/fs/stat.c
 +++ b/fs/stat.c
 @@ -52,7 +52,10 @@ void fill_mg_cmtime(struct kstat *stat, u32 request_mask, struct inode *inode)
@@ -880,7 +880,7 @@ index 3d9222807214..c90e3ba0323a 100644
  			return ret;
  	} else {
 diff --git a/include/linux/cache.h b/include/linux/cache.h
-index e69768f50d53..432c30a1fc7e 100644
+index e69768f50..432c30a1f 100644
 --- a/include/linux/cache.h
 +++ b/include/linux/cache.h
 @@ -60,6 +60,8 @@
@@ -893,7 +893,7 @@ index e69768f50d53..432c30a1fc7e 100644
  #ifdef CONFIG_SMP
  #define ____cacheline_aligned_in_smp ____cacheline_aligned
 diff --git a/include/linux/capability.h b/include/linux/capability.h
-index 1fb08922552c..014061510689 100644
+index 1fb089225..014061510 100644
 --- a/include/linux/capability.h
 +++ b/include/linux/capability.h
 @@ -145,6 +145,7 @@ extern bool has_capability_noaudit(struct task_struct *t, int cap);
@@ -916,7 +916,7 @@ index 1fb08922552c..014061510689 100644
  {
  	return true;
 diff --git a/include/linux/fs.h b/include/linux/fs.h
-index 1fe7bf10d442..5b606ee4d9c1 100644
+index 1fe7bf10d..5b606ee4d 100644
 --- a/include/linux/fs.h
 +++ b/include/linux/fs.h
 @@ -3930,4 +3930,15 @@ static inline bool vfs_empty_path(int dfd, const char __user *path)
@@ -936,7 +936,7 @@ index 1fe7bf10d442..5b606ee4d9c1 100644
 +
  #endif /* _LINUX_FS_H */
 diff --git a/include/linux/fsnotify.h b/include/linux/fsnotify.h
-index 454d8e466958..5499bb7499dc 100644
+index 454d8e466..5499bb749 100644
 --- a/include/linux/fsnotify.h
 +++ b/include/linux/fsnotify.h
 @@ -124,6 +124,9 @@ static inline int fsnotify_file(struct file *file, __u32 mask)
@@ -950,7 +950,7 @@ index 454d8e466958..5499bb7499dc 100644
  }
  
 diff --git a/include/linux/highmem.h b/include/linux/highmem.h
-index c698f8415675..804da344bcc9 100644
+index c698f8415..804da344b 100644
 --- a/include/linux/highmem.h
 +++ b/include/linux/highmem.h
 @@ -257,6 +257,13 @@ static inline void tag_clear_highpage(struct page *page)
@@ -968,7 +968,7 @@ index c698f8415675..804da344bcc9 100644
   * If we pass in a base or tail page, we can zero up to PAGE_SIZE.
   * If we pass in a head page, we can zero up to the size of the compound page.
 diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
-index c782a74d2a30..7dec3d06e985 100644
+index c782a74d2..7dec3d06e 100644
 --- a/include/linux/interrupt.h
 +++ b/include/linux/interrupt.h
 @@ -601,7 +601,7 @@ static inline void do_softirq_post_smp_call_flush(unsigned int unused)
@@ -981,7 +981,7 @@ index c782a74d2a30..7dec3d06e985 100644
  extern void __raise_softirq_irqoff(unsigned int nr);
  
 diff --git a/include/linux/kobject_ns.h b/include/linux/kobject_ns.h
-index 150fe2ae1b6b..67d22bb918c2 100644
+index 150fe2ae1..67d22bb91 100644
 --- a/include/linux/kobject_ns.h
 +++ b/include/linux/kobject_ns.h
 @@ -45,7 +45,7 @@ struct kobj_ns_type_operations {
@@ -994,7 +994,7 @@ index 150fe2ae1b6b..67d22bb918c2 100644
  const struct kobj_ns_type_operations *kobj_child_ns_ops(const struct kobject *parent);
  const struct kobj_ns_type_operations *kobj_ns_ops(const struct kobject *kobj);
 diff --git a/include/linux/perf_event.h b/include/linux/perf_event.h
-index 0069ba6866a4..129283d29318 100644
+index 0069ba686..129283d29 100644
 --- a/include/linux/perf_event.h
 +++ b/include/linux/perf_event.h
 @@ -1699,6 +1699,14 @@ static inline int perf_is_paranoid(void)
@@ -1013,7 +1013,7 @@ index 0069ba6866a4..129283d29318 100644
  {
  	if (sysctl_perf_event_paranoid > 0 && !perfmon_capable())
 diff --git a/include/linux/sysctl.h b/include/linux/sysctl.h
-index 40a6ac6c9713..e31868e08b3c 100644
+index 40a6ac6c9..e31868e08 100644
 --- a/include/linux/sysctl.h
 +++ b/include/linux/sysctl.h
 @@ -72,6 +72,8 @@ int proc_douintvec(const struct ctl_table *, int, void *, size_t *, loff_t *);
@@ -1026,7 +1026,7 @@ index 40a6ac6c9713..e31868e08b3c 100644
  			size_t *lenp, loff_t *ppos);
  int proc_dointvec_jiffies(const struct ctl_table *, int, void *, size_t *, loff_t *);
 diff --git a/include/linux/tty.h b/include/linux/tty.h
-index 0a46e4054dec..99c733852fb2 100644
+index 0a46e4054..99c733852 100644
 --- a/include/linux/tty.h
 +++ b/include/linux/tty.h
 @@ -14,6 +14,7 @@
@@ -1046,7 +1046,7 @@ index 0a46e4054dec..99c733852fb2 100644
  
  /* Each of a tty's open files has private_data pointing to tty_file_private */
 diff --git a/include/linux/usb.h b/include/linux/usb.h
-index c63a7a9191ca..fe8453d2e7ec 100644
+index c63a7a919..fe8453d2e 100644
 --- a/include/linux/usb.h
 +++ b/include/linux/usb.h
 @@ -2062,6 +2062,17 @@ extern void usb_led_activity(enum usb_led_event ev);
@@ -1068,7 +1068,7 @@ index c63a7a9191ca..fe8453d2e7ec 100644
  
  #endif
 diff --git a/include/net/tcp.h b/include/net/tcp.h
-index 61f73ca30be3..e1fbd429a54e 100644
+index 61f73ca30..e1fbd429a 100644
 --- a/include/net/tcp.h
 +++ b/include/net/tcp.h
 @@ -262,6 +262,7 @@ static_assert((1 << ATO_BITS) > TCP_DELACK_MAX);
@@ -1080,7 +1080,7 @@ index 61f73ca30be3..e1fbd429a54e 100644
  #define TCP_RACK_LOSS_DETECTION  0x1 /* Use RACK to detect losses */
  #define TCP_RACK_STATIC_REO_WND  0x2 /* Use static RACK reo wnd */
 diff --git a/init/Kconfig b/init/Kconfig
-index c524858118d2..f4c6ece18321 100644
+index 3bd8f03f9..73de79a94 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -494,6 +494,7 @@ config USELIB
@@ -1132,7 +1132,7 @@ index c524858118d2..f4c6ece18321 100644
  	  This option enables POSIX asynchronous I/O which may by used
  	  by some high performance threaded applications. Disabling
 diff --git a/io_uring/io_uring.c b/io_uring/io_uring.c
-index 211f7f5f507e..258be667d2b9 100644
+index 211f7f5f5..258be667d 100644
 --- a/io_uring/io_uring.c
 +++ b/io_uring/io_uring.c
 @@ -155,7 +155,7 @@ static __read_mostly DEFINE_STATIC_KEY_FALSE(io_key_has_sqarray);
@@ -1156,7 +1156,7 @@ index 211f7f5f507e..258be667d2b9 100644
  	},
  	{
 diff --git a/kernel/audit.c b/kernel/audit.c
-index 5f5bf85bcc90..e8d5bfa34abf 100644
+index 5f5bf85bc..e8d5bfa34 100644
 --- a/kernel/audit.c
 +++ b/kernel/audit.c
 @@ -1743,6 +1743,9 @@ static int __init audit_enable(char *str)
@@ -1170,7 +1170,7 @@ index 5f5bf85bcc90..e8d5bfa34abf 100644
  		pr_err("audit: error setting audit state (%d)\n",
  		       audit_default);
 diff --git a/kernel/bpf/core.c b/kernel/bpf/core.c
-index c20babbf998f..4e27e92c61b5 100644
+index 93e49b0c2..6ccfbf977 100644
 --- a/kernel/bpf/core.c
 +++ b/kernel/bpf/core.c
 @@ -571,7 +571,7 @@ void bpf_prog_kallsyms_del_all(struct bpf_prog *fp)
@@ -1183,7 +1183,7 @@ index c20babbf998f..4e27e92c61b5 100644
  long bpf_jit_limit_max __read_mostly;
  
 diff --git a/kernel/capability.c b/kernel/capability.c
-index 829f49ae07b9..5bb7ee4028ad 100644
+index 829f49ae0..5bb7ee402 100644
 --- a/kernel/capability.c
 +++ b/kernel/capability.c
 @@ -416,6 +416,12 @@ bool capable(int cap)
@@ -1200,7 +1200,7 @@ index 829f49ae07b9..5bb7ee4028ad 100644
  
  /**
 diff --git a/kernel/events/core.c b/kernel/events/core.c
-index 5a2ed3344392..55217b9647b7 100644
+index 033270a28..1873dab42 100644
 --- a/kernel/events/core.c
 +++ b/kernel/events/core.c
 @@ -463,8 +463,13 @@ static struct kmem_cache *perf_event_cache;
@@ -1217,7 +1217,7 @@ index 5a2ed3344392..55217b9647b7 100644
  
  /* Minimum for 512 kiB + 1 user control page. 'free' kiB per user. */
  static int sysctl_perf_event_mlock __read_mostly = 512 + (PAGE_SIZE / 1024);
-@@ -13145,7 +13150,7 @@ SYSCALL_DEFINE5(perf_event_open,
+@@ -13165,7 +13170,7 @@ SYSCALL_DEFINE5(perf_event_open,
  		return err;
  
  	/* Do we allow access to perf_event_open(2) ? */
@@ -1227,7 +1227,7 @@ index 5a2ed3344392..55217b9647b7 100644
  		return err;
  
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 39e47bfaea58..ccf94a533762 100644
+index 39e47bfae..349e2e85b 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -83,6 +83,7 @@
@@ -1238,19 +1238,32 @@ index 39e47bfaea58..ccf94a533762 100644
  #include <linux/oom.h>
  #include <linux/khugepaged.h>
  #include <linux/signalfd.h>
-@@ -106,10 +107,6 @@
- #include <linux/pidfs.h>
- #include <linux/tick.h>
+@@ -2188,6 +2189,10 @@ __latent_entropy struct task_struct *copy_process(
+ 	const u64 clone_flags = args->flags;
+ 	struct nsproxy *nsp = current->nsproxy;
  
--#ifdef CONFIG_USER_NS
--#include <linux/user_namespace.h>
--#endif
--
- #include <asm/pgalloc.h>
- #include <linux/uaccess.h>
- #include <asm/mmu_context.h>
++	if ((clone_flags & CLONE_NEWUSER) && !unprivileged_userns_clone)
++		if (!capable(CAP_SYS_ADMIN))
++			return ERR_PTR(-EPERM);
++
+ 	/*
+ 	 * Don't allow sharing the root directory with processes in a different
+ 	 * namespace
+@@ -3368,6 +3373,12 @@ int ksys_unshare(unsigned long unshare_flags)
+ 			goto bad_unshare_out;
+ 	}
+ 
++	if ((unshare_flags & CLONE_NEWUSER) && !unprivileged_userns_clone) {
++		err = -EPERM;
++		if (!capable(CAP_SYS_ADMIN))
++			goto bad_unshare_out;
++	}
++
+ 	err = check_unshare_flags(unshare_flags);
+ 	if (err)
+ 		goto bad_unshare_out;
 diff --git a/kernel/printk/sysctl.c b/kernel/printk/sysctl.c
-index da77f3f5c1fe..1418fc33ed1f 100644
+index da77f3f5c..1418fc33e 100644
 --- a/kernel/printk/sysctl.c
 +++ b/kernel/printk/sysctl.c
 @@ -11,15 +11,6 @@
@@ -1270,7 +1283,7 @@ index da77f3f5c1fe..1418fc33ed1f 100644
  	{
  		.procname	= "printk",
 diff --git a/kernel/softirq.c b/kernel/softirq.c
-index 513b1945987c..1e647e2a9eb6 100644
+index 513b19459..1e647e2a9 100644
 --- a/kernel/softirq.c
 +++ b/kernel/softirq.c
 @@ -57,7 +57,7 @@ DEFINE_PER_CPU_ALIGNED(irq_cpustat_t, irq_stat);
@@ -1292,7 +1305,7 @@ index 513b1945987c..1e647e2a9eb6 100644
  	softirq_vec[nr].action = action;
  }
 diff --git a/kernel/sysctl.c b/kernel/sysctl.c
-index fe7bec454345..ae254b58e76e 100644
+index fe7bec454..ae254b58e 100644
 --- a/kernel/sysctl.c
 +++ b/kernel/sysctl.c
 @@ -789,6 +789,35 @@ static int proc_taint(const struct ctl_table *table, int write,
@@ -1364,7 +1377,7 @@ index fe7bec454345..ae254b58e76e 100644
  EXPORT_SYMBOL(proc_dointvec_ms_jiffies);
  EXPORT_SYMBOL(proc_dostring);
 diff --git a/lib/Kconfig.debug b/lib/Kconfig.debug
-index f9051ab610d5..b25d36737615 100644
+index f9051ab61..b25d36737 100644
 --- a/lib/Kconfig.debug
 +++ b/lib/Kconfig.debug
 @@ -511,6 +511,9 @@ config SECTION_MISMATCH_WARN_ONLY
@@ -1412,7 +1425,7 @@ index f9051ab610d5..b25d36737615 100644
  	  If this option is disabled, you allow userspace (root) access to all
  	  io-memory regardless of whether a driver is actively using that
 diff --git a/lib/Kconfig.kfence b/lib/Kconfig.kfence
-index 6fbbebec683a..e494618f7193 100644
+index 6fbbebec6..e494618f7 100644
 --- a/lib/Kconfig.kfence
 +++ b/lib/Kconfig.kfence
 @@ -96,4 +96,13 @@ config KFENCE_KUNIT_TEST
@@ -1430,7 +1443,7 @@ index 6fbbebec683a..e494618f7193 100644
 +
  endif # KFENCE
 diff --git a/lib/kobject.c b/lib/kobject.c
-index abe5f5b856ce..a80fa9d8f2db 100644
+index abe5f5b85..a80fa9d8f 100644
 --- a/lib/kobject.c
 +++ b/lib/kobject.c
 @@ -1019,9 +1019,9 @@ EXPORT_SYMBOL_GPL(kset_create_and_add);
@@ -1446,7 +1459,7 @@ index abe5f5b856ce..a80fa9d8f2db 100644
  	enum kobj_ns_type type = ops->type;
  	int error;
 diff --git a/lib/nlattr.c b/lib/nlattr.c
-index be9c576b6e2d..484d839bcf5e 100644
+index be9c576b6..484d839bc 100644
 --- a/lib/nlattr.c
 +++ b/lib/nlattr.c
 @@ -837,6 +837,8 @@ int nla_memcpy(void *dest, const struct nlattr *src, int count)
@@ -1459,7 +1472,7 @@ index be9c576b6e2d..484d839bcf5e 100644
  	if (count > minlen)
  		memset(dest + minlen, 0, count - minlen);
 diff --git a/lib/vsprintf.c b/lib/vsprintf.c
-index d8a2ec083ace..f31e39656f90 100644
+index d8a2ec083..f31e39656 100644
 --- a/lib/vsprintf.c
 +++ b/lib/vsprintf.c
 @@ -840,7 +840,7 @@ static char *default_pointer(char *buf, char *end, const void *ptr,
@@ -1472,7 +1485,7 @@ index d8a2ec083ace..f31e39656f90 100644
  static noinline_for_stack
  char *restricted_pointer(char *buf, char *end, const void *ptr,
 diff --git a/mm/Kconfig b/mm/Kconfig
-index 825b5932debc..29ce3eda4f4e 100644
+index 825b5932d..29ce3eda4 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
 @@ -214,7 +214,6 @@ config SLUB_TINY
@@ -1551,7 +1564,7 @@ index 825b5932debc..29ce3eda4f4e 100644
  	  This is the portion of low virtual memory which should be protected
  	  from userspace allocation.  Keeping a user from writing to low pages
 diff --git a/mm/Kconfig.debug b/mm/Kconfig.debug
-index 32b65073d0cc..614bb7f4793f 100644
+index 32b65073d..614bb7f47 100644
 --- a/mm/Kconfig.debug
 +++ b/mm/Kconfig.debug
 @@ -47,7 +47,7 @@ config DEBUG_PAGEALLOC_ENABLE_DEFAULT
@@ -1572,7 +1585,7 @@ index 32b65073d0cc..614bb7f4793f 100644
  	  Generate a warning if any W+X mappings are found at boot.
  
 diff --git a/mm/internal.h b/mm/internal.h
-index 5c7a2b43ad76..3efb42cb87ec 100644
+index 5c7a2b43a..3efb42cb8 100644
 --- a/mm/internal.h
 +++ b/mm/internal.h
 @@ -754,6 +754,9 @@ static inline struct folio *page_rmappable_folio(struct page *page)
@@ -1586,7 +1599,7 @@ index 5c7a2b43ad76..3efb42cb87ec 100644
  {
  	struct folio *folio = (struct folio *)page;
 diff --git a/mm/kfence/report.c b/mm/kfence/report.c
-index 10e6802a2edf..01f8700fafc6 100644
+index 10e6802a2..01f8700fa 100644
 --- a/mm/kfence/report.c
 +++ b/mm/kfence/report.c
 @@ -8,6 +8,7 @@
@@ -1609,7 +1622,7 @@ index 10e6802a2edf..01f8700fafc6 100644
  
  	/* We encountered a memory safety error, taint the kernel! */
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index 8201039f1c1c..1d6988967dca 100644
+index 8201039f1..1d6988967 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -1998,6 +1998,7 @@ static void __init deferred_free_pages(unsigned long pfn,
@@ -1637,7 +1650,7 @@ index 8201039f1c1c..1d6988967dca 100644
  }
  
 diff --git a/mm/mmap.c b/mm/mmap.c
-index bd210aaf7ebd..c7b02ae43399 100644
+index bd210aaf7..c7b02ae43 100644
 --- a/mm/mmap.c
 +++ b/mm/mmap.c
 @@ -155,6 +155,13 @@ SYSCALL_DEFINE1(brk, unsigned long, brk)
@@ -1655,7 +1668,7 @@ index bd210aaf7ebd..c7b02ae43399 100644
  		mm->brk = brk;
  		goto success;
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 4632022638a5..d785a4ea7dbb 100644
+index 463202263..d785a4ea7 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -186,6 +186,15 @@ EXPORT_PER_CPU_SYMBOL(_numa_mem_);
@@ -1714,7 +1727,7 @@ index 4632022638a5..d785a4ea7dbb 100644
  	 * As memory initialization might be integrated into KASAN,
  	 * KASAN unpoisoning and memory initializion code must be
 diff --git a/mm/slab.h b/mm/slab.h
-index 05a21dc796e0..3a99b644cef8 100644
+index 05a21dc79..3a99b644c 100644
 --- a/mm/slab.h
 +++ b/mm/slab.h
 @@ -291,6 +291,11 @@ struct kmem_cache {
@@ -1769,7 +1782,7 @@ index 05a21dc796e0..3a99b644cef8 100644
  }
  
 diff --git a/mm/slab_common.c b/mm/slab_common.c
-index 5be257e03c7c..9df681d4593d 100644
+index 5be257e03..9df681d45 100644
 --- a/mm/slab_common.c
 +++ b/mm/slab_common.c
 @@ -37,10 +37,10 @@
@@ -1795,7 +1808,7 @@ index 5be257e03c7c..9df681d4593d 100644
  static int __init setup_slab_nomerge(char *str)
  {
 diff --git a/mm/slub.c b/mm/slub.c
-index be8b09e09d30..c4c77e0597e2 100644
+index b8d75fcab..3ee94c1cf 100644
 --- a/mm/slub.c
 +++ b/mm/slub.c
 @@ -40,6 +40,7 @@
@@ -2038,7 +2051,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  
  out:
  	/*
-@@ -4636,10 +4731,15 @@ static __fastpath_inline
+@@ -4641,10 +4736,15 @@ static __fastpath_inline
  void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
  	       unsigned long addr)
  {
@@ -2055,7 +2068,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  		do_slab_free(s, slab, object, object, 1, addr);
  }
  
-@@ -4648,7 +4748,11 @@ void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
+@@ -4653,7 +4753,11 @@ void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
  static noinline
  void memcg_alloc_abort_single(struct kmem_cache *s, void *object)
  {
@@ -2068,7 +2081,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  		do_slab_free(s, virt_to_slab(object), object, object, 1, _RET_IP_);
  }
  #endif
-@@ -4689,7 +4793,7 @@ static void slab_free_after_rcu_debug(struct rcu_head *rcu_head)
+@@ -4694,7 +4798,7 @@ static void slab_free_after_rcu_debug(struct rcu_head *rcu_head)
  		return;
  
  	/* resume freeing */
@@ -2077,7 +2090,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  		do_slab_free(s, slab, object, object, 1, _THIS_IP_);
  }
  #endif /* CONFIG_SLUB_RCU_DEBUG */
-@@ -4706,8 +4810,12 @@ static inline struct kmem_cache *virt_to_cache(const void *obj)
+@@ -4711,8 +4815,12 @@ static inline struct kmem_cache *virt_to_cache(const void *obj)
  	struct slab *slab;
  
  	slab = virt_to_slab(obj);
@@ -2090,7 +2103,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  	return slab->slab_cache;
  }
  
-@@ -4720,10 +4828,15 @@ static inline struct kmem_cache *cache_from_obj(struct kmem_cache *s, void *x)
+@@ -4725,10 +4833,15 @@ static inline struct kmem_cache *cache_from_obj(struct kmem_cache *s, void *x)
  		return s;
  
  	cachep = virt_to_cache(x);
@@ -2109,7 +2122,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  	return cachep;
  }
  
-@@ -4754,8 +4867,12 @@ static void free_large_kmalloc(struct folio *folio, void *object)
+@@ -4759,8 +4872,12 @@ static void free_large_kmalloc(struct folio *folio, void *object)
  		return;
  	}
  
@@ -2122,7 +2135,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  
  	kmemleak_free(object);
  	kasan_kfree_large(object);
-@@ -5253,7 +5370,7 @@ int __kmem_cache_alloc_bulk(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -5258,7 +5375,7 @@ int __kmem_cache_alloc_bulk(struct kmem_cache *s, gfp_t flags, size_t size,
  {
  	struct kmem_cache_cpu *c;
  	unsigned long irqflags;
@@ -2131,7 +2144,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  
  	/*
  	 * Drain objects in the per cpu slab, while disabling local
-@@ -5309,6 +5426,28 @@ int __kmem_cache_alloc_bulk(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -5314,6 +5431,28 @@ int __kmem_cache_alloc_bulk(struct kmem_cache *s, gfp_t flags, size_t size,
  	local_unlock_irqrestore(&s->cpu_slab->lock, irqflags);
  	slub_put_cpu_ptr(s->cpu_slab);
  
@@ -2160,7 +2173,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  	return i;
  
  error:
-@@ -5352,6 +5491,7 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -5357,6 +5496,7 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
  				 void **p)
  {
  	int i;
@@ -2168,7 +2181,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  
  	if (!size)
  		return 0;
-@@ -5368,8 +5508,11 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -5373,8 +5513,11 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
  	 * memcg and kmem_cache debug support and memory initialization.
  	 * Done outside of the IRQ disabled fastpath loop.
  	 */
@@ -2181,7 +2194,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  		return 0;
  	}
  	return i;
-@@ -5396,10 +5539,10 @@ EXPORT_SYMBOL(kmem_cache_alloc_bulk_noprof);
+@@ -5401,10 +5544,10 @@ EXPORT_SYMBOL(kmem_cache_alloc_bulk_noprof);
   * and increases the number of allocations possible without having to
   * take the list_lock.
   */
@@ -2195,7 +2208,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  
  /*
   * Calculate the order of allocation given an slab object size.
-@@ -5581,6 +5724,7 @@ static void early_kmem_cache_node_alloc(int node)
+@@ -5586,6 +5729,7 @@ static void early_kmem_cache_node_alloc(int node)
  #ifdef CONFIG_SLUB_DEBUG
  	init_object(kmem_cache_node, n, SLUB_RED_ACTIVE);
  #endif
@@ -2203,7 +2216,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  	n = kasan_slab_alloc(kmem_cache_node, n, GFP_KERNEL, false);
  	slab->freelist = get_freepointer(kmem_cache_node, n);
  	slab->inuse = 1;
-@@ -5751,6 +5895,9 @@ static int calculate_sizes(struct kmem_cache_args *args, struct kmem_cache *s)
+@@ -5756,6 +5900,9 @@ static int calculate_sizes(struct kmem_cache_args *args, struct kmem_cache *s)
  		s->offset = ALIGN_DOWN(s->object_size / 2, sizeof(void *));
  	}
  
@@ -2213,7 +2226,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  #ifdef CONFIG_SLUB_DEBUG
  	if (flags & SLAB_STORE_USER) {
  		/*
-@@ -6056,6 +6203,9 @@ void __check_heap_object(const void *ptr, unsigned long n,
+@@ -6061,6 +6208,9 @@ void __check_heap_object(const void *ptr, unsigned long n,
  		offset -= s->red_left_pad;
  	}
  
@@ -2223,7 +2236,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  	/* Allow address range falling entirely within usercopy region. */
  	if (offset >= s->useroffset &&
  	    offset - s->useroffset <= s->usersize &&
-@@ -6402,6 +6552,10 @@ int do_kmem_cache_create(struct kmem_cache *s, const char *name,
+@@ -6407,6 +6557,10 @@ int do_kmem_cache_create(struct kmem_cache *s, const char *name,
  	s->flags = kmem_cache_flags(flags, s->name);
  #ifdef CONFIG_SLAB_FREELIST_HARDENED
  	s->random = get_random_long();
@@ -2235,7 +2248,7 @@ index be8b09e09d30..c4c77e0597e2 100644
  	s->align = args->align;
  	s->ctor = args->ctor;
 diff --git a/mm/util.c b/mm/util.c
-index b9334775c51d..9429226bbd27 100644
+index b9334775c..9429226bb 100644
 --- a/mm/util.c
 +++ b/mm/util.c
 @@ -390,9 +390,9 @@ unsigned long __weak arch_randomize_brk(struct mm_struct *mm)
@@ -2251,7 +2264,7 @@ index b9334775c51d..9429226bbd27 100644
  
  unsigned long arch_mmap_rnd(void)
 diff --git a/net/ipv4/Kconfig b/net/ipv4/Kconfig
-index ddc116ef22cb..e1a2786f9687 100644
+index ddc116ef2..e1a2786f9 100644
 --- a/net/ipv4/Kconfig
 +++ b/net/ipv4/Kconfig
 @@ -267,6 +267,7 @@ config IP_PIMSM_V2
@@ -2290,7 +2303,7 @@ index ddc116ef22cb..e1a2786f9687 100644
 +
 +	  If unsure, say N.
 diff --git a/net/ipv4/sysctl_net_ipv4.c b/net/ipv4/sysctl_net_ipv4.c
-index 3a43010d726f..4ce93a361d07 100644
+index 3a43010d7..4ce93a361 100644
 --- a/net/ipv4/sysctl_net_ipv4.c
 +++ b/net/ipv4/sysctl_net_ipv4.c
 @@ -618,6 +618,15 @@ static struct ctl_table ipv4_table[] = {
@@ -2310,7 +2323,7 @@ index 3a43010d726f..4ce93a361d07 100644
  
  static struct ctl_table ipv4_net_table[] = {
 diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
-index ba2db4641c2b..fc9ca8840767 100644
+index 4181f212e..0ac142b70 100644
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
 @@ -83,6 +83,7 @@
@@ -2321,7 +2334,7 @@ index ba2db4641c2b..fc9ca8840767 100644
  
  #define FLAG_DATA		0x01 /* Incoming frame contained data.		*/
  #define FLAG_WIN_UPDATE		0x02 /* Incoming ACK was a window update.	*/
-@@ -6677,7 +6678,7 @@ static int tcp_rcv_synsent_state_process(struct sock *sk, struct sk_buff *skb,
+@@ -6679,7 +6680,7 @@ static int tcp_rcv_synsent_state_process(struct sock *sk, struct sk_buff *skb,
  		SKB_DR_SET(reason, TCP_RFC7323_PAWS);
  		goto discard_and_undo;
  	}
@@ -2331,7 +2344,7 @@ index ba2db4641c2b..fc9ca8840767 100644
  		 * simultaneous connect with crossed SYNs.
  		 * Particularly, it can be connect to self.
 diff --git a/scripts/Makefile.modpost b/scripts/Makefile.modpost
-index d7d45067d08b..b501130c534c 100644
+index d7d45067d..b501130c5 100644
 --- a/scripts/Makefile.modpost
 +++ b/scripts/Makefile.modpost
 @@ -47,6 +47,7 @@ modpost-args =										\
@@ -2343,7 +2356,7 @@ index d7d45067d08b..b501130c534c 100644
  	$(if $(KBUILD_NSDEPS),-d modules.nsdeps)					\
  	$(if $(CONFIG_MODULE_ALLOW_MISSING_NAMESPACE_IMPORTS)$(KBUILD_NSDEPS),-N)	\
 diff --git a/scripts/gcc-plugins/Kconfig b/scripts/gcc-plugins/Kconfig
-index e383cda05367..929997fb5e45 100644
+index e383cda05..929997fb5 100644
 --- a/scripts/gcc-plugins/Kconfig
 +++ b/scripts/gcc-plugins/Kconfig
 @@ -39,6 +39,11 @@ config GCC_PLUGIN_LATENT_ENTROPY
@@ -2359,7 +2372,7 @@ index e383cda05367..929997fb5e45 100644
  	  secure!
  
 diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
-index be89921d60b6..6d482a0f6c40 100644
+index 01717ed0d..1ce9a1e5b 100644
 --- a/scripts/mod/modpost.c
 +++ b/scripts/mod/modpost.c
 @@ -47,6 +47,8 @@ static bool sec_mismatch_warn_only = true;
@@ -2419,7 +2432,7 @@ index be89921d60b6..6d482a0f6c40 100644
  	}
  }
  
-@@ -2207,7 +2227,7 @@ int main(int argc, char **argv)
+@@ -2216,7 +2236,7 @@ int main(int argc, char **argv)
  	LIST_HEAD(dump_lists);
  	struct dump_list *dl, *dl2;
  
@@ -2428,7 +2441,7 @@ index be89921d60b6..6d482a0f6c40 100644
  		switch (opt) {
  		case 'e':
  			external_module = true;
-@@ -2217,6 +2237,9 @@ int main(int argc, char **argv)
+@@ -2226,6 +2246,9 @@ int main(int argc, char **argv)
  			dl->file = optarg;
  			list_add_tail(&dl->list, &dump_lists);
  			break;
@@ -2438,7 +2451,7 @@ index be89921d60b6..6d482a0f6c40 100644
  		case 'M':
  			module_enabled = true;
  			break;
-@@ -2317,5 +2340,11 @@ int main(int argc, char **argv)
+@@ -2326,5 +2349,11 @@ int main(int argc, char **argv)
  		warn("suppressed %u unresolved symbol warnings because there were too many)\n",
  		     nr_unresolved - MAX_UNRESOLVED_REPORTS);
  
@@ -2451,7 +2464,7 @@ index be89921d60b6..6d482a0f6c40 100644
  	return error_occurred ? 1 : 0;
  }
 diff --git a/security/Kconfig b/security/Kconfig
-index 4816fc74f81e..e8714b6e99f9 100644
+index 4816fc74f..e8714b6e9 100644
 --- a/security/Kconfig
 +++ b/security/Kconfig
 @@ -9,7 +9,7 @@ source "security/keys/Kconfig"
@@ -2515,7 +2528,7 @@ index 4816fc74f81e..e8714b6e99f9 100644
  	  This enables the socket and networking security hooks.
  	  If enabled, a security module can use these hooks to
 diff --git a/security/Kconfig.hardening b/security/Kconfig.hardening
-index 3fe9d7b945c4..a86d7f8bc988 100644
+index 3fe9d7b94..a86d7f8bc 100644
 --- a/security/Kconfig.hardening
 +++ b/security/Kconfig.hardening
 @@ -227,6 +227,7 @@ config STACKLEAK_RUNTIME_DISABLE
@@ -2589,7 +2602,7 @@ index 3fe9d7b945c4..a86d7f8bc988 100644
  	  Select this option if the kernel should BUG when it encounters
  	  data corruption in kernel memory structures when they get checked
 diff --git a/security/selinux/Kconfig b/security/selinux/Kconfig
-index 61abc1e094a8..ceda05c0c4f6 100644
+index 61abc1e09..ceda05c0c 100644
 --- a/security/selinux/Kconfig
 +++ b/security/selinux/Kconfig
 @@ -3,7 +3,7 @@ config SECURITY_SELINUX
@@ -2602,7 +2615,7 @@ index 61abc1e094a8..ceda05c0c4f6 100644
  	  This selects Security-Enhanced Linux (SELinux).
  	  You will also need a policy configuration and a labeled filesystem.
 diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
-index e7a7dcab81db..afd76c0a1a1f 100644
+index e7a7dcab8..afd76c0a1 100644
 --- a/security/selinux/hooks.c
 +++ b/security/selinux/hooks.c
 @@ -140,18 +140,6 @@ static int __init selinux_enabled_setup(char *str)
@@ -2625,7 +2638,7 @@ index e7a7dcab81db..afd76c0a1a1f 100644
   * selinux_secmark_enabled - Check to see if SECMARK is currently enabled
   *
 diff --git a/security/selinux/selinuxfs.c b/security/selinux/selinuxfs.c
-index 47480eb2189b..2abb1c651e86 100644
+index 47480eb21..2abb1c651 100644
 --- a/security/selinux/selinuxfs.c
 +++ b/security/selinux/selinuxfs.c
 @@ -699,20 +699,12 @@ static ssize_t sel_write_checkreqprot(struct file *file, const char __user *buf,
@@ -2651,7 +2664,7 @@ index 47480eb2189b..2abb1c651e86 100644
  
  out:
 diff --git a/security/yama/Kconfig b/security/yama/Kconfig
-index a810304123ca..b809050b25d2 100644
+index a81030412..b809050b2 100644
 --- a/security/yama/Kconfig
 +++ b/security/yama/Kconfig
 @@ -2,7 +2,7 @@
@@ -2664,7 +2677,7 @@ index a810304123ca..b809050b25d2 100644
  	  This selects Yama, which extends DAC support with additional
  	  system-wide security settings beyond regular Linux discretionary
 diff --git a/tools/perf/Documentation/security.txt b/tools/perf/Documentation/security.txt
-index 4fe3b8b1958f..a7d88cc23a70 100644
+index 4fe3b8b19..a7d88cc23 100644
 --- a/tools/perf/Documentation/security.txt
 +++ b/tools/perf/Documentation/security.txt
 @@ -148,6 +148,7 @@ Perf tool provides a message similar to the one below:
@@ -2676,10 +2689,10 @@ index 4fe3b8b1958f..a7d88cc23a70 100644
     in /etc/sysctl.conf (e.g. kernel.perf_event_paranoid = <setting>)
  
 diff --git a/tools/perf/util/evsel.c b/tools/perf/util/evsel.c
-index 3c030da2e477..52eaef60fb5a 100644
+index 08fd9b9af..39c309dd4 100644
 --- a/tools/perf/util/evsel.c
 +++ b/tools/perf/util/evsel.c
-@@ -3703,6 +3703,7 @@ int evsel__open_strerror(struct evsel *evsel, struct target *target,
+@@ -3714,6 +3714,7 @@ int evsel__open_strerror(struct evsel *evsel, struct target *target,
  		 ">= 0: Disallow raw and ftrace function tracepoint access\n"
  		 ">= 1: Disallow CPU event access\n"
  		 ">= 2: Disallow kernel profiling\n"
@@ -2687,6 +2700,3 @@ index 3c030da2e477..52eaef60fb5a 100644
  		 "To make the adjusted perf_event_paranoid setting permanent preserve it\n"
  		 "in /etc/sysctl.conf (e.g. kernel.perf_event_paranoid = <setting>)",
  		 perf_event_paranoid());
--- 
-2.50.1
-

--- a/6.15/sched/0001-bore-cachy.patch
+++ b/6.15/sched/0001-bore-cachy.patch
@@ -1,27 +1,29 @@
-From 5a24ad3784c74f624454b7467d6165368df9419f Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
+From a60bb3276cefa3d1653ab64399df9ff02e8b0fec Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
 Date: Mon, 21 Jul 2025 21:11:58 +0200
 Subject: [PATCH] bore-cachy
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
- include/linux/sched.h      |  18 ++
- include/linux/sched/bore.h |  42 ++++
+ include/linux/sched.h      |  20 ++
+ include/linux/sched/bore.h |  44 ++++
  init/Kconfig               |  17 ++
  kernel/Kconfig.hz          |  17 ++
  kernel/fork.c              |   8 +
+ kernel/futex/waitwake.c    |  11 +
  kernel/sched/Makefile      |   1 +
- kernel/sched/bore.c        | 425 +++++++++++++++++++++++++++++++++++++
- kernel/sched/core.c        |   8 +
- kernel/sched/debug.c       |  61 +++++-
- kernel/sched/fair.c        | 101 +++++++--
+ kernel/sched/bore.c        | 440 +++++++++++++++++++++++++++++++++++++
+ kernel/sched/core.c        |  12 +
+ kernel/sched/debug.c       |  61 ++++-
+ kernel/sched/fair.c        | 123 +++++++++--
+ kernel/sched/features.h    |   3 +
  kernel/sched/sched.h       |   9 +
- 11 files changed, 690 insertions(+), 17 deletions(-)
+ 13 files changed, 741 insertions(+), 25 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index f96ac1982..f9946f366 100644
+index f96ac1982..4aa3e5e85 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -566,6 +566,14 @@ struct sched_statistics {
@@ -39,7 +41,7 @@ index f96ac1982..f9946f366 100644
  struct sched_entity {
  	/* For load-balancing: */
  	struct load_weight		load;
-@@ -585,6 +593,16 @@ struct sched_entity {
+@@ -585,6 +593,18 @@ struct sched_entity {
  	u64				sum_exec_runtime;
  	u64				prev_sum_exec_runtime;
  	u64				vruntime;
@@ -49,7 +51,9 @@ index f96ac1982..f9946f366 100644
 +	u32				curr_burst_penalty;
 +	u32				burst_penalty;
 +	u8				burst_score;
-+	u8				burst_count;
++	u8				damper;
++	bool			stop_burst_update;
++	bool			waiting_for_futex;
 +	struct sched_burst_cache child_burst;
 +	struct sched_burst_cache group_burst;
 +#endif // CONFIG_SCHED_BORE
@@ -58,10 +62,10 @@ index f96ac1982..f9946f366 100644
  
 diff --git a/include/linux/sched/bore.h b/include/linux/sched/bore.h
 new file mode 100644
-index 000000000..55c19da46
+index 000000000..c2819edb1
 --- /dev/null
 +++ b/include/linux/sched/bore.h
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,44 @@
 +
 +#include <linux/sched.h>
 +#include <linux/sched/cputime.h>
@@ -71,20 +75,22 @@ index 000000000..55c19da46
 +#define SCHED_BORE_AUTHOR   "Masahito Suzuki"
 +#define SCHED_BORE_PROGNAME "BORE CPU Scheduler modification"
 +
-+#define SCHED_BORE_VERSION  "6.1.0"
++#define SCHED_BORE_VERSION  "6.4.0"
 +
 +#ifdef CONFIG_SCHED_BORE
 +extern u8   __read_mostly sched_bore;
 +extern u8   __read_mostly sched_burst_exclude_kthreads;
-+extern u8   __read_mostly sched_burst_smoothness;
++extern u8   __read_mostly sched_burst_min_smooth;
++extern u8   __read_mostly sched_burst_max_damper;
 +extern u8   __read_mostly sched_burst_fork_atavistic;
-+extern u8   __read_mostly sched_burst_parity_threshold;
 +extern u8   __read_mostly sched_burst_penalty_offset;
++extern u8   __read_mostly sched_burst_futex_boost;
 +extern uint __read_mostly sched_burst_penalty_scale;
 +extern uint __read_mostly sched_burst_cache_stop_count;
 +extern uint __read_mostly sched_burst_cache_lifetime;
 +extern uint __read_mostly sched_deadline_boost_mask;
 +
++extern u8   effective_prio_bore(struct task_struct *p);
 +extern void update_burst_score(struct sched_entity *se);
 +extern void update_curr_bore(u64 delta_exec, struct sched_entity *se);
 +
@@ -100,12 +106,12 @@ index 000000000..55c19da46
 +extern void reset_task_bore(struct task_struct *p);
 +extern void sched_bore_init(void);
 +
-+extern void reweight_entity(struct cfs_rq *cfs_rq,
-+	struct sched_entity *se, unsigned long weight, bool no_update_curr);
++extern void reweight_entity(
++	struct cfs_rq *cfs_rq, struct sched_entity *se, unsigned long weight);
 +#endif // CONFIG_SCHED_BORE
 +#endif // _LINUX_SCHED_BORE_H
 diff --git a/init/Kconfig b/init/Kconfig
-index c52485811..880b48ef3 100644
+index 3bd8f03f9..f992d0378 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1382,6 +1382,23 @@ config CHECKPOINT_RESTORE
@@ -133,13 +139,14 @@ index c52485811..880b48ef3 100644
  	bool "Automatic process group scheduling"
  	select CGROUPS
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index e1359db55..57c09523a 100644
+index e1359db55..31053e619 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
-@@ -79,5 +79,22 @@ config HZ
- 	default 750 if HZ_750
- 	default 1000 if HZ_1000
+@@ -81,3 +81,20 @@ config HZ
  
+ config SCHED_HRTICK
+ 	def_bool HIGH_RES_TIMERS
++
 +config MIN_BASE_SLICE_NS
 +	int "Default value for min_base_slice_ns"
 +	default 2000000
@@ -156,9 +163,6 @@ index e1359db55..57c09523a 100644
 +	 Setting this value too high can cause the system to boot with
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
-+
- config SCHED_HRTICK
- 	def_bool HIGH_RES_TIMERS
 diff --git a/kernel/fork.c b/kernel/fork.c
 index 39e47bfae..f5a554327 100644
 --- a/kernel/fork.c
@@ -185,6 +189,36 @@ index 39e47bfae..f5a554327 100644
  
  	/* CLONE_PARENT re-uses the old parent */
  	if (clone_flags & (CLONE_PARENT|CLONE_THREAD)) {
+diff --git a/kernel/futex/waitwake.c b/kernel/futex/waitwake.c
+index 25877d4f2..96ce4aa45 100644
+--- a/kernel/futex/waitwake.c
++++ b/kernel/futex/waitwake.c
+@@ -4,6 +4,9 @@
+ #include <linux/sched/task.h>
+ #include <linux/sched/signal.h>
+ #include <linux/freezer.h>
++#ifdef CONFIG_SCHED_BORE
++#include <linux/sched/bore.h>
++#endif // CONFIG_SCHED_BORE
+ 
+ #include "futex.h"
+ 
+@@ -366,7 +369,15 @@ void futex_wait_queue(struct futex_hash_bucket *hb, struct futex_q *q,
+ 		 * is no timeout, or if it has yet to expire.
+ 		 */
+ 		if (!timeout || timeout->task)
++#ifdef CONFIG_SCHED_BORE
++		{
++			current->se.waiting_for_futex = true;
++#endif // CONFIG_SCHED_BORE
+ 			schedule();
++#ifdef CONFIG_SCHED_BORE
++			current->se.waiting_for_futex = false;
++		}
++#endif // CONFIG_SCHED_BORE
+ 	}
+ 	__set_current_state(TASK_RUNNING);
+ }
 diff --git a/kernel/sched/Makefile b/kernel/sched/Makefile
 index 8ae86371d..b688084bc 100644
 --- a/kernel/sched/Makefile
@@ -196,10 +230,10 @@ index 8ae86371d..b688084bc 100644
 +obj-$(CONFIG_SCHED_BORE) += bore.o
 diff --git a/kernel/sched/bore.c b/kernel/sched/bore.c
 new file mode 100644
-index 000000000..e7f80d91c
+index 000000000..de6f1526e
 --- /dev/null
 +++ b/kernel/sched/bore.c
-@@ -0,0 +1,425 @@
+@@ -0,0 +1,440 @@
 +/*
 + *  Burst-Oriented Response Enhancer (BORE) CPU Scheduler
 + *  Copyright (C) 2021-2025 Masahito Suzuki <firelzrd@gmail.com>
@@ -212,15 +246,17 @@ index 000000000..e7f80d91c
 +#ifdef CONFIG_SCHED_BORE
 +u8   __read_mostly sched_bore                   = 1;
 +u8   __read_mostly sched_burst_exclude_kthreads = 1;
-+u8   __read_mostly sched_burst_smoothness       = 40;
-+u8   __read_mostly sched_burst_fork_atavistic   = 2;
-+u8   __read_mostly sched_burst_parity_threshold = 2;
++u8   __read_mostly sched_burst_min_smooth       = 6;
++u8   __read_mostly sched_burst_max_damper       = 40;
++u8   __read_mostly sched_burst_fork_atavistic   = 1;
 +u8   __read_mostly sched_burst_penalty_offset   = 24;
++u8   __read_mostly sched_burst_futex_boost      = 1;
 +uint __read_mostly sched_burst_penalty_scale    = 3180;
 +uint __read_mostly sched_burst_cache_stop_count = 64;
 +uint __read_mostly sched_burst_cache_lifetime   = 75000000;
 +uint __read_mostly sched_deadline_boost_mask    = ENQUEUE_INITIAL
 +                                                | ENQUEUE_WAKEUP;
++static int __maybe_unused maxval_prio    =   39;
 +static int __maybe_unused maxval_6_bits  =   63;
 +static int __maybe_unused maxval_8_bits  =  255;
 +static int __maybe_unused maxval_12_bits = 4095;
@@ -256,60 +292,65 @@ index 000000000..e7f80d91c
 +	struct sched_entity *se = &p->se;
 +	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
 +
-+	reweight_entity(cfs_rq_of(se), se, weight, true);
++	se->stop_burst_update = true;
++	reweight_entity(cfs_rq_of(se), se, weight);
++	se->stop_burst_update = false;
 +	se->load.inv_weight = sched_prio_to_wmult[prio];
 +}
 +
-+static inline u8 effective_prio(struct task_struct *p) {
-+	u8 prio = p->static_prio - MAX_RT_PRIO;
++inline u8 effective_prio_bore(struct task_struct *p) {
++	int prio = p->static_prio - MAX_RT_PRIO;
 +	if (likely(sched_bore))
 +		prio += p->se.burst_score;
-+	return min(39, prio);
++	return (u8)clamp(prio, 0, maxval_prio);
 +}
 +
 +void update_burst_score(struct sched_entity *se) {
 +	if (!entity_is_task(se)) return;
 +	struct task_struct *p = task_of(se);
-+	u8 prev_prio = effective_prio(p);
++	u8 prev_prio = effective_prio_bore(p);
 +
 +	u8 burst_score = 0;
 +	if (!((p->flags & PF_KTHREAD) && likely(sched_burst_exclude_kthreads)))
 +		burst_score = se->burst_penalty >> BURST_PENALTY_SHIFT;
 +	se->burst_score = burst_score;
 +
-+	u8 new_prio = effective_prio(p);
++	u8 new_prio = effective_prio_bore(p);
 +	if (new_prio != prev_prio)
 +		reweight_task_by_prio(p, new_prio);
 +}
 +
 +void update_curr_bore(u64 delta_exec, struct sched_entity *se) {
-+	if (!entity_is_task(se)) return;
++	if (!entity_is_task(se) || se->stop_burst_update) return;
++
++	u32 prev_penalty = se->prev_burst_penalty;
++	u32 curr_penalty = calc_burst_penalty(se->burst_time);
 +
 +	se->burst_time += delta_exec;
-+	se->curr_burst_penalty = calc_burst_penalty(se->burst_time);
-+	if (se->curr_burst_penalty > se->prev_burst_penalty)
-+		se->burst_penalty = se->prev_burst_penalty +
-+		(se->curr_burst_penalty - se->prev_burst_penalty) / se->burst_count;
++	se->curr_burst_penalty = curr_penalty;
++	if (curr_penalty > prev_penalty) {
++		u8 damper = se->damper;
++		u32 excess = curr_penalty - prev_penalty;
++		u32 soft_excess = excess / damper + !!(excess % damper);
++		se->burst_penalty = prev_penalty + soft_excess;
++	}
 +	update_burst_score(se);
 +}
 +
-+static inline u32 binary_smooth(u32 new, u32 old, u8 dumper) {
-+	u32 abs_diff = (new > old)? (new - old): (old - new);
-+	u32 adj_diff = (abs_diff / dumper) + ((abs_diff % dumper) != 0);
-+	return (new > old)? (old + adj_diff): (old - adj_diff);
++static inline u32 binary_smooth(s32 new, s32 old, u8 damper) {
++	return old + ((new - old) / damper) + !!((new - old) % damper);
 +}
 +
 +static void __restart_burst(struct sched_entity *se) {
-+	se->prev_burst_penalty = binary_smooth(
-+		se->curr_burst_penalty, se->prev_burst_penalty, se->burst_count);
-+	se->burst_time = 0;
-+	se->curr_burst_penalty = 0;
++	se->prev_burst_penalty = binary_smooth(se->curr_burst_penalty,
++		se->prev_burst_penalty, max(se->damper, sched_burst_min_smooth));
++	se->burst_time = se->curr_burst_penalty = 0;
 +
-+	u8 smoothness = sched_burst_smoothness;
-+	if (se->burst_count < smoothness)
-+		se->burst_count++;
-+	else if (unlikely(se->burst_count > smoothness))
-+		se->burst_count = smoothness;
++	u8 max_damper = sched_burst_max_damper;
++	if (se->damper < max_damper)
++		se->damper++;
++	else if (unlikely(se->damper > max_damper))
++		se->damper = max_damper;
 +}
 +
 +inline void restart_burst(struct sched_entity *se) {
@@ -321,9 +362,9 @@ index 000000000..e7f80d91c
 +void restart_burst_rescale_deadline(struct sched_entity *se) {
 +	s64 vscaled, wremain, vremain = se->deadline - se->vruntime;
 +	struct task_struct *p = task_of(se);
-+	u8 prev_prio = effective_prio(p);
++	u8 prev_prio = effective_prio_bore(p);
 +	restart_burst(se);
-+	u8 new_prio = effective_prio(p);
++	u8 new_prio = effective_prio_bore(p);
 +	if (prev_prio > new_prio) {
 +		wremain = __unscale_slice(abs(vremain), prev_prio);
 +		vscaled = __scale_slice(wremain, new_prio);
@@ -344,11 +385,10 @@ index 000000000..e7f80d91c
 +	write_lock_irq(&tasklist_lock);
 +	for_each_process(task) {
 +		if (!task_is_bore_eligible(task)) continue;
-+		rq = task_rq(task);
-+		rq_pin_lock(rq, &rf);
++		rq = task_rq_lock(task, &rf);
 +		update_rq_clock(rq);
-+		reweight_task_by_prio(task, effective_prio(task));
-+		rq_unpin_lock(rq, &rf);
++		reweight_task_by_prio(task, effective_prio_bore(task));
++		task_rq_unlock(rq, task, &rf);
 +	}
 +	write_unlock_irq(&tasklist_lock);
 +}
@@ -508,7 +548,7 @@ index 000000000..e7f80d91c
 +	__restart_burst(se);
 +	se->burst_penalty = se->prev_burst_penalty =
 +		max(se->prev_burst_penalty, penalty);
-+	se->burst_count = 1;
++	se->damper = 1;
 +	se->child_burst.timestamp = 0;
 +	se->group_burst.timestamp = 0;
 +}
@@ -519,7 +559,7 @@ index 000000000..e7f80d91c
 +	p->se.curr_burst_penalty = 0;
 +	p->se.burst_penalty = 0;
 +	p->se.burst_score = 0;
-+	p->se.burst_count = 1;
++	p->se.damper = 1;
 +	memset(&p->se.child_burst, 0, sizeof(struct sched_burst_cache));
 +	memset(&p->se.group_burst, 0, sizeof(struct sched_burst_cache));
 +}
@@ -551,8 +591,17 @@ index 000000000..e7f80d91c
 +		.extra2		= SYSCTL_ONE,
 +	},
 +	{
-+		.procname	= "sched_burst_smoothness",
-+		.data		= &sched_burst_smoothness,
++		.procname	= "sched_burst_min_smooth",
++		.data		= &sched_burst_min_smooth,
++		.maxlen		= sizeof(u8),
++		.mode		= 0644,
++		.proc_handler = proc_dou8vec_minmax,
++		.extra1		= SYSCTL_ONE,
++		.extra2		= &maxval_8_bits,
++	},
++	{
++		.procname	= "sched_burst_max_damper",
++		.data		= &sched_burst_max_damper,
 +		.maxlen		= sizeof(u8),
 +		.mode		= 0644,
 +		.proc_handler = proc_dou8vec_minmax,
@@ -569,15 +618,6 @@ index 000000000..e7f80d91c
 +		.extra2		= SYSCTL_THREE,
 +	},
 +	{
-+		.procname	= "sched_burst_parity_threshold",
-+		.data		= &sched_burst_parity_threshold,
-+		.maxlen		= sizeof(u8),
-+		.mode		= 0644,
-+		.proc_handler = proc_dou8vec_minmax,
-+		.extra1		= SYSCTL_ZERO,
-+		.extra2		= &maxval_8_bits,
-+	},
-+	{
 +		.procname	= "sched_burst_penalty_offset",
 +		.data		= &sched_burst_penalty_offset,
 +		.maxlen		= sizeof(u8),
@@ -585,6 +625,15 @@ index 000000000..e7f80d91c
 +		.proc_handler = proc_dou8vec_minmax,
 +		.extra1		= SYSCTL_ZERO,
 +		.extra2		= &maxval_6_bits,
++	},
++	{
++		.procname	= "sched_burst_futex_boost",
++		.data		= &sched_burst_futex_boost,
++		.maxlen		= sizeof(u8),
++		.mode		= 0644,
++		.proc_handler = proc_dou8vec_minmax,
++		.extra1		= SYSCTL_ZERO,
++		.extra2		= SYSCTL_ONE,
 +	},
 +	{
 +		.procname	= "sched_burst_penalty_scale",
@@ -626,7 +675,7 @@ index 000000000..e7f80d91c
 +#endif // CONFIG_SYSCTL
 +#endif // CONFIG_SCHED_BORE
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 7d5f51e2f..f80bdc89c 100644
+index 7d5f51e2f..a5a252198 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -96,6 +96,10 @@
@@ -640,7 +689,19 @@ index 7d5f51e2f..f80bdc89c 100644
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpu);
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpumask);
  
-@@ -8554,6 +8558,10 @@ void __init sched_init(void)
+@@ -1422,7 +1426,11 @@ int tg_nop(struct task_group *tg, void *data)
+ 
+ void set_load_weight(struct task_struct *p, bool update_load)
+ {
++#ifdef CONFIG_SCHED_BORE
++	int prio = effective_prio_bore(p);
++#else // !CONFIG_SCHED_BORE
+ 	int prio = p->static_prio - MAX_RT_PRIO;
++#endif // CONFIG_SCHED_BORE
+ 	struct load_weight lw;
+ 
+ 	if (task_has_idle_policy(p)) {
+@@ -8554,6 +8562,10 @@ void __init sched_init(void)
  	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
  #endif
  
@@ -701,9 +762,9 @@ index 557246880..c1f6219f2 100644
 +	.llseek		= seq_lseek, \
 +	.release	= single_release, \
 +};
- 
-+DEFINE_SYSCTL_SCHED_FUNC(min_base_slice, min_base_slice)
 +
++DEFINE_SYSCTL_SCHED_FUNC(min_base_slice, min_base_slice)
+ 
 +#undef DEFINE_SYSCTL_SCHED_FUNC
 +#else // !CONFIG_SCHED_BORE
  static ssize_t sched_scaling_write(struct file *filp, const char __user *ubuf,
@@ -760,7 +821,7 @@ index 557246880..c1f6219f2 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index ff9070239..845081676 100644
+index 86db81fb8..f4a574bc0 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -58,6 +58,10 @@
@@ -863,18 +924,22 @@ index ff9070239..845081676 100644
  
  	se->vlag = clamp(vlag, -limit, limit);
  }
-@@ -953,6 +968,10 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq)
+@@ -952,7 +967,14 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq)
+ 	if (curr && (!curr->on_rq || !entity_eligible(cfs_rq, curr)))
  		curr = NULL;
  
++#if !defined(CONFIG_SCHED_BORE)
  	if (sched_feat(RUN_TO_PARITY) && curr && protect_slice(curr))
-+#ifdef CONFIG_SCHED_BORE
-+		if (!(likely(sched_bore) && likely(sched_burst_parity_threshold) &&
-+			sched_burst_parity_threshold < cfs_rq->nr_queued))
++#else // CONFIG_SCHED_BORE
++	bool run_to_parity = likely(sched_bore) ?
++		sched_feat(RUN_TO_PARITY_BORE) : sched_feat(RUN_TO_PARITY);
++	if (run_to_parity && curr && protect_slice(curr) &&
++		(!curr->waiting_for_futex || unlikely(!sched_bore)))
 +#endif // CONFIG_SCHED_BORE
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -1010,6 +1029,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -1010,6 +1032,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
   * Scheduling class statistics methods:
   */
  #ifdef CONFIG_SMP
@@ -882,7 +947,7 @@ index ff9070239..845081676 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -1021,6 +1041,7 @@ int sched_update_scaling(void)
+@@ -1021,6 +1044,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -890,7 +955,7 @@ index ff9070239..845081676 100644
  #endif
  
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
-@@ -1250,6 +1271,9 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1250,6 +1274,9 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	if (unlikely(delta_exec <= 0))
  		return;
  
@@ -900,67 +965,129 @@ index ff9070239..845081676 100644
  	curr->vruntime += calc_delta_fair(delta_exec, curr);
  	resched = update_deadline(cfs_rq, curr);
  	update_min_vruntime(cfs_rq);
-@@ -3797,13 +3821,22 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se) { }
+@@ -3797,7 +3824,7 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se) { }
  
  static void place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags);
  
-+
-+#ifdef CONFIG_SCHED_BORE
+-static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
 +void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
-+			    unsigned long weight, bool no_update_curr)
-+#else // !CONFIG_SCHED_BORE
- static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
  			    unsigned long weight)
-+#endif // CONFIG_SCHED_BORE
  {
  	bool curr = cfs_rq->curr == se;
+@@ -5215,12 +5242,11 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
+ static void
+ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ {
+-	u64 vslice, vruntime = avg_vruntime(cfs_rq);
++	u64 vslice = 0, vruntime = avg_vruntime(cfs_rq);
+ 	s64 lag = 0;
  
- 	if (se->on_rq) {
- 		/* commit outstanding execution time */
-+#ifdef CONFIG_SCHED_BORE
-+		if (!no_update_curr)
-+#endif // CONFIG_SCHED_BORE
- 		update_curr(cfs_rq);
- 		update_entity_lag(cfs_rq, se);
- 		se->deadline -= se->vruntime;
-@@ -3859,7 +3892,11 @@ static void reweight_task_fair(struct rq *rq, struct task_struct *p,
- 	struct cfs_rq *cfs_rq = cfs_rq_of(se);
- 	struct load_weight *load = &se->load;
+ 	if (!se->custom_slice)
+ 		se->slice = sysctl_sched_base_slice;
+-	vslice = calc_delta_fair(se->slice, se);
  
-+#ifdef CONFIG_SCHED_BORE
-+	reweight_entity(cfs_rq, se, lw->weight, false);
-+#else // !CONFIG_SCHED_BORE
- 	reweight_entity(cfs_rq, se, lw->weight);
-+#endif // CONFIG_SCHED_BORE
- 	load->inv_weight = lw->inv_weight;
- }
- 
-@@ -4000,7 +4037,11 @@ static void update_cfs_group(struct sched_entity *se)
- 	shares = calc_group_shares(gcfs_rq);
- #endif
- 	if (unlikely(se->load.weight != shares))
-+#ifdef CONFIG_SCHED_BORE
-+		reweight_entity(cfs_rq_of(se), se, shares, false);
-+#else // !CONFIG_SCHED_BORE
- 		reweight_entity(cfs_rq_of(se), se, shares);
-+#endif // CONFIG_SCHED_BORE
- }
- 
- #else /* CONFIG_FAIR_GROUP_SCHED */
-@@ -5305,7 +5346,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 	/*
+ 	 * Due to how V is constructed as the weighted average of entities,
+@@ -5305,7 +5331,16 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		se->rel_deadline = 0;
  		return;
  	}
 -
 +#ifdef CONFIG_SCHED_BORE
-+	else if (likely(sched_bore))
++	if (likely(sched_bore) && sched_burst_futex_boost && se->waiting_for_futex)
++		goto vslice_found;
++#endif // !CONFIG_SCHED_BORE
++	vslice = calc_delta_fair(se->slice, se);
++#ifdef CONFIG_SCHED_BORE
++	if (likely(sched_bore))
 +		vslice >>= !!(flags & sched_deadline_boost_mask);
 +	else
 +#endif // CONFIG_SCHED_BORE
  	/*
  	 * When joining the competition; the existing tasks will be,
  	 * on average, halfway through their slice, as such start tasks
-@@ -7200,6 +7245,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -5314,6 +5349,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
+ 		vslice /= 2;
+ 
++#ifdef CONFIG_SCHED_BORE
++vslice_found:
++#endif // CONFIG_SCHED_BORE
+ 	/*
+ 	 * EEVDF: vd_i = ve_i + r_i/w_i
+ 	 */
+@@ -5324,7 +5362,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
+ static inline int cfs_rq_throttled(struct cfs_rq *cfs_rq);
+ 
+ static void
+-requeue_delayed_entity(struct sched_entity *se);
++requeue_delayed_entity(struct sched_entity *se, int flags);
+ 
+ static void
+ enqueue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5488,6 +5526,10 @@ dequeue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 		if (sched_feat(DELAY_DEQUEUE) && delay &&
+ 		    !entity_eligible(cfs_rq, se)) {
+ 			update_load_avg(cfs_rq, se, 0);
++#ifdef CONFIG_SCHED_BORE
++			if (sched_feat(DELAY_ZERO) && likely(sched_bore))
++				update_entity_lag(cfs_rq, se);
++#endif // CONFIG_SCHED_BORE
+ 			set_delayed(se);
+ 			return false;
+ 		}
+@@ -6904,7 +6946,7 @@ static int sched_idle_cpu(int cpu)
+ #endif
+ 
+ static void
+-requeue_delayed_entity(struct sched_entity *se)
++requeue_delayed_entity(struct sched_entity *se, int flags)
+ {
+ 	struct cfs_rq *cfs_rq = cfs_rq_of(se);
+ 
+@@ -6917,13 +6959,22 @@ requeue_delayed_entity(struct sched_entity *se)
+ 	WARN_ON_ONCE(!se->on_rq);
+ 
+ 	if (sched_feat(DELAY_ZERO)) {
++#ifdef CONFIG_SCHED_BORE
++		if (likely(sched_bore))
++			flags |= ENQUEUE_WAKEUP;
++		else {
++#endif // CONFIG_SCHED_BORE
++		flags = 0;
+ 		update_entity_lag(cfs_rq, se);
++#ifdef CONFIG_SCHED_BORE
++		}
++#endif // CONFIG_SCHED_BORE
+ 		if (se->vlag > 0) {
+ 			cfs_rq->nr_queued--;
+ 			if (se != cfs_rq->curr)
+ 				__dequeue_entity(cfs_rq, se);
+ 			se->vlag = 0;
+-			place_entity(cfs_rq, se, 0);
++			place_entity(cfs_rq, se, flags);
+ 			if (se != cfs_rq->curr)
+ 				__enqueue_entity(cfs_rq, se);
+ 			cfs_rq->nr_queued++;
+@@ -6960,7 +7011,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 		util_est_enqueue(&rq->cfs, p);
+ 
+ 	if (flags & ENQUEUE_DELAYED) {
+-		requeue_delayed_entity(se);
++		requeue_delayed_entity(se, flags);
+ 		return;
+ 	}
+ 
+@@ -6978,7 +7029,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 	for_each_sched_entity(se) {
+ 		if (se->on_rq) {
+ 			if (se->sched_delayed)
+-				requeue_delayed_entity(se);
++				requeue_delayed_entity(se, flags);
+ 			break;
+ 		}
+ 		cfs_rq = cfs_rq_of(se);
+@@ -7200,6 +7251,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_dequeue(&rq->cfs, p);
  
  	util_est_update(&rq->cfs, p, flags & DEQUEUE_SLEEP);
@@ -976,7 +1103,7 @@ index ff9070239..845081676 100644
  	if (dequeue_entities(rq, &p->se, flags) < 0)
  		return false;
  
-@@ -9029,16 +9083,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -9029,16 +9089,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -1002,7 +1129,7 @@ index ff9070239..845081676 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -13152,6 +13215,9 @@ static void task_tick_fair(struct rq *rq, struct task_struct *curr, int queued)
+@@ -13165,6 +13234,9 @@ static void task_tick_fair(struct rq *rq, struct task_struct *curr, int queued)
  static void task_fork_fair(struct task_struct *p)
  {
  	set_task_max_allowed_capacity(p);
@@ -1012,7 +1139,7 @@ index ff9070239..845081676 100644
  }
  
  /*
-@@ -13269,6 +13335,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
+@@ -13282,6 +13354,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  {
  	WARN_ON_ONCE(p->se.sched_delayed);
  
@@ -1022,8 +1149,22 @@ index ff9070239..845081676 100644
  	attach_task_cfs_rq(p);
  
  	set_task_max_allowed_capacity(p);
+diff --git a/kernel/sched/features.h b/kernel/sched/features.h
+index 3c12d9f93..b87171053 100644
+--- a/kernel/sched/features.h
++++ b/kernel/sched/features.h
+@@ -18,6 +18,9 @@ SCHED_FEAT(PLACE_REL_DEADLINE, true)
+  * 0-lag point or until is has exhausted it's slice.
+  */
+ SCHED_FEAT(RUN_TO_PARITY, true)
++#ifdef CONFIG_SCHED_BORE
++SCHED_FEAT(RUN_TO_PARITY_BORE, false)
++#endif // CONFIG_SCHED_BORE
+ /*
+  * Allow wakeup of tasks with a shorter slice to cancel RUN_TO_PARITY for
+  * current.
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 0892942cf..882b16a54 100644
+index ad6cbf2d9..b0a1a0289 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2100,7 +2100,11 @@ extern int group_balance_cpu(struct sched_group *sg);
@@ -1051,6 +1192,3 @@ index 0892942cf..882b16a54 100644
  
  extern int sysctl_resched_latency_warn_ms;
  extern int sysctl_resched_latency_warn_once;
--- 
-2.50.1
-

--- a/6.15/sched/0001-bore.patch
+++ b/6.15/sched/0001-bore.patch
@@ -1,27 +1,29 @@
-From ed88c7d60c53704b58a3fe813c4acbd04066bd67 Mon Sep 17 00:00:00 2001
+From 026200fe1a0a784c5fb03a5a1556331151b45801 Mon Sep 17 00:00:00 2001
 From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Mon, 21 Jul 2025 21:11:11 +0200
+Date: Sun, 17 Aug 2025 17:45:25 +0800
 Subject: [PATCH] bore
 
 Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
- include/linux/sched.h      |  18 ++
- include/linux/sched/bore.h |  42 ++++
+ include/linux/sched.h      |  20 ++
+ include/linux/sched/bore.h |  44 ++++
  init/Kconfig               |  17 ++
  kernel/Kconfig.hz          |  17 ++
  kernel/fork.c              |   8 +
+ kernel/futex/waitwake.c    |  11 +
  kernel/sched/Makefile      |   1 +
- kernel/sched/bore.c        | 425 +++++++++++++++++++++++++++++++++++++
- kernel/sched/core.c        |   8 +
- kernel/sched/debug.c       |  61 +++++-
- kernel/sched/fair.c        |  88 +++++++-
+ kernel/sched/bore.c        | 440 +++++++++++++++++++++++++++++++++++++
+ kernel/sched/core.c        |  12 +
+ kernel/sched/debug.c       |  61 ++++-
+ kernel/sched/fair.c        | 110 +++++++++-
+ kernel/sched/features.h    |   3 +
  kernel/sched/sched.h       |   9 +
- 11 files changed, 690 insertions(+), 4 deletions(-)
+ 13 files changed, 741 insertions(+), 12 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index f96ac1982..f9946f366 100644
+index f96ac1982..4aa3e5e85 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -566,6 +566,14 @@ struct sched_statistics {
@@ -39,7 +41,7 @@ index f96ac1982..f9946f366 100644
  struct sched_entity {
  	/* For load-balancing: */
  	struct load_weight		load;
-@@ -585,6 +593,16 @@ struct sched_entity {
+@@ -585,6 +593,18 @@ struct sched_entity {
  	u64				sum_exec_runtime;
  	u64				prev_sum_exec_runtime;
  	u64				vruntime;
@@ -49,7 +51,9 @@ index f96ac1982..f9946f366 100644
 +	u32				curr_burst_penalty;
 +	u32				burst_penalty;
 +	u8				burst_score;
-+	u8				burst_count;
++	u8				damper;
++	bool			stop_burst_update;
++	bool			waiting_for_futex;
 +	struct sched_burst_cache child_burst;
 +	struct sched_burst_cache group_burst;
 +#endif // CONFIG_SCHED_BORE
@@ -58,10 +62,10 @@ index f96ac1982..f9946f366 100644
  
 diff --git a/include/linux/sched/bore.h b/include/linux/sched/bore.h
 new file mode 100644
-index 000000000..55c19da46
+index 000000000..c2819edb1
 --- /dev/null
 +++ b/include/linux/sched/bore.h
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,44 @@
 +
 +#include <linux/sched.h>
 +#include <linux/sched/cputime.h>
@@ -71,20 +75,22 @@ index 000000000..55c19da46
 +#define SCHED_BORE_AUTHOR   "Masahito Suzuki"
 +#define SCHED_BORE_PROGNAME "BORE CPU Scheduler modification"
 +
-+#define SCHED_BORE_VERSION  "6.1.0"
++#define SCHED_BORE_VERSION  "6.4.0"
 +
 +#ifdef CONFIG_SCHED_BORE
 +extern u8   __read_mostly sched_bore;
 +extern u8   __read_mostly sched_burst_exclude_kthreads;
-+extern u8   __read_mostly sched_burst_smoothness;
++extern u8   __read_mostly sched_burst_min_smooth;
++extern u8   __read_mostly sched_burst_max_damper;
 +extern u8   __read_mostly sched_burst_fork_atavistic;
-+extern u8   __read_mostly sched_burst_parity_threshold;
 +extern u8   __read_mostly sched_burst_penalty_offset;
++extern u8   __read_mostly sched_burst_futex_boost;
 +extern uint __read_mostly sched_burst_penalty_scale;
 +extern uint __read_mostly sched_burst_cache_stop_count;
 +extern uint __read_mostly sched_burst_cache_lifetime;
 +extern uint __read_mostly sched_deadline_boost_mask;
 +
++extern u8   effective_prio_bore(struct task_struct *p);
 +extern void update_burst_score(struct sched_entity *se);
 +extern void update_curr_bore(u64 delta_exec, struct sched_entity *se);
 +
@@ -100,12 +106,12 @@ index 000000000..55c19da46
 +extern void reset_task_bore(struct task_struct *p);
 +extern void sched_bore_init(void);
 +
-+extern void reweight_entity(struct cfs_rq *cfs_rq,
-+	struct sched_entity *se, unsigned long weight, bool no_update_curr);
++extern void reweight_entity(
++	struct cfs_rq *cfs_rq, struct sched_entity *se, unsigned long weight);
 +#endif // CONFIG_SCHED_BORE
 +#endif // _LINUX_SCHED_BORE_H
 diff --git a/init/Kconfig b/init/Kconfig
-index bf3a92006..5efa0ec37 100644
+index b2367239a..cdc1a4e4b 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1362,6 +1362,23 @@ config CHECKPOINT_RESTORE
@@ -133,13 +139,14 @@ index bf3a92006..5efa0ec37 100644
  	bool "Automatic process group scheduling"
  	select CGROUPS
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index ce1435cb0..b93d1f657 100644
+index ce1435cb0..9eee2005e 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
-@@ -55,5 +55,22 @@ config HZ
- 	default 300 if HZ_300
- 	default 1000 if HZ_1000
+@@ -57,3 +57,20 @@ config HZ
  
+ config SCHED_HRTICK
+ 	def_bool HIGH_RES_TIMERS
++
 +config MIN_BASE_SLICE_NS
 +	int "Default value for min_base_slice_ns"
 +	default 2000000
@@ -156,9 +163,6 @@ index ce1435cb0..b93d1f657 100644
 +	 Setting this value too high can cause the system to boot with
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
-+
- config SCHED_HRTICK
- 	def_bool HIGH_RES_TIMERS
 diff --git a/kernel/fork.c b/kernel/fork.c
 index 168681fc4..6b1644cfd 100644
 --- a/kernel/fork.c
@@ -185,6 +189,36 @@ index 168681fc4..6b1644cfd 100644
  
  	/* CLONE_PARENT re-uses the old parent */
  	if (clone_flags & (CLONE_PARENT|CLONE_THREAD)) {
+diff --git a/kernel/futex/waitwake.c b/kernel/futex/waitwake.c
+index 25877d4f2..96ce4aa45 100644
+--- a/kernel/futex/waitwake.c
++++ b/kernel/futex/waitwake.c
+@@ -4,6 +4,9 @@
+ #include <linux/sched/task.h>
+ #include <linux/sched/signal.h>
+ #include <linux/freezer.h>
++#ifdef CONFIG_SCHED_BORE
++#include <linux/sched/bore.h>
++#endif // CONFIG_SCHED_BORE
+ 
+ #include "futex.h"
+ 
+@@ -366,7 +369,15 @@ void futex_wait_queue(struct futex_hash_bucket *hb, struct futex_q *q,
+ 		 * is no timeout, or if it has yet to expire.
+ 		 */
+ 		if (!timeout || timeout->task)
++#ifdef CONFIG_SCHED_BORE
++		{
++			current->se.waiting_for_futex = true;
++#endif // CONFIG_SCHED_BORE
+ 			schedule();
++#ifdef CONFIG_SCHED_BORE
++			current->se.waiting_for_futex = false;
++		}
++#endif // CONFIG_SCHED_BORE
+ 	}
+ 	__set_current_state(TASK_RUNNING);
+ }
 diff --git a/kernel/sched/Makefile b/kernel/sched/Makefile
 index 8ae86371d..b688084bc 100644
 --- a/kernel/sched/Makefile
@@ -196,10 +230,10 @@ index 8ae86371d..b688084bc 100644
 +obj-$(CONFIG_SCHED_BORE) += bore.o
 diff --git a/kernel/sched/bore.c b/kernel/sched/bore.c
 new file mode 100644
-index 000000000..e7f80d91c
+index 000000000..de6f1526e
 --- /dev/null
 +++ b/kernel/sched/bore.c
-@@ -0,0 +1,425 @@
+@@ -0,0 +1,440 @@
 +/*
 + *  Burst-Oriented Response Enhancer (BORE) CPU Scheduler
 + *  Copyright (C) 2021-2025 Masahito Suzuki <firelzrd@gmail.com>
@@ -212,15 +246,17 @@ index 000000000..e7f80d91c
 +#ifdef CONFIG_SCHED_BORE
 +u8   __read_mostly sched_bore                   = 1;
 +u8   __read_mostly sched_burst_exclude_kthreads = 1;
-+u8   __read_mostly sched_burst_smoothness       = 40;
-+u8   __read_mostly sched_burst_fork_atavistic   = 2;
-+u8   __read_mostly sched_burst_parity_threshold = 2;
++u8   __read_mostly sched_burst_min_smooth       = 6;
++u8   __read_mostly sched_burst_max_damper       = 40;
++u8   __read_mostly sched_burst_fork_atavistic   = 1;
 +u8   __read_mostly sched_burst_penalty_offset   = 24;
++u8   __read_mostly sched_burst_futex_boost      = 1;
 +uint __read_mostly sched_burst_penalty_scale    = 3180;
 +uint __read_mostly sched_burst_cache_stop_count = 64;
 +uint __read_mostly sched_burst_cache_lifetime   = 75000000;
 +uint __read_mostly sched_deadline_boost_mask    = ENQUEUE_INITIAL
 +                                                | ENQUEUE_WAKEUP;
++static int __maybe_unused maxval_prio    =   39;
 +static int __maybe_unused maxval_6_bits  =   63;
 +static int __maybe_unused maxval_8_bits  =  255;
 +static int __maybe_unused maxval_12_bits = 4095;
@@ -256,60 +292,65 @@ index 000000000..e7f80d91c
 +	struct sched_entity *se = &p->se;
 +	unsigned long weight = scale_load(sched_prio_to_weight[prio]);
 +
-+	reweight_entity(cfs_rq_of(se), se, weight, true);
++	se->stop_burst_update = true;
++	reweight_entity(cfs_rq_of(se), se, weight);
++	se->stop_burst_update = false;
 +	se->load.inv_weight = sched_prio_to_wmult[prio];
 +}
 +
-+static inline u8 effective_prio(struct task_struct *p) {
-+	u8 prio = p->static_prio - MAX_RT_PRIO;
++inline u8 effective_prio_bore(struct task_struct *p) {
++	int prio = p->static_prio - MAX_RT_PRIO;
 +	if (likely(sched_bore))
 +		prio += p->se.burst_score;
-+	return min(39, prio);
++	return (u8)clamp(prio, 0, maxval_prio);
 +}
 +
 +void update_burst_score(struct sched_entity *se) {
 +	if (!entity_is_task(se)) return;
 +	struct task_struct *p = task_of(se);
-+	u8 prev_prio = effective_prio(p);
++	u8 prev_prio = effective_prio_bore(p);
 +
 +	u8 burst_score = 0;
 +	if (!((p->flags & PF_KTHREAD) && likely(sched_burst_exclude_kthreads)))
 +		burst_score = se->burst_penalty >> BURST_PENALTY_SHIFT;
 +	se->burst_score = burst_score;
 +
-+	u8 new_prio = effective_prio(p);
++	u8 new_prio = effective_prio_bore(p);
 +	if (new_prio != prev_prio)
 +		reweight_task_by_prio(p, new_prio);
 +}
 +
 +void update_curr_bore(u64 delta_exec, struct sched_entity *se) {
-+	if (!entity_is_task(se)) return;
++	if (!entity_is_task(se) || se->stop_burst_update) return;
++
++	u32 prev_penalty = se->prev_burst_penalty;
++	u32 curr_penalty = calc_burst_penalty(se->burst_time);
 +
 +	se->burst_time += delta_exec;
-+	se->curr_burst_penalty = calc_burst_penalty(se->burst_time);
-+	if (se->curr_burst_penalty > se->prev_burst_penalty)
-+		se->burst_penalty = se->prev_burst_penalty +
-+		(se->curr_burst_penalty - se->prev_burst_penalty) / se->burst_count;
++	se->curr_burst_penalty = curr_penalty;
++	if (curr_penalty > prev_penalty) {
++		u8 damper = se->damper;
++		u32 excess = curr_penalty - prev_penalty;
++		u32 soft_excess = excess / damper + !!(excess % damper);
++		se->burst_penalty = prev_penalty + soft_excess;
++	}
 +	update_burst_score(se);
 +}
 +
-+static inline u32 binary_smooth(u32 new, u32 old, u8 dumper) {
-+	u32 abs_diff = (new > old)? (new - old): (old - new);
-+	u32 adj_diff = (abs_diff / dumper) + ((abs_diff % dumper) != 0);
-+	return (new > old)? (old + adj_diff): (old - adj_diff);
++static inline u32 binary_smooth(s32 new, s32 old, u8 damper) {
++	return old + ((new - old) / damper) + !!((new - old) % damper);
 +}
 +
 +static void __restart_burst(struct sched_entity *se) {
-+	se->prev_burst_penalty = binary_smooth(
-+		se->curr_burst_penalty, se->prev_burst_penalty, se->burst_count);
-+	se->burst_time = 0;
-+	se->curr_burst_penalty = 0;
++	se->prev_burst_penalty = binary_smooth(se->curr_burst_penalty,
++		se->prev_burst_penalty, max(se->damper, sched_burst_min_smooth));
++	se->burst_time = se->curr_burst_penalty = 0;
 +
-+	u8 smoothness = sched_burst_smoothness;
-+	if (se->burst_count < smoothness)
-+		se->burst_count++;
-+	else if (unlikely(se->burst_count > smoothness))
-+		se->burst_count = smoothness;
++	u8 max_damper = sched_burst_max_damper;
++	if (se->damper < max_damper)
++		se->damper++;
++	else if (unlikely(se->damper > max_damper))
++		se->damper = max_damper;
 +}
 +
 +inline void restart_burst(struct sched_entity *se) {
@@ -321,9 +362,9 @@ index 000000000..e7f80d91c
 +void restart_burst_rescale_deadline(struct sched_entity *se) {
 +	s64 vscaled, wremain, vremain = se->deadline - se->vruntime;
 +	struct task_struct *p = task_of(se);
-+	u8 prev_prio = effective_prio(p);
++	u8 prev_prio = effective_prio_bore(p);
 +	restart_burst(se);
-+	u8 new_prio = effective_prio(p);
++	u8 new_prio = effective_prio_bore(p);
 +	if (prev_prio > new_prio) {
 +		wremain = __unscale_slice(abs(vremain), prev_prio);
 +		vscaled = __scale_slice(wremain, new_prio);
@@ -344,11 +385,10 @@ index 000000000..e7f80d91c
 +	write_lock_irq(&tasklist_lock);
 +	for_each_process(task) {
 +		if (!task_is_bore_eligible(task)) continue;
-+		rq = task_rq(task);
-+		rq_pin_lock(rq, &rf);
++		rq = task_rq_lock(task, &rf);
 +		update_rq_clock(rq);
-+		reweight_task_by_prio(task, effective_prio(task));
-+		rq_unpin_lock(rq, &rf);
++		reweight_task_by_prio(task, effective_prio_bore(task));
++		task_rq_unlock(rq, task, &rf);
 +	}
 +	write_unlock_irq(&tasklist_lock);
 +}
@@ -508,7 +548,7 @@ index 000000000..e7f80d91c
 +	__restart_burst(se);
 +	se->burst_penalty = se->prev_burst_penalty =
 +		max(se->prev_burst_penalty, penalty);
-+	se->burst_count = 1;
++	se->damper = 1;
 +	se->child_burst.timestamp = 0;
 +	se->group_burst.timestamp = 0;
 +}
@@ -519,7 +559,7 @@ index 000000000..e7f80d91c
 +	p->se.curr_burst_penalty = 0;
 +	p->se.burst_penalty = 0;
 +	p->se.burst_score = 0;
-+	p->se.burst_count = 1;
++	p->se.damper = 1;
 +	memset(&p->se.child_burst, 0, sizeof(struct sched_burst_cache));
 +	memset(&p->se.group_burst, 0, sizeof(struct sched_burst_cache));
 +}
@@ -551,8 +591,17 @@ index 000000000..e7f80d91c
 +		.extra2		= SYSCTL_ONE,
 +	},
 +	{
-+		.procname	= "sched_burst_smoothness",
-+		.data		= &sched_burst_smoothness,
++		.procname	= "sched_burst_min_smooth",
++		.data		= &sched_burst_min_smooth,
++		.maxlen		= sizeof(u8),
++		.mode		= 0644,
++		.proc_handler = proc_dou8vec_minmax,
++		.extra1		= SYSCTL_ONE,
++		.extra2		= &maxval_8_bits,
++	},
++	{
++		.procname	= "sched_burst_max_damper",
++		.data		= &sched_burst_max_damper,
 +		.maxlen		= sizeof(u8),
 +		.mode		= 0644,
 +		.proc_handler = proc_dou8vec_minmax,
@@ -569,15 +618,6 @@ index 000000000..e7f80d91c
 +		.extra2		= SYSCTL_THREE,
 +	},
 +	{
-+		.procname	= "sched_burst_parity_threshold",
-+		.data		= &sched_burst_parity_threshold,
-+		.maxlen		= sizeof(u8),
-+		.mode		= 0644,
-+		.proc_handler = proc_dou8vec_minmax,
-+		.extra1		= SYSCTL_ZERO,
-+		.extra2		= &maxval_8_bits,
-+	},
-+	{
 +		.procname	= "sched_burst_penalty_offset",
 +		.data		= &sched_burst_penalty_offset,
 +		.maxlen		= sizeof(u8),
@@ -585,6 +625,15 @@ index 000000000..e7f80d91c
 +		.proc_handler = proc_dou8vec_minmax,
 +		.extra1		= SYSCTL_ZERO,
 +		.extra2		= &maxval_6_bits,
++	},
++	{
++		.procname	= "sched_burst_futex_boost",
++		.data		= &sched_burst_futex_boost,
++		.maxlen		= sizeof(u8),
++		.mode		= 0644,
++		.proc_handler = proc_dou8vec_minmax,
++		.extra1		= SYSCTL_ZERO,
++		.extra2		= SYSCTL_ONE,
 +	},
 +	{
 +		.procname	= "sched_burst_penalty_scale",
@@ -626,7 +675,7 @@ index 000000000..e7f80d91c
 +#endif // CONFIG_SYSCTL
 +#endif // CONFIG_SCHED_BORE
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 7d5f51e2f..f80bdc89c 100644
+index 7d5f51e2f..a5a252198 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -96,6 +96,10 @@
@@ -640,7 +689,19 @@ index 7d5f51e2f..f80bdc89c 100644
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpu);
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpumask);
  
-@@ -8554,6 +8558,10 @@ void __init sched_init(void)
+@@ -1422,7 +1426,11 @@ int tg_nop(struct task_group *tg, void *data)
+ 
+ void set_load_weight(struct task_struct *p, bool update_load)
+ {
++#ifdef CONFIG_SCHED_BORE
++	int prio = effective_prio_bore(p);
++#else // !CONFIG_SCHED_BORE
+ 	int prio = p->static_prio - MAX_RT_PRIO;
++#endif // CONFIG_SCHED_BORE
+ 	struct load_weight lw;
+ 
+ 	if (task_has_idle_policy(p)) {
+@@ -8554,6 +8562,10 @@ void __init sched_init(void)
  	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
  #endif
  
@@ -652,7 +713,7 @@ index 7d5f51e2f..f80bdc89c 100644
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 56ae54e0c..4302a4d60 100644
+index 557246880..c1f6219f2 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -167,7 +167,53 @@ static const struct file_operations sched_feat_fops = {
@@ -701,9 +762,9 @@ index 56ae54e0c..4302a4d60 100644
 +	.llseek		= seq_lseek, \
 +	.release	= single_release, \
 +};
- 
-+DEFINE_SYSCTL_SCHED_FUNC(min_base_slice, min_base_slice)
 +
++DEFINE_SYSCTL_SCHED_FUNC(min_base_slice, min_base_slice)
+ 
 +#undef DEFINE_SYSCTL_SCHED_FUNC
 +#else // !CONFIG_SCHED_BORE
  static ssize_t sched_scaling_write(struct file *filp, const char __user *ubuf,
@@ -739,7 +800,7 @@ index 56ae54e0c..4302a4d60 100644
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
  
-@@ -758,6 +811,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
+@@ -762,6 +815,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
@@ -749,7 +810,7 @@ index 56ae54e0c..4302a4d60 100644
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, "   %d      %d", task_node(p), task_numa_group_id(p));
  #endif
-@@ -1244,6 +1300,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
+@@ -1248,6 +1304,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  
  	P(se.load.weight);
  #ifdef CONFIG_SMP
@@ -760,7 +821,7 @@ index 56ae54e0c..4302a4d60 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 138d9f465..5f1d4dd44 100644
+index 9bf6931c8..f4a574bc0 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -58,6 +58,10 @@
@@ -839,18 +900,22 @@ index 138d9f465..5f1d4dd44 100644
  
  	se->vlag = clamp(vlag, -limit, limit);
  }
-@@ -940,6 +968,10 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq)
+@@ -939,7 +967,14 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq)
+ 	if (curr && (!curr->on_rq || !entity_eligible(cfs_rq, curr)))
  		curr = NULL;
  
++#if !defined(CONFIG_SCHED_BORE)
  	if (sched_feat(RUN_TO_PARITY) && curr && protect_slice(curr))
-+#ifdef CONFIG_SCHED_BORE
-+		if (!(likely(sched_bore) && likely(sched_burst_parity_threshold) &&
-+			sched_burst_parity_threshold < cfs_rq->nr_queued))
++#else // CONFIG_SCHED_BORE
++	bool run_to_parity = likely(sched_bore) ?
++		sched_feat(RUN_TO_PARITY_BORE) : sched_feat(RUN_TO_PARITY);
++	if (run_to_parity && curr && protect_slice(curr) &&
++		(!curr->waiting_for_futex || unlikely(!sched_bore)))
 +#endif // CONFIG_SCHED_BORE
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -997,6 +1029,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -997,6 +1032,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
   * Scheduling class statistics methods:
   */
  #ifdef CONFIG_SMP
@@ -858,7 +923,7 @@ index 138d9f465..5f1d4dd44 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -1008,6 +1041,7 @@ int sched_update_scaling(void)
+@@ -1008,6 +1044,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -866,7 +931,7 @@ index 138d9f465..5f1d4dd44 100644
  #endif
  
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
-@@ -1237,6 +1271,9 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1237,6 +1274,9 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	if (unlikely(delta_exec <= 0))
  		return;
  
@@ -876,67 +941,129 @@ index 138d9f465..5f1d4dd44 100644
  	curr->vruntime += calc_delta_fair(delta_exec, curr);
  	resched = update_deadline(cfs_rq, curr);
  	update_min_vruntime(cfs_rq);
-@@ -3784,13 +3821,22 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se) { }
+@@ -3784,7 +3824,7 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se) { }
  
  static void place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags);
  
-+
-+#ifdef CONFIG_SCHED_BORE
+-static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
 +void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
-+			    unsigned long weight, bool no_update_curr)
-+#else // !CONFIG_SCHED_BORE
- static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
  			    unsigned long weight)
-+#endif // CONFIG_SCHED_BORE
  {
  	bool curr = cfs_rq->curr == se;
+@@ -5202,12 +5242,11 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
+ static void
+ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ {
+-	u64 vslice, vruntime = avg_vruntime(cfs_rq);
++	u64 vslice = 0, vruntime = avg_vruntime(cfs_rq);
+ 	s64 lag = 0;
  
- 	if (se->on_rq) {
- 		/* commit outstanding execution time */
-+#ifdef CONFIG_SCHED_BORE
-+		if (!no_update_curr)
-+#endif // CONFIG_SCHED_BORE
- 		update_curr(cfs_rq);
- 		update_entity_lag(cfs_rq, se);
- 		se->deadline -= se->vruntime;
-@@ -3846,7 +3892,11 @@ static void reweight_task_fair(struct rq *rq, struct task_struct *p,
- 	struct cfs_rq *cfs_rq = cfs_rq_of(se);
- 	struct load_weight *load = &se->load;
+ 	if (!se->custom_slice)
+ 		se->slice = sysctl_sched_base_slice;
+-	vslice = calc_delta_fair(se->slice, se);
  
-+#ifdef CONFIG_SCHED_BORE
-+	reweight_entity(cfs_rq, se, lw->weight, false);
-+#else // !CONFIG_SCHED_BORE
- 	reweight_entity(cfs_rq, se, lw->weight);
-+#endif // CONFIG_SCHED_BORE
- 	load->inv_weight = lw->inv_weight;
- }
- 
-@@ -3987,7 +4037,11 @@ static void update_cfs_group(struct sched_entity *se)
- 	shares = calc_group_shares(gcfs_rq);
- #endif
- 	if (unlikely(se->load.weight != shares))
-+#ifdef CONFIG_SCHED_BORE
-+		reweight_entity(cfs_rq_of(se), se, shares, false);
-+#else // !CONFIG_SCHED_BORE
- 		reweight_entity(cfs_rq_of(se), se, shares);
-+#endif // CONFIG_SCHED_BORE
- }
- 
- #else /* CONFIG_FAIR_GROUP_SCHED */
-@@ -5292,7 +5346,11 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 	/*
+ 	 * Due to how V is constructed as the weighted average of entities,
+@@ -5292,7 +5331,16 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		se->rel_deadline = 0;
  		return;
  	}
 -
 +#ifdef CONFIG_SCHED_BORE
-+	else if (likely(sched_bore))
++	if (likely(sched_bore) && sched_burst_futex_boost && se->waiting_for_futex)
++		goto vslice_found;
++#endif // !CONFIG_SCHED_BORE
++	vslice = calc_delta_fair(se->slice, se);
++#ifdef CONFIG_SCHED_BORE
++	if (likely(sched_bore))
 +		vslice >>= !!(flags & sched_deadline_boost_mask);
 +	else
 +#endif // CONFIG_SCHED_BORE
  	/*
  	 * When joining the competition; the existing tasks will be,
  	 * on average, halfway through their slice, as such start tasks
-@@ -7187,6 +7245,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -5301,6 +5349,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
+ 		vslice /= 2;
+ 
++#ifdef CONFIG_SCHED_BORE
++vslice_found:
++#endif // CONFIG_SCHED_BORE
+ 	/*
+ 	 * EEVDF: vd_i = ve_i + r_i/w_i
+ 	 */
+@@ -5311,7 +5362,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
+ static inline int cfs_rq_throttled(struct cfs_rq *cfs_rq);
+ 
+ static void
+-requeue_delayed_entity(struct sched_entity *se);
++requeue_delayed_entity(struct sched_entity *se, int flags);
+ 
+ static void
+ enqueue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5475,6 +5526,10 @@ dequeue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 		if (sched_feat(DELAY_DEQUEUE) && delay &&
+ 		    !entity_eligible(cfs_rq, se)) {
+ 			update_load_avg(cfs_rq, se, 0);
++#ifdef CONFIG_SCHED_BORE
++			if (sched_feat(DELAY_ZERO) && likely(sched_bore))
++				update_entity_lag(cfs_rq, se);
++#endif // CONFIG_SCHED_BORE
+ 			set_delayed(se);
+ 			return false;
+ 		}
+@@ -6891,7 +6946,7 @@ static int sched_idle_cpu(int cpu)
+ #endif
+ 
+ static void
+-requeue_delayed_entity(struct sched_entity *se)
++requeue_delayed_entity(struct sched_entity *se, int flags)
+ {
+ 	struct cfs_rq *cfs_rq = cfs_rq_of(se);
+ 
+@@ -6904,13 +6959,22 @@ requeue_delayed_entity(struct sched_entity *se)
+ 	WARN_ON_ONCE(!se->on_rq);
+ 
+ 	if (sched_feat(DELAY_ZERO)) {
++#ifdef CONFIG_SCHED_BORE
++		if (likely(sched_bore))
++			flags |= ENQUEUE_WAKEUP;
++		else {
++#endif // CONFIG_SCHED_BORE
++		flags = 0;
+ 		update_entity_lag(cfs_rq, se);
++#ifdef CONFIG_SCHED_BORE
++		}
++#endif // CONFIG_SCHED_BORE
+ 		if (se->vlag > 0) {
+ 			cfs_rq->nr_queued--;
+ 			if (se != cfs_rq->curr)
+ 				__dequeue_entity(cfs_rq, se);
+ 			se->vlag = 0;
+-			place_entity(cfs_rq, se, 0);
++			place_entity(cfs_rq, se, flags);
+ 			if (se != cfs_rq->curr)
+ 				__enqueue_entity(cfs_rq, se);
+ 			cfs_rq->nr_queued++;
+@@ -6947,7 +7011,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 		util_est_enqueue(&rq->cfs, p);
+ 
+ 	if (flags & ENQUEUE_DELAYED) {
+-		requeue_delayed_entity(se);
++		requeue_delayed_entity(se, flags);
+ 		return;
+ 	}
+ 
+@@ -6965,7 +7029,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 	for_each_sched_entity(se) {
+ 		if (se->on_rq) {
+ 			if (se->sched_delayed)
+-				requeue_delayed_entity(se);
++				requeue_delayed_entity(se, flags);
+ 			break;
+ 		}
+ 		cfs_rq = cfs_rq_of(se);
+@@ -7187,6 +7251,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_dequeue(&rq->cfs, p);
  
  	util_est_update(&rq->cfs, p, flags & DEQUEUE_SLEEP);
@@ -952,7 +1079,7 @@ index 138d9f465..5f1d4dd44 100644
  	if (dequeue_entities(rq, &p->se, flags) < 0)
  		return false;
  
-@@ -9016,16 +9083,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -9016,16 +9089,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -978,7 +1105,7 @@ index 138d9f465..5f1d4dd44 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -13138,6 +13214,9 @@ static void task_tick_fair(struct rq *rq, struct task_struct *curr, int queued)
+@@ -13152,6 +13234,9 @@ static void task_tick_fair(struct rq *rq, struct task_struct *curr, int queued)
  static void task_fork_fair(struct task_struct *p)
  {
  	set_task_max_allowed_capacity(p);
@@ -988,7 +1115,7 @@ index 138d9f465..5f1d4dd44 100644
  }
  
  /*
-@@ -13255,6 +13334,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
+@@ -13269,6 +13354,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  {
  	WARN_ON_ONCE(p->se.sched_delayed);
  
@@ -998,8 +1125,22 @@ index 138d9f465..5f1d4dd44 100644
  	attach_task_cfs_rq(p);
  
  	set_task_max_allowed_capacity(p);
+diff --git a/kernel/sched/features.h b/kernel/sched/features.h
+index 3c12d9f93..b87171053 100644
+--- a/kernel/sched/features.h
++++ b/kernel/sched/features.h
+@@ -18,6 +18,9 @@ SCHED_FEAT(PLACE_REL_DEADLINE, true)
+  * 0-lag point or until is has exhausted it's slice.
+  */
+ SCHED_FEAT(RUN_TO_PARITY, true)
++#ifdef CONFIG_SCHED_BORE
++SCHED_FEAT(RUN_TO_PARITY_BORE, false)
++#endif // CONFIG_SCHED_BORE
+ /*
+  * Allow wakeup of tasks with a shorter slice to cancel RUN_TO_PARITY for
+  * current.
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 47972f34e..a7c69cfbc 100644
+index d6f82833f..a739aafa9 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2100,7 +2100,11 @@ extern int group_balance_cpu(struct sched_group *sg);
@@ -1027,6 +1168,3 @@ index 47972f34e..a7c69cfbc 100644
  
  extern int sysctl_resched_latency_warn_ms;
  extern int sysctl_resched_latency_warn_once;
--- 
-2.50.1
-

--- a/6.16/0004-cachy.patch
+++ b/6.16/0004-cachy.patch
@@ -7224,17 +7224,17 @@ index 000000000000..e70a381fe3df
 +	  will be called vhba.
 diff --git a/drivers/scsi/vhba/Makefile b/drivers/scsi/vhba/Makefile
 new file mode 100644
-index 000000000000..2d7524b66199
+index 000000000..560d24689
 --- /dev/null
 +++ b/drivers/scsi/vhba/Makefile
 @@ -0,0 +1,4 @@
-+VHBA_VERSION := 20240917
++VHBA_VERSION := 20250329
 +
 +obj-$(CONFIG_VHBA)		+= vhba.o
 +ccflags-y := -DVHBA_VERSION=\"$(VHBA_VERSION)\" -Werror
 diff --git a/drivers/scsi/vhba/vhba.c b/drivers/scsi/vhba/vhba.c
 new file mode 100644
-index 000000000000..878a3be0ba2b
+index 000000000..64b09ece2
 --- /dev/null
 +++ b/drivers/scsi/vhba/vhba.c
 @@ -0,0 +1,1132 @@
@@ -7777,10 +7777,10 @@ index 000000000000..878a3be0ba2b
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
 +    .slave_alloc = vhba_slave_alloc,
 +#endif
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
-+    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
-+#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 +    .tag_alloc_policy_rr = true,
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
++    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
 +#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
 +    .use_blk_tags = 1,

--- a/6.16/0004-cachy.patch
+++ b/6.16/0004-cachy.patch
@@ -174,7 +174,7 @@ index 9bef46151d53..0ee649d4808b 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 1.
++The default value is 15.
 +
 +
 +clean_low_ratio
@@ -195,7 +195,7 @@ index 9bef46151d53..0ee649d4808b 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 15.
++The default value is 0.
 +
 +
 +clean_min_ratio
@@ -216,7 +216,7 @@ index 9bef46151d53..0ee649d4808b 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 4.
++The default value is 15.
 +
 +
  compact_memory
@@ -8763,7 +8763,7 @@ index 781be3240e21..5bd761b2976e 100644
 +	int "Default value for vm.anon_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 1
++	default 15
 +	help
 +	  This option sets the default value for vm.anon_min_ratio sysctl knob.
 +
@@ -8781,7 +8781,7 @@ index 781be3240e21..5bd761b2976e 100644
 +	int "Default value for vm.clean_low_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 15
++	default 0
 +	help
 +	  This option sets the default value for vm.clean_low_ratio sysctl knob.
 +
@@ -8803,7 +8803,7 @@ index 781be3240e21..5bd761b2976e 100644
 +	int "Default value for vm.clean_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 4
++	default 15
 +	help
 +	  This option sets the default value for vm.clean_min_ratio sysctl knob.
 +
@@ -8835,7 +8835,7 @@ index 781be3240e21..5bd761b2976e 100644
  
  #
 diff --git a/mm/compaction.c b/mm/compaction.c
-index 3925cb61dbb8..42374158dc17 100644
+index 3925cb61d..42374158d 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -1923,7 +1923,11 @@ static int sysctl_compact_unevictable_allowed __read_mostly = CONFIG_COMPACT_UNE
@@ -8867,19 +8867,19 @@ index 49b98082c540..788e87fb5969 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index f2944748f526..b658e131a8c3 100644
+index f2944748f..c8ed2f4fd 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -2725,6 +2725,7 @@ static void __init mem_init_print_info(void)
  		, K(totalhigh_pages())
  #endif
  		);
-+	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15a by Masahito Suzuki (forked from hakavlad's original le9 patch)");
++	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15 by Masahito Suzuki (forked from hakavlad's original le9 patch)");
  }
  
  void __init __weak arch_mm_preinit(void)
 diff --git a/mm/page-writeback.c b/mm/page-writeback.c
-index 72b0ff0d4bae..e68d05aaff6f 100644
+index 72b0ff0d4..e68d05aaf 100644
 --- a/mm/page-writeback.c
 +++ b/mm/page-writeback.c
 @@ -72,7 +72,11 @@ static long ratelimit_pages = 32;

--- a/6.16/all/0001-cachyos-base-all.patch
+++ b/6.16/all/0001-cachyos-base-all.patch
@@ -17922,17 +17922,17 @@ index 000000000000..e70a381fe3df
 +	  will be called vhba.
 diff --git a/drivers/scsi/vhba/Makefile b/drivers/scsi/vhba/Makefile
 new file mode 100644
-index 000000000000..2d7524b66199
+index 000000000..560d24689
 --- /dev/null
 +++ b/drivers/scsi/vhba/Makefile
 @@ -0,0 +1,4 @@
-+VHBA_VERSION := 20240917
++VHBA_VERSION := 20250329
 +
 +obj-$(CONFIG_VHBA)		+= vhba.o
 +ccflags-y := -DVHBA_VERSION=\"$(VHBA_VERSION)\" -Werror
 diff --git a/drivers/scsi/vhba/vhba.c b/drivers/scsi/vhba/vhba.c
 new file mode 100644
-index 000000000000..878a3be0ba2b
+index 000000000..64b09ece2
 --- /dev/null
 +++ b/drivers/scsi/vhba/vhba.c
 @@ -0,0 +1,1132 @@
@@ -18475,10 +18475,10 @@ index 000000000000..878a3be0ba2b
 +#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 19, 0)
 +    .slave_alloc = vhba_slave_alloc,
 +#endif
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
-+    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
-+#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 +    .tag_alloc_policy_rr = true,
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
++    .tag_alloc_policy = BLK_TAG_ALLOC_RR,
 +#endif
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 19, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 0)
 +    .use_blk_tags = 1,

--- a/6.16/all/0001-cachyos-base-all.patch
+++ b/6.16/all/0001-cachyos-base-all.patch
@@ -10872,7 +10872,7 @@ index 9bef46151d53..0ee649d4808b 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 1.
++The default value is 15.
 +
 +
 +clean_low_ratio
@@ -10893,7 +10893,7 @@ index 9bef46151d53..0ee649d4808b 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 15.
++The default value is 0.
 +
 +
 +clean_min_ratio
@@ -10914,7 +10914,7 @@ index 9bef46151d53..0ee649d4808b 100644
 +
 +The unit of measurement is the percentage of the total memory of the node.
 +
-+The default value is 4.
++The default value is 15.
 +
 +
  compact_memory
@@ -19461,7 +19461,7 @@ index 781be3240e21..5bd761b2976e 100644
 +	int "Default value for vm.anon_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 1
++	default 15
 +	help
 +	  This option sets the default value for vm.anon_min_ratio sysctl knob.
 +
@@ -19479,7 +19479,7 @@ index 781be3240e21..5bd761b2976e 100644
 +	int "Default value for vm.clean_low_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 15
++	default 0
 +	help
 +	  This option sets the default value for vm.clean_low_ratio sysctl knob.
 +
@@ -19501,7 +19501,7 @@ index 781be3240e21..5bd761b2976e 100644
 +	int "Default value for vm.clean_min_ratio"
 +	depends on SYSCTL
 +	range 0 100
-+	default 4
++	default 15
 +	help
 +	  This option sets the default value for vm.clean_min_ratio sysctl knob.
 +
@@ -19533,7 +19533,7 @@ index 781be3240e21..5bd761b2976e 100644
  
  #
 diff --git a/mm/compaction.c b/mm/compaction.c
-index 3925cb61dbb8..42374158dc17 100644
+index 3925cb61d..42374158d 100644
 --- a/mm/compaction.c
 +++ b/mm/compaction.c
 @@ -1923,7 +1923,11 @@ static int sysctl_compact_unevictable_allowed __read_mostly = CONFIG_COMPACT_UNE
@@ -19565,19 +19565,19 @@ index 49b98082c540..788e87fb5969 100644
  	(1<<TRANSPARENT_HUGEPAGE_USE_ZERO_PAGE_FLAG);
  
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index f2944748f526..b658e131a8c3 100644
+index f2944748f..c8ed2f4fd 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -2725,6 +2725,7 @@ static void __init mem_init_print_info(void)
  		, K(totalhigh_pages())
  #endif
  		);
-+	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15a by Masahito Suzuki (forked from hakavlad's original le9 patch)");
++	printk(KERN_INFO "le9 Unofficial (le9uo) working set protection 1.15 by Masahito Suzuki (forked from hakavlad's original le9 patch)");
  }
  
  void __init __weak arch_mm_preinit(void)
 diff --git a/mm/page-writeback.c b/mm/page-writeback.c
-index 72b0ff0d4bae..e68d05aaff6f 100644
+index 72b0ff0d4..e68d05aaf 100644
 --- a/mm/page-writeback.c
 +++ b/mm/page-writeback.c
 @@ -72,7 +72,11 @@ static long ratelimit_pages = 32;

--- a/6.16/misc/0001-aufs-6.16-merge-v20250821.patch
+++ b/6.16/misc/0001-aufs-6.16-merge-v20250821.patch
@@ -1,130 +1,120 @@
-From 5f7acf387c6b9fcf6f2f6f700e193b638fff2830 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Mon, 16 Jun 2025 15:29:18 +0200
-Subject: [PATCH] aufs-6.16: merge v20250616
+From 08f224d4f9350f82d4342fe4872d79e11436c381 Mon Sep 17 00:00:00 2001
+From: Yang Kun <193369907+nukyan@users.noreply.github.com>
+Date: Thu, 21 Aug 2025 12:22:29 +0800
+Subject: [PATCH] aufs-6.16: merge v20250821
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  Documentation/ABI/testing/debugfs-aufs        |   55 +
  Documentation/ABI/testing/sysfs-aufs          |   31 +
  Documentation/filesystems/aufs/README         |  409 ++++
- .../filesystems/aufs/design/01intro.txt       |  171 ++
- .../filesystems/aufs/design/02struct.txt      |  258 +++
- .../filesystems/aufs/design/03atomic_open.txt |   85 +
- .../filesystems/aufs/design/03lookup.txt      |  113 +
- .../filesystems/aufs/design/04branch.txt      |   74 +
- .../filesystems/aufs/design/05wbr_policy.txt  |   64 +
- .../filesystems/aufs/design/06dirren.dot      |   44 +
- .../filesystems/aufs/design/06dirren.txt      |  102 +
- .../filesystems/aufs/design/06fhsm.txt        |  118 +
- .../filesystems/aufs/design/06mmap.txt        |   72 +
- .../filesystems/aufs/design/06xattr.txt       |   94 +
- .../filesystems/aufs/design/07export.txt      |   58 +
- .../filesystems/aufs/design/08shwh.txt        |   52 +
- .../filesystems/aufs/design/10dynop.txt       |   47 +
+ .../filesystems/aufs/design/01intro.txt       |  158 ++
+ .../filesystems/aufs/design/02struct.txt      |  245 +++
+ .../filesystems/aufs/design/03atomic_open.txt |   72 +
+ .../filesystems/aufs/design/03lookup.txt      |  100 +
+ .../filesystems/aufs/design/04branch.txt      |   61 +
+ .../filesystems/aufs/design/05wbr_policy.txt  |   51 +
+ .../filesystems/aufs/design/06dirren.dot      |   31 +
+ .../filesystems/aufs/design/06dirren.txt      |   89 +
+ .../filesystems/aufs/design/06fhsm.txt        |  105 +
+ .../filesystems/aufs/design/06mmap.txt        |   59 +
+ .../filesystems/aufs/design/06xattr.txt       |   81 +
+ .../filesystems/aufs/design/07export.txt      |   45 +
+ .../filesystems/aufs/design/08shwh.txt        |   39 +
+ .../filesystems/aufs/design/10dynop.txt       |   34 +
  MAINTAINERS                                   |   13 +
- drivers/block/loop.c                          |   62 +-
+ drivers/block/loop.c                          |   20 +
  fs/Kconfig                                    |    1 +
  fs/Makefile                                   |    1 +
  fs/aufs/Kconfig                               |  201 ++
- fs/aufs/Makefile                              |   47 +
- fs/aufs/aufs.h                                |   62 +
- fs/aufs/branch.c                              | 1427 ++++++++++++
- fs/aufs/branch.h                              |  375 ++++
- fs/aufs/conf.mk                               |   40 +
- fs/aufs/cpup.c                                | 1466 +++++++++++++
- fs/aufs/cpup.h                                |  101 +
- fs/aufs/dbgaufs.c                             |  525 +++++
- fs/aufs/dbgaufs.h                             |   53 +
- fs/aufs/dcsub.c                               |  225 ++
- fs/aufs/dcsub.h                               |  139 ++
- fs/aufs/debug.c                               |  448 ++++
- fs/aufs/debug.h                               |  226 ++
- fs/aufs/dentry.c                              | 1228 +++++++++++
- fs/aufs/dentry.h                              |  270 +++
- fs/aufs/dinfo.c                               |  555 +++++
- fs/aufs/dir.c                                 |  765 +++++++
- fs/aufs/dir.h                                 |  134 ++
- fs/aufs/dirren.c                              | 1315 +++++++++++
- fs/aufs/dirren.h                              |  140 ++
- fs/aufs/dynop.c                               |  364 ++++
- fs/aufs/dynop.h                               |   77 +
- fs/aufs/export.c                              |  846 ++++++++
- fs/aufs/f_op.c                                |  782 +++++++
- fs/aufs/fhsm.c                                |  426 ++++
- fs/aufs/file.c                                |  854 ++++++++
- fs/aufs/file.h                                |  342 +++
- fs/aufs/finfo.c                               |  147 ++
- fs/aufs/fsctx.c                               | 1244 +++++++++++
- fs/aufs/fstype.h                              |  419 ++++
- fs/aufs/hbl.h                                 |   65 +
- fs/aufs/hfsnotify.c                           |  290 +++
- fs/aufs/hfsplus.c                             |   60 +
- fs/aufs/hnotify.c                             |  715 ++++++
- fs/aufs/i_op.c                                | 1522 +++++++++++++
- fs/aufs/i_op_add.c                            |  979 +++++++++
- fs/aufs/i_op_del.c                            |  523 +++++
- fs/aufs/i_op_ren.c                            | 1264 +++++++++++
- fs/aufs/iinfo.c                               |  287 +++
- fs/aufs/inode.c                               |  532 +++++
- fs/aufs/inode.h                               |  727 +++++++
- fs/aufs/ioctl.c                               |  220 ++
- fs/aufs/lcnt.h                                |  186 ++
- fs/aufs/loop.c                                |  164 ++
- fs/aufs/loop.h                                |   59 +
+ fs/aufs/Makefile                              |   40 +
+ fs/aufs/aufs.h                                |   49 +
+ fs/aufs/branch.c                              | 1414 ++++++++++++
+ fs/aufs/branch.h                              |  362 ++++
+ fs/aufs/cpup.c                                | 1453 +++++++++++++
+ fs/aufs/cpup.h                                |   88 +
+ fs/aufs/dbgaufs.c                             |  512 +++++
+ fs/aufs/dbgaufs.h                             |   40 +
+ fs/aufs/dcsub.c                               |  212 ++
+ fs/aufs/dcsub.h                               |  126 ++
+ fs/aufs/debug.c                               |  435 ++++
+ fs/aufs/debug.h                               |  213 ++
+ fs/aufs/dentry.c                              | 1215 +++++++++++
+ fs/aufs/dentry.h                              |  257 +++
+ fs/aufs/dinfo.c                               |  542 +++++
+ fs/aufs/dir.c                                 |  752 +++++++
+ fs/aufs/dir.h                                 |  121 ++
+ fs/aufs/dirren.c                              | 1302 +++++++++++
+ fs/aufs/dirren.h                              |  127 ++
+ fs/aufs/dynop.c                               |  351 +++
+ fs/aufs/dynop.h                               |   64 +
+ fs/aufs/export.c                              |  815 +++++++
+ fs/aufs/f_op.c                                |  769 +++++++
+ fs/aufs/fhsm.c                                |  413 ++++
+ fs/aufs/file.c                                |  841 ++++++++
+ fs/aufs/file.h                                |  329 +++
+ fs/aufs/finfo.c                               |  134 ++
+ fs/aufs/fsctx.c                               | 1231 +++++++++++
+ fs/aufs/fstype.h                              |  406 ++++
+ fs/aufs/hbl.h                                 |   52 +
+ fs/aufs/hfsnotify.c                           |  277 +++
+ fs/aufs/hfsplus.c                             |   47 +
+ fs/aufs/hnotify.c                             |  702 ++++++
+ fs/aufs/i_op.c                                | 1509 +++++++++++++
+ fs/aufs/i_op_add.c                            |  966 +++++++++
+ fs/aufs/i_op_del.c                            |  510 +++++
+ fs/aufs/i_op_ren.c                            | 1251 +++++++++++
+ fs/aufs/iinfo.c                               |  274 +++
+ fs/aufs/inode.c                               |  519 +++++
+ fs/aufs/inode.h                               |  714 ++++++
+ fs/aufs/ioctl.c                               |  207 ++
+ fs/aufs/lcnt.h                                |  173 ++
+ fs/aufs/loop.c                                |  135 ++
+ fs/aufs/loop.h                                |   42 +
  fs/aufs/magic.mk                              |   31 +
- fs/aufs/module.c                              |  275 +++
- fs/aufs/module.h                              |  180 ++
- fs/aufs/mvdown.c                              |  714 ++++++
- fs/aufs/opts.c                                | 1030 +++++++++
- fs/aufs/opts.h                                |  264 +++
- fs/aufs/plink.c                               |  516 +++++
- fs/aufs/poll.c                                |   51 +
- fs/aufs/posix_acl.c                           |  108 +
- fs/aufs/procfs.c                              |  168 ++
- fs/aufs/rdu.c                                 |  384 ++++
- fs/aufs/rwsem.h                               |   89 +
- fs/aufs/sbinfo.c                              |  316 +++
- fs/aufs/super.c                               |  875 ++++++++
- fs/aufs/super.h                               |  618 ++++++
- fs/aufs/sysaufs.c                             |   94 +
- fs/aufs/sysaufs.h                             |  102 +
- fs/aufs/sysfs.c                               |  374 ++++
- fs/aufs/sysrq.c                               |  157 ++
- fs/aufs/vdir.c                                |  896 ++++++++
- fs/aufs/vfsub.c                               |  972 +++++++++
- fs/aufs/vfsub.h                               |  441 ++++
- fs/aufs/wbr_policy.c                          |  835 +++++++
- fs/aufs/whout.c                               | 1096 ++++++++++
- fs/aufs/whout.h                               |   87 +
- fs/aufs/wkq.c                                 |  370 ++++
- fs/aufs/wkq.h                                 |   89 +
- fs/aufs/xattr.c                               |  360 +++
- fs/aufs/xino.c                                | 1926 +++++++++++++++++
- fs/dcache.c                                   |    7 +-
- fs/exec.c                                     |    1 +
- fs/fcntl.c                                    |    5 +-
- fs/file_table.c                               |    1 +
- fs/namespace.c                                |   10 +
- fs/notify/fsnotify.c                          |    1 +
- fs/notify/group.c                             |    1 +
- fs/open.c                                     |    1 +
+ fs/aufs/module.c                              |  261 +++
+ fs/aufs/module.h                              |  167 ++
+ fs/aufs/mvdown.c                              |  701 ++++++
+ fs/aufs/opts.c                                | 1017 +++++++++
+ fs/aufs/opts.h                                |  251 +++
+ fs/aufs/plink.c                               |  503 +++++
+ fs/aufs/poll.c                                |   38 +
+ fs/aufs/posix_acl.c                           |   95 +
+ fs/aufs/procfs.c                              |  155 ++
+ fs/aufs/rdu.c                                 |  371 ++++
+ fs/aufs/rwsem.h                               |   76 +
+ fs/aufs/sbinfo.c                              |  303 +++
+ fs/aufs/super.c                               |  859 ++++++++
+ fs/aufs/super.h                               |  605 ++++++
+ fs/aufs/sysaufs.c                             |   81 +
+ fs/aufs/sysaufs.h                             |   89 +
+ fs/aufs/sysfs.c                               |  338 +++
+ fs/aufs/sysrq.c                               |  144 ++
+ fs/aufs/vdir.c                                |  883 ++++++++
+ fs/aufs/vfsub.c                               |  959 +++++++++
+ fs/aufs/vfsub.h                               |  428 ++++
+ fs/aufs/wbr_policy.c                          |  822 +++++++
+ fs/aufs/whout.c                               | 1083 ++++++++++
+ fs/aufs/whout.h                               |   74 +
+ fs/aufs/wkq.c                                 |  357 +++
+ fs/aufs/wkq.h                                 |   76 +
+ fs/aufs/xattr.c                               |  347 +++
+ fs/aufs/xino.c                                | 1913 +++++++++++++++++
+ fs/dcache.c                                   |    5 +-
+ fs/fcntl.c                                    |    4 +-
+ fs/namespace.c                                |    6 +
  fs/proc/base.c                                |    2 +-
  fs/proc/nommu.c                               |    5 +-
  fs/proc/task_mmu.c                            |    8 +-
  fs/proc/task_nommu.c                          |    5 +-
- fs/read_write.c                               |    2 +
- fs/splice.c                                   |    3 +-
- fs/xattr.c                                    |    1 +
- include/linux/fs.h                            |    7 +
+ fs/splice.c                                   |    2 +-
+ include/linux/fs.h                            |    2 +
  include/linux/lockdep.h                       |    2 +
  include/linux/mm.h                            |   48 +
  include/linux/mm_types.h                      |    6 +
  include/linux/mnt_namespace.h                 |    3 +
  include/linux/splice.h                        |    3 +
- include/uapi/linux/aufs_type.h                |  452 ++++
- kernel/locking/lockdep.c                      |    4 +-
- kernel/task_work.c                            |    1 +
+ include/uapi/linux/aufs_type.h                |  439 ++++
+ kernel/locking/lockdep.c                      |    3 +-
  mm/Makefile                                   |    1 +
  mm/filemap.c                                  |    2 +-
  mm/mmap.c                                     |   28 +-
@@ -132,8 +122,7 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  mm/prfile.c                                   |   86 +
  mm/vma.c                                      |   10 +-
  mm/vma_init.c                                 |    1 +
- security/security.c                           |    8 +
- 128 files changed, 38878 insertions(+), 25 deletions(-)
+ 118 files changed, 37576 insertions(+), 24 deletions(-)
  create mode 100644 Documentation/ABI/testing/debugfs-aufs
  create mode 100644 Documentation/ABI/testing/sysfs-aufs
  create mode 100644 Documentation/filesystems/aufs/README
@@ -156,7 +145,6 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  create mode 100644 fs/aufs/aufs.h
  create mode 100644 fs/aufs/branch.c
  create mode 100644 fs/aufs/branch.h
- create mode 100644 fs/aufs/conf.mk
  create mode 100644 fs/aufs/cpup.c
  create mode 100644 fs/aufs/cpup.h
  create mode 100644 fs/aufs/dbgaufs.c
@@ -744,25 +732,12 @@ index 000000000..559fbe0d0
 +# End: ;
 diff --git a/Documentation/filesystems/aufs/design/01intro.txt b/Documentation/filesystems/aufs/design/01intro.txt
 new file mode 100644
-index 000000000..a22a37bad
+index 000000000..1627d9386
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/01intro.txt
-@@ -0,0 +1,171 @@
+@@ -0,0 +1,158 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Introduction
 +----------------------------------------
@@ -921,25 +896,12 @@ index 000000000..a22a37bad
 +about it. But currently I have implemented it in kernel space.
 diff --git a/Documentation/filesystems/aufs/design/02struct.txt b/Documentation/filesystems/aufs/design/02struct.txt
 new file mode 100644
-index 000000000..e89dc7122
+index 000000000..b6d3e6f87
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/02struct.txt
-@@ -0,0 +1,258 @@
+@@ -0,0 +1,245 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Basic Aufs Internal Structure
 +
@@ -1185,25 +1147,12 @@ index 000000000..e89dc7122
 +For this purpose, use "aumvdown" command in aufs-util.git.
 diff --git a/Documentation/filesystems/aufs/design/03atomic_open.txt b/Documentation/filesystems/aufs/design/03atomic_open.txt
 new file mode 100644
-index 000000000..0401e8923
+index 000000000..374d8c756
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/03atomic_open.txt
-@@ -0,0 +1,85 @@
+@@ -0,0 +1,72 @@
 +
 +# Copyright (C) 2015-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Support for a branch who has its ->atomic_open()
 +----------------------------------------------------------------------
@@ -1276,25 +1225,12 @@ index 000000000..0401e8923
 +       be implemented in aufs, but not all I am afraid.
 diff --git a/Documentation/filesystems/aufs/design/03lookup.txt b/Documentation/filesystems/aufs/design/03lookup.txt
 new file mode 100644
-index 000000000..35efe7079
+index 000000000..dad7a4a27
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/03lookup.txt
-@@ -0,0 +1,113 @@
+@@ -0,0 +1,100 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Lookup in a Branch
 +----------------------------------------------------------------------
@@ -1395,25 +1331,12 @@ index 000000000..35efe7079
 +   by over-mounting something (or another method).
 diff --git a/Documentation/filesystems/aufs/design/04branch.txt b/Documentation/filesystems/aufs/design/04branch.txt
 new file mode 100644
-index 000000000..0286ccdfc
+index 000000000..a48a1adbb
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/04branch.txt
-@@ -0,0 +1,74 @@
+@@ -0,0 +1,61 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Branch Manipulation
 +
@@ -1475,25 +1398,12 @@ index 000000000..0286ccdfc
 +    same named entry on the upper branch.
 diff --git a/Documentation/filesystems/aufs/design/05wbr_policy.txt b/Documentation/filesystems/aufs/design/05wbr_policy.txt
 new file mode 100644
-index 000000000..0eeb6ee21
+index 000000000..c04c62a8b
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/05wbr_policy.txt
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,51 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Policies to Select One among Multiple Writable Branches
 +----------------------------------------------------------------------
@@ -1545,25 +1455,12 @@ index 000000000..0eeb6ee21
 +  copyup policy.
 diff --git a/Documentation/filesystems/aufs/design/06dirren.dot b/Documentation/filesystems/aufs/design/06dirren.dot
 new file mode 100644
-index 000000000..4e6c7e7c2
+index 000000000..2d62bb6dd
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06dirren.dot
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,31 @@
 +
 +// to view this graph, run dot(1) command in GRAPHVIZ.
-+//
-+// This program is free software; you can redistribute it and/or modify
-+// it under the terms of the GNU General Public License as published by
-+// the Free Software Foundation; either version 2 of the License, or
-+// (at your option) any later version.
-+//
-+// This program is distributed in the hope that it will be useful,
-+// but WITHOUT ANY WARRANTY; without even the implied warranty of
-+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+// GNU General Public License for more details.
-+//
-+// You should have received a copy of the GNU General Public License
-+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +digraph G {
 +node [shape=box];
@@ -1595,25 +1492,12 @@ index 000000000..4e6c7e7c2
 +}
 diff --git a/Documentation/filesystems/aufs/design/06dirren.txt b/Documentation/filesystems/aufs/design/06dirren.txt
 new file mode 100644
-index 000000000..6b305def6
+index 000000000..cde6c2d6a
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06dirren.txt
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,89 @@
 +
 +# Copyright (C) 2017-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Special handling for renaming a directory (DIRREN)
 +----------------------------------------------------------------------
@@ -1703,25 +1587,12 @@ index 000000000..6b305def6
 +equivalen to udba=reval case.
 diff --git a/Documentation/filesystems/aufs/design/06fhsm.txt b/Documentation/filesystems/aufs/design/06fhsm.txt
 new file mode 100644
-index 000000000..edb1b765b
+index 000000000..be1fa5aee
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06fhsm.txt
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,105 @@
 +
 +# Copyright (C) 2011-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +File-based Hierarchical Storage Management (FHSM)
 +----------------------------------------------------------------------
@@ -1827,25 +1698,12 @@ index 000000000..edb1b765b
 +should restore the original file state after an error happens.
 diff --git a/Documentation/filesystems/aufs/design/06mmap.txt b/Documentation/filesystems/aufs/design/06mmap.txt
 new file mode 100644
-index 000000000..9b1c4806c
+index 000000000..4a294102c
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06mmap.txt
-@@ -0,0 +1,72 @@
+@@ -0,0 +1,59 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +mmap(2) -- File Memory Mapping
 +----------------------------------------------------------------------
@@ -1905,25 +1763,12 @@ index 000000000..9b1c4806c
 +I have to give up this "looks-smater" approach.
 diff --git a/Documentation/filesystems/aufs/design/06xattr.txt b/Documentation/filesystems/aufs/design/06xattr.txt
 new file mode 100644
-index 000000000..354a8e28d
+index 000000000..974c323b1
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/06xattr.txt
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,81 @@
 +
 +# Copyright (C) 2014-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Listing XATTR/EA and getting the value
 +----------------------------------------------------------------------
@@ -2005,25 +1850,12 @@ index 000000000..354a8e28d
 +now, aufs implements the branch attributes to ignore the error.
 diff --git a/Documentation/filesystems/aufs/design/07export.txt b/Documentation/filesystems/aufs/design/07export.txt
 new file mode 100644
-index 000000000..317f84e09
+index 000000000..34e45e4a9
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/07export.txt
-@@ -0,0 +1,58 @@
+@@ -0,0 +1,45 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Export Aufs via NFS
 +----------------------------------------------------------------------
@@ -2069,25 +1901,12 @@ index 000000000..317f84e09
 +  lookup_one_len(), vfs_getattr(), encode_fh() and others.
 diff --git a/Documentation/filesystems/aufs/design/08shwh.txt b/Documentation/filesystems/aufs/design/08shwh.txt
 new file mode 100644
-index 000000000..4c7d0b4ab
+index 000000000..3cfb56884
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/08shwh.txt
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,39 @@
 +
 +# Copyright (C) 2005-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Show Whiteout Mode (shwh)
 +----------------------------------------------------------------------
@@ -2127,25 +1946,12 @@ index 000000000..4c7d0b4ab
 +initramfs will use it to replace the old one at the next boot.
 diff --git a/Documentation/filesystems/aufs/design/10dynop.txt b/Documentation/filesystems/aufs/design/10dynop.txt
 new file mode 100644
-index 000000000..973d8d190
+index 000000000..12a4f2ab4
 --- /dev/null
 +++ b/Documentation/filesystems/aufs/design/10dynop.txt
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,34 @@
 +
 +# Copyright (C) 2010-2025 Junjiro R. Okajima
-+#
-+# This program is free software; you can redistribute it and/or modify
-+# it under the terms of the GNU General Public License as published by
-+# the Free Software Foundation; either version 2 of the License, or
-+# (at your option) any later version.
-+#
-+# This program is distributed in the hope that it will be useful,
-+# but WITHOUT ANY WARRANTY; without even the implied warranty of
-+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+# GNU General Public License for more details.
-+#
-+# You should have received a copy of the GNU General Public License
-+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 +
 +Dynamically customizable FS operations
 +----------------------------------------------------------------------
@@ -2179,10 +1985,10 @@ index 000000000..973d8d190
 +Currently this approach is applied to address_space_operations for
 +regular files only.
 diff --git a/MAINTAINERS b/MAINTAINERS
-index 0c1d245bf..ab5ade0b9 100644
+index c0b444e5f..65367aa97 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -3944,6 +3944,19 @@ S:	Supported
+@@ -3943,6 +3943,19 @@ S:	Supported
  F:	Documentation/dev-tools/autofdo.rst
  F:	scripts/Makefile.autofdo
  
@@ -2203,88 +2009,10 @@ index 0c1d245bf..ab5ade0b9 100644
  M:	Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  R:	Dave Ertman <david.m.ertman@intel.com>
 diff --git a/drivers/block/loop.c b/drivers/block/loop.c
-index 500840e4a..bdadcca49 100644
+index 8d994cae3..f4fbdf6c6 100644
 --- a/drivers/block/loop.c
 +++ b/drivers/block/loop.c
-@@ -52,7 +52,7 @@ struct loop_device {
- 	int		lo_flags;
- 	char		lo_file_name[LO_NAME_SIZE];
- 
--	struct file	*lo_backing_file;
-+	struct file	*lo_backing_file, *lo_backing_virt_file;
- 	unsigned int	lo_min_dio_size;
- 	struct block_device *lo_device;
- 
-@@ -432,6 +432,15 @@ static int do_req_filebacked(struct loop_device *lo, struct request *rq)
- 	}
- }
- 
-+static struct file *loop_real_file(struct file *file)
-+{
-+	struct file *f = NULL;
-+
-+	if (file->f_path.dentry->d_sb->s_op->real_loop)
-+		f = file->f_path.dentry->d_sb->s_op->real_loop(file);
-+	return f;
-+}
-+
- static void loop_reread_partitions(struct loop_device *lo)
- {
- 	int rc;
-@@ -533,6 +542,7 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- {
- 	struct file *file = fget(arg);
- 	struct file *old_file;
-+	struct file *f, *virt_file = NULL, *old_virt_file;
- 	unsigned int memflags;
- 	int error;
- 	bool partscan;
-@@ -561,11 +571,19 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	if (!(lo->lo_flags & LO_FLAGS_READ_ONLY))
- 		goto out_err;
- 
-+	f = loop_real_file(file);
-+	if (f) {
-+		virt_file = file;
-+		file = f;
-+		get_file(file);
-+	}
-+
- 	error = loop_validate_file(file, bdev);
- 	if (error)
- 		goto out_err;
- 
- 	old_file = lo->lo_backing_file;
-+	old_virt_file = lo->lo_backing_virt_file;
- 
- 	error = -EINVAL;
- 
-@@ -585,6 +603,7 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	memflags = blk_mq_freeze_queue(lo->lo_queue);
- 	mapping_set_gfp_mask(old_file->f_mapping, lo->old_gfp_mask);
- 	loop_assign_backing_file(lo, file);
-+	lo->lo_backing_virt_file = virt_file;
- 	loop_update_dio(lo);
- 	blk_mq_unfreeze_queue(lo->lo_queue, memflags);
- 	partscan = lo->lo_flags & LO_FLAGS_PARTSCAN;
-@@ -604,6 +623,9 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	 * dependency.
- 	 */
- 	fput(old_file);
-+	if (old_virt_file)
-+		fput(old_virt_file);
-+
- 	dev_set_uevent_suppress(disk_to_dev(lo->lo_disk), 0);
- 	if (partscan)
- 		loop_reread_partitions(lo);
-@@ -617,10 +639,33 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
- 	loop_global_unlock(lo, is_loop);
- out_putf:
- 	fput(file);
-+	if (virt_file)
-+		fput(virt_file);
-+
- 	dev_set_uevent_suppress(disk_to_dev(lo->lo_disk), 0);
+@@ -620,6 +620,26 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
  	goto done;
  }
  
@@ -2311,68 +2039,6 @@ index 500840e4a..bdadcca49 100644
  /* loop sysfs attributes */
  
  static ssize_t loop_attr_show(struct device *dev, char *page,
-@@ -974,6 +1019,7 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 			  const struct loop_config *config)
- {
- 	struct file *file = fget(config->fd);
-+	struct file *f, *virt_file = NULL;
- 	struct queue_limits lim;
- 	int error;
- 	loff_t size;
-@@ -992,6 +1038,13 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 	/* This is safe, since we have a reference from open(). */
- 	__module_get(THIS_MODULE);
- 
-+	f = loop_real_file(file);
-+	if (f) {
-+		virt_file = file;
-+		file = f;
-+		get_file(file);
-+	}
-+
- 	/*
- 	 * If we don't hold exclusive handle for the device, upgrade to it
- 	 * here to avoid changing device under exclusive owner.
-@@ -1046,6 +1099,7 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 
- 	lo->lo_device = bdev;
- 	loop_assign_backing_file(lo, file);
-+	lo->lo_backing_virt_file = virt_file;
- 
- 	lim = queue_limits_start_update(lo->lo_queue);
- 	loop_update_limits(lo, &lim, config->block_size);
-@@ -1096,6 +1150,8 @@ static int loop_configure(struct loop_device *lo, blk_mode_t mode,
- 		bd_abort_claiming(bdev, loop_configure);
- out_putf:
- 	fput(file);
-+	if (virt_file)
-+		fput(virt_file);
- 	/* This is safe: open() is still holding a reference. */
- 	module_put(THIS_MODULE);
- 	return error;
-@@ -1105,11 +1161,13 @@ static void __loop_clr_fd(struct loop_device *lo)
- {
- 	struct queue_limits lim;
- 	struct file *filp;
-+	struct file *virt_filp = lo->lo_backing_virt_file;
- 	gfp_t gfp = lo->old_gfp_mask;
- 
- 	spin_lock_irq(&lo->lo_lock);
- 	filp = lo->lo_backing_file;
- 	lo->lo_backing_file = NULL;
-+	lo->lo_backing_virt_file = NULL;
- 	spin_unlock_irq(&lo->lo_lock);
- 
- 	lo->lo_device = NULL;
-@@ -1176,6 +1234,8 @@ static void __loop_clr_fd(struct loop_device *lo)
- 	 * fput can take open_mutex which is usually taken before lo_mutex.
- 	 */
- 	fput(filp);
-+	if (virt_filp)
-+		fput(virt_filp);
- }
- 
- static int loop_clr_fd(struct loop_device *lo)
 diff --git a/fs/Kconfig b/fs/Kconfig
 index 44b6cdd36..d571db04d 100644
 --- a/fs/Kconfig
@@ -2396,13 +2062,13 @@ index 79c08b914..dcd049ca8 100644
 +obj-$(CONFIG_AUFS_FS)           += aufs/
 diff --git a/fs/aufs/Kconfig b/fs/aufs/Kconfig
 new file mode 100644
-index 000000000..f6434a7da
+index 000000000..cfa5d0abf
 --- /dev/null
 +++ b/fs/aufs/Kconfig
 @@ -0,0 +1,201 @@
 +# SPDX-License-Identifier: GPL-2.0
 +config AUFS_FS
-+	tristate "Aufs (Advanced multi layered unification filesystem) support"
++	bool "Aufs (Advanced multi layered unification filesystem) support"
 +	help
 +	Aufs is a stackable unification filesystem such as Unionfs,
 +	which unifies several directories and provides a merged single
@@ -2476,7 +2142,7 @@ index 000000000..f6434a7da
 +
 +config AUFS_EXPORT
 +	bool "NFS-exportable aufs"
-+	depends on EXPORTFS
++	depends on EXPORTFS = y
 +	help
 +	If you want to export your mounted aufs via NFS, then enable this
 +	option. There are several requirements for this configuration.
@@ -2603,16 +2269,13 @@ index 000000000..f6434a7da
 +endif
 diff --git a/fs/aufs/Makefile b/fs/aufs/Makefile
 new file mode 100644
-index 000000000..3be9f879d
+index 000000000..fb72261a5
 --- /dev/null
 +++ b/fs/aufs/Makefile
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,40 @@
 +# SPDX-License-Identifier: GPL-2.0
 +
 +include ${src}/magic.mk
-+ifeq (${CONFIG_AUFS_FS},m)
-+include ${src}/conf.mk
-+endif
 +-include ${src}/priv_def.mk
 +
 +ccflags-y += ${EXTRA_CFLAGS}
@@ -2620,11 +2283,7 @@ index 000000000..3be9f879d
 +# enable pr_debug
 +ccflags-y += -DDEBUG
 +# sparse requires the full pathname
-+ifdef M
-+ccflags-y += -include ${M}/../../include/uapi/linux/aufs_type.h
-+else
 +ccflags-y += -include ${srctree}/include/uapi/linux/aufs_type.h
-+endif
 +
 +obj-$(CONFIG_AUFS_FS) += aufs.o
 +aufs-y := module.o sbinfo.o super.o branch.o xino.o sysaufs.o opts.o fsctx.o \
@@ -2656,26 +2315,13 @@ index 000000000..3be9f879d
 +aufs-$(CONFIG_AUFS_MAGIC_SYSRQ) += sysrq.o
 diff --git a/fs/aufs/aufs.h b/fs/aufs/aufs.h
 new file mode 100644
-index 000000000..3bee75b16
+index 000000000..912324f18
 --- /dev/null
 +++ b/fs/aufs/aufs.h
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,49 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -2724,26 +2370,13 @@ index 000000000..3bee75b16
 +#endif /* __AUFS_H__ */
 diff --git a/fs/aufs/branch.c b/fs/aufs/branch.c
 new file mode 100644
-index 000000000..2c61b267c
+index 000000000..41ac62fbe
 --- /dev/null
 +++ b/fs/aufs/branch.c
-@@ -0,0 +1,1427 @@
+@@ -0,0 +1,1414 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -4157,26 +3790,13 @@ index 000000000..2c61b267c
 +}
 diff --git a/fs/aufs/branch.h b/fs/aufs/branch.h
 new file mode 100644
-index 000000000..3f2c51613
+index 000000000..44dac4caf
 --- /dev/null
 +++ b/fs/aufs/branch.h
-@@ -0,0 +1,375 @@
+@@ -0,0 +1,362 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -4536,74 +4156,15 @@ index 000000000..3f2c51613
 +
 +#endif /* __KERNEL__ */
 +#endif /* __AUFS_BRANCH_H__ */
-diff --git a/fs/aufs/conf.mk b/fs/aufs/conf.mk
-new file mode 100644
-index 000000000..12782f8e0
---- /dev/null
-+++ b/fs/aufs/conf.mk
-@@ -0,0 +1,40 @@
-+# SPDX-License-Identifier: GPL-2.0
-+
-+AuConfStr = CONFIG_AUFS_FS=${CONFIG_AUFS_FS}
-+
-+define AuConf
-+ifdef ${1}
-+AuConfStr += ${1}=${${1}}
-+endif
-+endef
-+
-+AuConfAll = BRANCH_MAX_127 BRANCH_MAX_511 BRANCH_MAX_1023 BRANCH_MAX_32767 \
-+	SBILIST \
-+	HNOTIFY HFSNOTIFY \
-+	EXPORT INO_T_64 \
-+	XATTR \
-+	FHSM \
-+	RDU \
-+	DIRREN \
-+	SHWH \
-+	BR_RAMFS \
-+	BR_FUSE POLL \
-+	BR_HFSPLUS \
-+	BDEV_LOOP \
-+	DEBUG MAGIC_SYSRQ
-+$(foreach i, ${AuConfAll}, \
-+	$(eval $(call AuConf,CONFIG_AUFS_${i})))
-+
-+AuConfName = ${obj}/conf.str
-+${AuConfName}.tmp: FORCE
-+	@echo ${AuConfStr} | tr ' ' '\n' | sed -e 's/^/"/' -e 's/$$/\\n"/' > $@
-+${AuConfName}: ${AuConfName}.tmp
-+	@diff -q $< $@ > /dev/null 2>&1 || { \
-+	echo '  GEN    ' $@; \
-+	cp -p $< $@; \
-+	}
-+FORCE:
-+clean-files += ${AuConfName} ${AuConfName}.tmp
-+${obj}/sysfs.o: ${AuConfName}
-+
-+-include ${srctree}/${src}/conf_priv.mk
 diff --git a/fs/aufs/cpup.c b/fs/aufs/cpup.c
 new file mode 100644
-index 000000000..3ecf694c9
+index 000000000..e279c5080
 --- /dev/null
 +++ b/fs/aufs/cpup.c
-@@ -0,0 +1,1466 @@
+@@ -0,0 +1,1453 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6056,26 +5617,13 @@ index 000000000..3ecf694c9
 +}
 diff --git a/fs/aufs/cpup.h b/fs/aufs/cpup.h
 new file mode 100644
-index 000000000..b87aeacea
+index 000000000..6da20c60b
 --- /dev/null
 +++ b/fs/aufs/cpup.h
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,88 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6163,26 +5711,13 @@ index 000000000..b87aeacea
 +#endif /* __AUFS_CPUP_H__ */
 diff --git a/fs/aufs/dbgaufs.c b/fs/aufs/dbgaufs.c
 new file mode 100644
-index 000000000..007d67fdc
+index 000000000..c4bb48ceb
 --- /dev/null
 +++ b/fs/aufs/dbgaufs.c
-@@ -0,0 +1,525 @@
+@@ -0,0 +1,512 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6694,26 +6229,13 @@ index 000000000..007d67fdc
 +}
 diff --git a/fs/aufs/dbgaufs.h b/fs/aufs/dbgaufs.h
 new file mode 100644
-index 000000000..8ee442569
+index 000000000..abab8ebd7
 --- /dev/null
 +++ b/fs/aufs/dbgaufs.h
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,40 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6753,26 +6275,13 @@ index 000000000..8ee442569
 +#endif /* __DBGAUFS_H__ */
 diff --git a/fs/aufs/dcsub.c b/fs/aufs/dcsub.c
 new file mode 100644
-index 000000000..2c890b0fe
+index 000000000..794ea0eb0
 --- /dev/null
 +++ b/fs/aufs/dcsub.c
-@@ -0,0 +1,225 @@
+@@ -0,0 +1,212 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -6984,26 +6493,13 @@ index 000000000..2c890b0fe
 +}
 diff --git a/fs/aufs/dcsub.h b/fs/aufs/dcsub.h
 new file mode 100644
-index 000000000..b001c6325
+index 000000000..8900c0749
 --- /dev/null
 +++ b/fs/aufs/dcsub.h
-@@ -0,0 +1,139 @@
+@@ -0,0 +1,126 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -7129,26 +6625,13 @@ index 000000000..b001c6325
 +#endif /* __AUFS_DCSUB_H__ */
 diff --git a/fs/aufs/debug.c b/fs/aufs/debug.c
 new file mode 100644
-index 000000000..fbf2ee8b8
+index 000000000..ac04136a1
 --- /dev/null
 +++ b/fs/aufs/debug.c
-@@ -0,0 +1,448 @@
+@@ -0,0 +1,435 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -7583,26 +7066,13 @@ index 000000000..fbf2ee8b8
 +}
 diff --git a/fs/aufs/debug.h b/fs/aufs/debug.h
 new file mode 100644
-index 000000000..65001ebe7
+index 000000000..caabe84b9
 --- /dev/null
 +++ b/fs/aufs/debug.h
-@@ -0,0 +1,226 @@
+@@ -0,0 +1,213 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -7815,26 +7285,13 @@ index 000000000..65001ebe7
 +#endif /* __AUFS_DEBUG_H__ */
 diff --git a/fs/aufs/dentry.c b/fs/aufs/dentry.c
 new file mode 100644
-index 000000000..ff43181f0
+index 000000000..fa2e16790
 --- /dev/null
 +++ b/fs/aufs/dentry.c
-@@ -0,0 +1,1228 @@
+@@ -0,0 +1,1215 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -9049,26 +8506,13 @@ index 000000000..ff43181f0
 +};
 diff --git a/fs/aufs/dentry.h b/fs/aufs/dentry.h
 new file mode 100644
-index 000000000..7d58888c2
+index 000000000..e0bddac22
 --- /dev/null
 +++ b/fs/aufs/dentry.h
-@@ -0,0 +1,270 @@
+@@ -0,0 +1,257 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -9325,26 +8769,13 @@ index 000000000..7d58888c2
 +#endif /* __AUFS_DENTRY_H__ */
 diff --git a/fs/aufs/dinfo.c b/fs/aufs/dinfo.c
 new file mode 100644
-index 000000000..c99a77cf6
+index 000000000..ab5e4485b
 --- /dev/null
 +++ b/fs/aufs/dinfo.c
-@@ -0,0 +1,555 @@
+@@ -0,0 +1,542 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -9886,26 +9317,13 @@ index 000000000..c99a77cf6
 +}
 diff --git a/fs/aufs/dir.c b/fs/aufs/dir.c
 new file mode 100644
-index 000000000..9fa63600f
+index 000000000..141a745df
 --- /dev/null
 +++ b/fs/aufs/dir.c
-@@ -0,0 +1,765 @@
+@@ -0,0 +1,752 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -10657,26 +10075,13 @@ index 000000000..9fa63600f
 +};
 diff --git a/fs/aufs/dir.h b/fs/aufs/dir.h
 new file mode 100644
-index 000000000..775419669
+index 000000000..cc38c8c8c
 --- /dev/null
 +++ b/fs/aufs/dir.h
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,121 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -10797,26 +10202,13 @@ index 000000000..775419669
 +#endif /* __AUFS_DIR_H__ */
 diff --git a/fs/aufs/dirren.c b/fs/aufs/dirren.c
 new file mode 100644
-index 000000000..e915d97d8
+index 000000000..82be36092
 --- /dev/null
 +++ b/fs/aufs/dirren.c
-@@ -0,0 +1,1315 @@
+@@ -0,0 +1,1302 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2017-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12118,26 +11510,13 @@ index 000000000..e915d97d8
 +}
 diff --git a/fs/aufs/dirren.h b/fs/aufs/dirren.h
 new file mode 100644
-index 000000000..1fc0345f2
+index 000000000..43f71c666
 --- /dev/null
 +++ b/fs/aufs/dirren.h
-@@ -0,0 +1,140 @@
+@@ -0,0 +1,127 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2017-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12264,26 +11643,13 @@ index 000000000..1fc0345f2
 +#endif /* __AUFS_DIRREN_H__ */
 diff --git a/fs/aufs/dynop.c b/fs/aufs/dynop.c
 new file mode 100644
-index 000000000..1c992fa47
+index 000000000..84848db96
 --- /dev/null
 +++ b/fs/aufs/dynop.c
-@@ -0,0 +1,364 @@
+@@ -0,0 +1,351 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12634,26 +12000,13 @@ index 000000000..1c992fa47
 +}
 diff --git a/fs/aufs/dynop.h b/fs/aufs/dynop.h
 new file mode 100644
-index 000000000..22e1f7acf
+index 000000000..b5483452a
 --- /dev/null
 +++ b/fs/aufs/dynop.h
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,64 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12717,26 +12070,13 @@ index 000000000..22e1f7acf
 +#endif /* __AUFS_DYNOP_H__ */
 diff --git a/fs/aufs/export.c b/fs/aufs/export.c
 new file mode 100644
-index 000000000..022c3bc8f
+index 000000000..890266e6a
 --- /dev/null
 +++ b/fs/aufs/export.c
-@@ -0,0 +1,846 @@
+@@ -0,0 +1,815 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -12995,32 +12335,11 @@ index 000000000..022c3bc8f
 +/* todo: dirty? */
 +/* if exportfs_decode_fh() passed vfsmount*, we could be happy */
 +
-+struct au_compare_mnt_args {
-+	/* input */
-+	struct super_block *sb;
-+
-+	/* output */
-+	struct vfsmount *mnt;
-+};
-+
-+static int au_compare_mnt(struct vfsmount *mnt, void *arg)
-+{
-+	struct au_compare_mnt_args *a = arg;
-+
-+	if (mnt->mnt_sb != a->sb)
-+		return 0;
-+	a->mnt = mntget(mnt);
-+	return 1;
-+}
-+
 +static struct vfsmount *au_mnt_get(struct super_block *sb)
 +{
-+	int err;
-+	struct path root;
 +	struct vfsmount *mnt;
-+	struct au_compare_mnt_args args = {
-+		.sb = sb
-+	};
++	struct path root, *paths, *p;
++	struct path a[8];
 +
 +	get_fs_root(current->fs, &root);
 +	/*
@@ -13028,23 +12347,26 @@ index 000000000..022c3bc8f
 +	 * Really?
 +	 */
 +	si_read_unlock(sb);
-+	mnt = collect_mounts(&root);
-+	if (IS_ERR(mnt)) {
-+		args.mnt = mnt;
++	paths = collect_paths(&root, a, ARRAY_SIZE(a));
++	if (IS_ERR(paths)) {
++		mnt = ERR_CAST(paths);
 +		goto out;
 +	}
 +
-+	rcu_read_lock();
-+	err = iterate_mounts(au_compare_mnt, &args, mnt);
-+	rcu_read_unlock();
-+	drop_collected_mounts(mnt);
-+	AuDebugOn(!err);
++	for (p = paths; p->dentry; p++) {
++		mnt = p->mnt;
++		if (mnt->mnt_sb == sb) {
++			mntget(mnt);
++			break;
++		}
++	}
++	drop_collected_paths(paths, a);
 +
 +out:
 +	si_noflush_read_lock(sb);
-+	AuDebugOn(!args.mnt);
++	AuDebugOn(!mnt);
 +	path_put(&root);
-+	return args.mnt;
++	return mnt;
 +}
 +
 +struct au_nfsd_si_lock {
@@ -13569,26 +12891,13 @@ index 000000000..022c3bc8f
 +}
 diff --git a/fs/aufs/f_op.c b/fs/aufs/f_op.c
 new file mode 100644
-index 000000000..8c0ec9339
+index 000000000..886b1d2fa
 --- /dev/null
 +++ b/fs/aufs/f_op.c
-@@ -0,0 +1,782 @@
+@@ -0,0 +1,769 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -13902,7 +13211,7 @@ index 000000000..8c0ec9339
 +	if (IS_ERR(h_file))
 +		goto out;
 +
-+	if (0 && au_test_loopback_kthread()) {
++	if (au_test_loopback_kthread()) {
 +		au_warn_loopback(h_file->f_path.dentry->d_sb);
 +		if (file->f_mapping != h_file->f_mapping) {
 +			file->f_mapping = h_file->f_mapping;
@@ -14357,26 +13666,13 @@ index 000000000..8c0ec9339
 +};
 diff --git a/fs/aufs/fhsm.c b/fs/aufs/fhsm.c
 new file mode 100644
-index 000000000..4d8810388
+index 000000000..92b8b6465
 --- /dev/null
 +++ b/fs/aufs/fhsm.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,413 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2011-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -14789,26 +14085,13 @@ index 000000000..4d8810388
 +}
 diff --git a/fs/aufs/file.c b/fs/aufs/file.c
 new file mode 100644
-index 000000000..806306e91
+index 000000000..76b0d79de
 --- /dev/null
 +++ b/fs/aufs/file.c
-@@ -0,0 +1,854 @@
+@@ -0,0 +1,841 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -15649,26 +14932,13 @@ index 000000000..806306e91
 +};
 diff --git a/fs/aufs/file.h b/fs/aufs/file.h
 new file mode 100644
-index 000000000..75035d791
+index 000000000..3e5de5887
 --- /dev/null
 +++ b/fs/aufs/file.h
-@@ -0,0 +1,342 @@
+@@ -0,0 +1,329 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -15997,26 +15267,13 @@ index 000000000..75035d791
 +#endif /* __AUFS_FILE_H__ */
 diff --git a/fs/aufs/finfo.c b/fs/aufs/finfo.c
 new file mode 100644
-index 000000000..ae2f801b1
+index 000000000..cbc2f42ff
 --- /dev/null
 +++ b/fs/aufs/finfo.c
-@@ -0,0 +1,147 @@
+@@ -0,0 +1,134 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -16150,26 +15407,13 @@ index 000000000..ae2f801b1
 +}
 diff --git a/fs/aufs/fsctx.c b/fs/aufs/fsctx.c
 new file mode 100644
-index 000000000..01d224a52
+index 000000000..048f81c2b
 --- /dev/null
 +++ b/fs/aufs/fsctx.c
-@@ -0,0 +1,1244 @@
+@@ -0,0 +1,1231 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2022-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -17400,26 +16644,13 @@ index 000000000..01d224a52
 +}
 diff --git a/fs/aufs/fstype.h b/fs/aufs/fstype.h
 new file mode 100644
-index 000000000..1c4d94511
+index 000000000..c3a098d94
 --- /dev/null
 +++ b/fs/aufs/fstype.h
-@@ -0,0 +1,419 @@
+@@ -0,0 +1,406 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -17825,26 +17056,13 @@ index 000000000..1c4d94511
 +#endif /* __AUFS_FSTYPE_H__ */
 diff --git a/fs/aufs/hbl.h b/fs/aufs/hbl.h
 new file mode 100644
-index 000000000..6be35b9ab
+index 000000000..710198d09
 --- /dev/null
 +++ b/fs/aufs/hbl.h
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,52 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2017-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -17896,26 +17114,13 @@ index 000000000..6be35b9ab
 +#endif /* __AUFS_HBL_H__ */
 diff --git a/fs/aufs/hfsnotify.c b/fs/aufs/hfsnotify.c
 new file mode 100644
-index 000000000..0984a7d39
+index 000000000..9ca21b356
 --- /dev/null
 +++ b/fs/aufs/hfsnotify.c
-@@ -0,0 +1,290 @@
+@@ -0,0 +1,277 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -18192,26 +17397,13 @@ index 000000000..0984a7d39
 +};
 diff --git a/fs/aufs/hfsplus.c b/fs/aufs/hfsplus.c
 new file mode 100644
-index 000000000..1f33dad7a
+index 000000000..8e2073976
 --- /dev/null
 +++ b/fs/aufs/hfsplus.c
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,47 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -18258,26 +17450,13 @@ index 000000000..1f33dad7a
 +}
 diff --git a/fs/aufs/hnotify.c b/fs/aufs/hnotify.c
 new file mode 100644
-index 000000000..fdebd41be
+index 000000000..2292e3d2d
 --- /dev/null
 +++ b/fs/aufs/hnotify.c
-@@ -0,0 +1,715 @@
+@@ -0,0 +1,702 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -18979,26 +18158,13 @@ index 000000000..fdebd41be
 +}
 diff --git a/fs/aufs/i_op.c b/fs/aufs/i_op.c
 new file mode 100644
-index 000000000..d948b77e7
+index 000000000..a043640ce
 --- /dev/null
 +++ b/fs/aufs/i_op.c
-@@ -0,0 +1,1522 @@
+@@ -0,0 +1,1509 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -20507,26 +19673,13 @@ index 000000000..d948b77e7
 +};
 diff --git a/fs/aufs/i_op_add.c b/fs/aufs/i_op_add.c
 new file mode 100644
-index 000000000..28fc3910f
+index 000000000..92b5c22d0
 --- /dev/null
 +++ b/fs/aufs/i_op_add.c
-@@ -0,0 +1,979 @@
+@@ -0,0 +1,966 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -21492,26 +20645,13 @@ index 000000000..28fc3910f
 +}
 diff --git a/fs/aufs/i_op_del.c b/fs/aufs/i_op_del.c
 new file mode 100644
-index 000000000..80943a5ba
+index 000000000..9a31b0e7f
 --- /dev/null
 +++ b/fs/aufs/i_op_del.c
-@@ -0,0 +1,523 @@
+@@ -0,0 +1,510 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -22021,26 +21161,13 @@ index 000000000..80943a5ba
 +}
 diff --git a/fs/aufs/i_op_ren.c b/fs/aufs/i_op_ren.c
 new file mode 100644
-index 000000000..939dcd050
+index 000000000..969262ac7
 --- /dev/null
 +++ b/fs/aufs/i_op_ren.c
-@@ -0,0 +1,1264 @@
+@@ -0,0 +1,1251 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -23291,26 +22418,13 @@ index 000000000..939dcd050
 +}
 diff --git a/fs/aufs/iinfo.c b/fs/aufs/iinfo.c
 new file mode 100644
-index 000000000..e82a63773
+index 000000000..bf8aea459
 --- /dev/null
 +++ b/fs/aufs/iinfo.c
-@@ -0,0 +1,287 @@
+@@ -0,0 +1,274 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -23584,26 +22698,13 @@ index 000000000..e82a63773
 +}
 diff --git a/fs/aufs/inode.c b/fs/aufs/inode.c
 new file mode 100644
-index 000000000..391de2ea1
+index 000000000..2a74ee2f8
 --- /dev/null
 +++ b/fs/aufs/inode.c
-@@ -0,0 +1,532 @@
+@@ -0,0 +1,519 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -24122,26 +23223,13 @@ index 000000000..391de2ea1
 +}
 diff --git a/fs/aufs/inode.h b/fs/aufs/inode.h
 new file mode 100644
-index 000000000..6f4f6a837
+index 000000000..5bca97110
 --- /dev/null
 +++ b/fs/aufs/inode.h
-@@ -0,0 +1,727 @@
+@@ -0,0 +1,714 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -24855,26 +23943,13 @@ index 000000000..6f4f6a837
 +#endif /* __AUFS_INODE_H__ */
 diff --git a/fs/aufs/ioctl.c b/fs/aufs/ioctl.c
 new file mode 100644
-index 000000000..807b133c4
+index 000000000..a175714ea
 --- /dev/null
 +++ b/fs/aufs/ioctl.c
-@@ -0,0 +1,220 @@
+@@ -0,0 +1,207 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25081,26 +24156,13 @@ index 000000000..807b133c4
 +#endif
 diff --git a/fs/aufs/lcnt.h b/fs/aufs/lcnt.h
 new file mode 100644
-index 000000000..95df0ac9b
+index 000000000..07aca1a7d
 --- /dev/null
 +++ b/fs/aufs/lcnt.h
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,173 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2018-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25273,26 +24335,13 @@ index 000000000..95df0ac9b
 +#endif /* __AUFS_LCNT_H__ */
 diff --git a/fs/aufs/loop.c b/fs/aufs/loop.c
 new file mode 100644
-index 000000000..38ed1393d
+index 000000000..69dea4cda
 --- /dev/null
 +++ b/fs/aufs/loop.c
-@@ -0,0 +1,164 @@
+@@ -0,0 +1,135 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25425,44 +24474,15 @@ index 000000000..38ed1393d
 +		symbol_put(loop_backing_file);
 +	au_kfree_try_rcu(au_warn_loopback_array);
 +}
-+
-+/* ---------------------------------------------------------------------- */
-+
-+/* support the loopback block device insude aufs */
-+
-+struct file *aufs_real_loop(struct file *file)
-+{
-+	struct file *f;
-+
-+	BUG_ON(!au_test_aufs(file->f_path.dentry->d_sb));
-+	fi_read_lock(file);
-+	f = au_hf_top(file);
-+	fi_read_unlock(file);
-+	AuDebugOn(!f);
-+	return f;
-+}
 diff --git a/fs/aufs/loop.h b/fs/aufs/loop.h
 new file mode 100644
-index 000000000..9d479fa1a
+index 000000000..519efba31
 --- /dev/null
 +++ b/fs/aufs/loop.h
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,42 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25488,8 +24508,6 @@ index 000000000..9d479fa1a
 +
 +int au_loopback_init(void);
 +void au_loopback_fin(void);
-+
-+struct file *aufs_real_loop(struct file *file);
 +#else
 +AuStub(struct file *, loop_backing_file, return NULL, struct super_block *sb)
 +
@@ -25500,8 +24518,6 @@ index 000000000..9d479fa1a
 +
 +AuStubInt0(au_loopback_init, void)
 +AuStubVoid(au_loopback_fin, void)
-+
-+AuStub(struct file *, aufs_real_loop, return NULL, struct file *file)
 +#endif /* BLK_DEV_LOOP */
 +
 +#endif /* __KERNEL__ */
@@ -25545,26 +24561,13 @@ index 000000000..7bc9eef3f
 +endif
 diff --git a/fs/aufs/module.c b/fs/aufs/module.c
 new file mode 100644
-index 000000000..bfd314893
+index 000000000..f66ccf60c
 --- /dev/null
 +++ b/fs/aufs/module.c
-@@ -0,0 +1,275 @@
+@@ -0,0 +1,261 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -25697,7 +24700,6 @@ index 000000000..bfd314893
 +MODULE_DESCRIPTION(AUFS_NAME
 +	" -- Advanced multi layered unification filesystem");
 +MODULE_VERSION(AUFS_VERSION);
-+MODULE_ALIAS_FS(AUFS_NAME);
 +
 +/* this module parameter has no meaning when SYSFS is disabled */
 +int sysaufs_brs = 1;
@@ -25826,26 +24828,13 @@ index 000000000..bfd314893
 +module_exit(aufs_exit);
 diff --git a/fs/aufs/module.h b/fs/aufs/module.h
 new file mode 100644
-index 000000000..aad4f097e
+index 000000000..296fde588
 --- /dev/null
 +++ b/fs/aufs/module.h
-@@ -0,0 +1,180 @@
+@@ -0,0 +1,167 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -26012,26 +25001,13 @@ index 000000000..aad4f097e
 +#endif /* __AUFS_MODULE_H__ */
 diff --git a/fs/aufs/mvdown.c b/fs/aufs/mvdown.c
 new file mode 100644
-index 000000000..942736a99
+index 000000000..e314168b2
 --- /dev/null
 +++ b/fs/aufs/mvdown.c
-@@ -0,0 +1,714 @@
+@@ -0,0 +1,701 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2011-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -26732,26 +25708,13 @@ index 000000000..942736a99
 +}
 diff --git a/fs/aufs/opts.c b/fs/aufs/opts.c
 new file mode 100644
-index 000000000..533c87bda
+index 000000000..9df49bab0
 --- /dev/null
 +++ b/fs/aufs/opts.c
-@@ -0,0 +1,1030 @@
+@@ -0,0 +1,1017 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -27768,26 +26731,13 @@ index 000000000..533c87bda
 +}
 diff --git a/fs/aufs/opts.h b/fs/aufs/opts.h
 new file mode 100644
-index 000000000..62cc3c40b
+index 000000000..c633d1e16
 --- /dev/null
 +++ b/fs/aufs/opts.h
-@@ -0,0 +1,264 @@
+@@ -0,0 +1,251 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28038,26 +26988,13 @@ index 000000000..62cc3c40b
 +#endif /* __AUFS_OPTS_H__ */
 diff --git a/fs/aufs/plink.c b/fs/aufs/plink.c
 new file mode 100644
-index 000000000..6a47db86c
+index 000000000..365e8bc62
 --- /dev/null
 +++ b/fs/aufs/plink.c
-@@ -0,0 +1,516 @@
+@@ -0,0 +1,503 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28560,26 +27497,13 @@ index 000000000..6a47db86c
 +}
 diff --git a/fs/aufs/poll.c b/fs/aufs/poll.c
 new file mode 100644
-index 000000000..0b8b948fc
+index 000000000..4714bdf21
 --- /dev/null
 +++ b/fs/aufs/poll.c
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,38 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28617,26 +27541,13 @@ index 000000000..0b8b948fc
 +}
 diff --git a/fs/aufs/posix_acl.c b/fs/aufs/posix_acl.c
 new file mode 100644
-index 000000000..12ed81a59
+index 000000000..471e30d17
 --- /dev/null
 +++ b/fs/aufs/posix_acl.c
-@@ -0,0 +1,108 @@
+@@ -0,0 +1,95 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2014-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28731,26 +27642,13 @@ index 000000000..12ed81a59
 +}
 diff --git a/fs/aufs/procfs.c b/fs/aufs/procfs.c
 new file mode 100644
-index 000000000..2ed220449
+index 000000000..aafdba088
 --- /dev/null
 +++ b/fs/aufs/procfs.c
-@@ -0,0 +1,168 @@
+@@ -0,0 +1,155 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2010-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -28905,26 +27803,13 @@ index 000000000..2ed220449
 +}
 diff --git a/fs/aufs/rdu.c b/fs/aufs/rdu.c
 new file mode 100644
-index 000000000..54ebca84a
+index 000000000..6e5d76228
 --- /dev/null
 +++ b/fs/aufs/rdu.c
-@@ -0,0 +1,384 @@
+@@ -0,0 +1,371 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -29295,26 +28180,13 @@ index 000000000..54ebca84a
 +#endif
 diff --git a/fs/aufs/rwsem.h b/fs/aufs/rwsem.h
 new file mode 100644
-index 000000000..c71f6542f
+index 000000000..302782f5b
 --- /dev/null
 +++ b/fs/aufs/rwsem.h
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,76 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -29390,26 +28262,13 @@ index 000000000..c71f6542f
 +#endif /* __AUFS_RWSEM_H__ */
 diff --git a/fs/aufs/sbinfo.c b/fs/aufs/sbinfo.c
 new file mode 100644
-index 000000000..9433b21b3
+index 000000000..bd7a50bc0
 --- /dev/null
 +++ b/fs/aufs/sbinfo.c
-@@ -0,0 +1,316 @@
+@@ -0,0 +1,303 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -29712,26 +28571,13 @@ index 000000000..9433b21b3
 +}
 diff --git a/fs/aufs/super.c b/fs/aufs/super.c
 new file mode 100644
-index 000000000..cf6e08a0f
+index 000000000..e867aa6e7
 --- /dev/null
 +++ b/fs/aufs/super.c
-@@ -0,0 +1,875 @@
+@@ -0,0 +1,859 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -30489,10 +29335,7 @@ index 000000000..cf6e08a0f
 +	.show_options	= aufs_show_options,
 +	.statfs		= aufs_statfs,
 +	.put_super	= aufs_put_super,
-+	.sync_fs	= aufs_sync_fs,
-+#ifdef CONFIG_AUFS_BDEV_LOOP
-+	.real_loop	= aufs_real_loop
-+#endif
++	.sync_fs	= aufs_sync_fs
 +};
 +
 +/* ---------------------------------------------------------------------- */
@@ -30593,26 +29436,13 @@ index 000000000..cf6e08a0f
 +};
 diff --git a/fs/aufs/super.h b/fs/aufs/super.h
 new file mode 100644
-index 000000000..039d507aa
+index 000000000..afabf38a6
 --- /dev/null
 +++ b/fs/aufs/super.h
-@@ -0,0 +1,618 @@
+@@ -0,0 +1,605 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31217,26 +30047,13 @@ index 000000000..039d507aa
 +#endif /* __AUFS_SUPER_H__ */
 diff --git a/fs/aufs/sysaufs.c b/fs/aufs/sysaufs.c
 new file mode 100644
-index 000000000..2c28abfd5
+index 000000000..5c01ea8dd
 --- /dev/null
 +++ b/fs/aufs/sysaufs.c
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,81 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31317,26 +30134,13 @@ index 000000000..2c28abfd5
 +}
 diff --git a/fs/aufs/sysaufs.h b/fs/aufs/sysaufs.h
 new file mode 100644
-index 000000000..224895b10
+index 000000000..66cec0acb
 --- /dev/null
 +++ b/fs/aufs/sysaufs.h
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,89 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31425,26 +30229,13 @@ index 000000000..224895b10
 +#endif /* __SYSAUFS_H__ */
 diff --git a/fs/aufs/sysfs.c b/fs/aufs/sysfs.c
 new file mode 100644
-index 000000000..9d68cf89e
+index 000000000..904a91c1b
 --- /dev/null
 +++ b/fs/aufs/sysfs.c
-@@ -0,0 +1,374 @@
+@@ -0,0 +1,338 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31455,30 +30246,7 @@ index 000000000..9d68cf89e
 +#include <linux/seq_file.h>
 +#include "aufs.h"
 +
-+#ifdef CONFIG_AUFS_FS_MODULE
-+/* this entry violates the "one line per file" policy of sysfs */
-+static ssize_t config_show(struct kobject *kobj, struct kobj_attribute *attr,
-+			   char *buf)
-+{
-+	ssize_t err;
-+	static char *conf =
-+/* this file is generated at compiling */
-+#include "conf.str"
-+		;
-+
-+	err = snprintf(buf, PAGE_SIZE, conf);
-+	if (unlikely(err >= PAGE_SIZE))
-+		err = -EFBIG;
-+	return err;
-+}
-+
-+static struct kobj_attribute au_config_attr = __ATTR_RO(config);
-+#endif
-+
 +static struct attribute *au_attr[] = {
-+#ifdef CONFIG_AUFS_FS_MODULE
-+	&au_config_attr.attr,
-+#endif
 +	NULL,	/* need to NULL terminate the list of attributes */
 +};
 +
@@ -31805,26 +30573,13 @@ index 000000000..9d68cf89e
 +}
 diff --git a/fs/aufs/sysrq.c b/fs/aufs/sysrq.c
 new file mode 100644
-index 000000000..57fa54ce5
+index 000000000..1a8be2e5e
 --- /dev/null
 +++ b/fs/aufs/sysrq.c
-@@ -0,0 +1,157 @@
+@@ -0,0 +1,144 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -31968,26 +30723,13 @@ index 000000000..57fa54ce5
 +}
 diff --git a/fs/aufs/vdir.c b/fs/aufs/vdir.c
 new file mode 100644
-index 000000000..eb6bd9fb1
+index 000000000..e42740b72
 --- /dev/null
 +++ b/fs/aufs/vdir.c
-@@ -0,0 +1,896 @@
+@@ -0,0 +1,883 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -32870,26 +31612,13 @@ index 000000000..eb6bd9fb1
 +}
 diff --git a/fs/aufs/vfsub.c b/fs/aufs/vfsub.c
 new file mode 100644
-index 000000000..6616c908c
+index 000000000..fe12b2aaa
 --- /dev/null
 +++ b/fs/aufs/vfsub.c
-@@ -0,0 +1,972 @@
+@@ -0,0 +1,959 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -33848,26 +32577,13 @@ index 000000000..6616c908c
 +}
 diff --git a/fs/aufs/vfsub.h b/fs/aufs/vfsub.h
 new file mode 100644
-index 000000000..5f2a363b2
+index 000000000..35450f242
 --- /dev/null
 +++ b/fs/aufs/vfsub.h
-@@ -0,0 +1,441 @@
+@@ -0,0 +1,428 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -34295,26 +33011,13 @@ index 000000000..5f2a363b2
 +#endif /* __AUFS_VFSUB_H__ */
 diff --git a/fs/aufs/wbr_policy.c b/fs/aufs/wbr_policy.c
 new file mode 100644
-index 000000000..d8b5f1288
+index 000000000..4a7763999
 --- /dev/null
 +++ b/fs/aufs/wbr_policy.c
-@@ -0,0 +1,835 @@
+@@ -0,0 +1,822 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -35136,26 +33839,13 @@ index 000000000..d8b5f1288
 +};
 diff --git a/fs/aufs/whout.c b/fs/aufs/whout.c
 new file mode 100644
-index 000000000..61f1ea856
+index 000000000..a62bbe3f4
 --- /dev/null
 +++ b/fs/aufs/whout.c
-@@ -0,0 +1,1096 @@
+@@ -0,0 +1,1083 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36238,26 +34928,13 @@ index 000000000..61f1ea856
 +}
 diff --git a/fs/aufs/whout.h b/fs/aufs/whout.h
 new file mode 100644
-index 000000000..ae2ef1cf4
+index 000000000..95345cf34
 --- /dev/null
 +++ b/fs/aufs/whout.h
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,74 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36331,26 +35008,13 @@ index 000000000..ae2ef1cf4
 +#endif /* __AUFS_WHOUT_H__ */
 diff --git a/fs/aufs/wkq.c b/fs/aufs/wkq.c
 new file mode 100644
-index 000000000..869f3ff57
+index 000000000..bf34327ee
 --- /dev/null
 +++ b/fs/aufs/wkq.c
-@@ -0,0 +1,370 @@
+@@ -0,0 +1,357 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36707,26 +35371,13 @@ index 000000000..869f3ff57
 +}
 diff --git a/fs/aufs/wkq.h b/fs/aufs/wkq.h
 new file mode 100644
-index 000000000..9132cfeae
+index 000000000..490621359
 --- /dev/null
 +++ b/fs/aufs/wkq.h
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,76 @@
 +/* SPDX-License-Identifier: GPL-2.0 */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -36802,26 +35453,13 @@ index 000000000..9132cfeae
 +#endif /* __AUFS_WKQ_H__ */
 diff --git a/fs/aufs/xattr.c b/fs/aufs/xattr.c
 new file mode 100644
-index 000000000..261510b24
+index 000000000..bf651e781
 --- /dev/null
 +++ b/fs/aufs/xattr.c
-@@ -0,0 +1,360 @@
+@@ -0,0 +1,347 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2014-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -37168,26 +35806,13 @@ index 000000000..261510b24
 +}
 diff --git a/fs/aufs/xino.c b/fs/aufs/xino.c
 new file mode 100644
-index 000000000..e6ffdfdb1
+index 000000000..c202f91aa
 --- /dev/null
 +++ b/fs/aufs/xino.c
-@@ -0,0 +1,1926 @@
+@@ -0,0 +1,1913 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +/*
@@ -39099,7 +37724,7 @@ index 000000000..e6ffdfdb1
 +	return err;
 +}
 diff --git a/fs/dcache.c b/fs/dcache.c
-index 03d58b2d4..7f1b9af13 100644
+index 03d58b2d4..7f483c978 100644
 --- a/fs/dcache.c
 +++ b/fs/dcache.c
 @@ -1277,6 +1277,9 @@ enum d_walk_ret {
@@ -39121,36 +37746,8 @@ index 03d58b2d4..7f1b9af13 100644
  		   enum d_walk_ret (*enter)(void *, struct dentry *))
  {
  	struct dentry *this_parent, *dentry;
-@@ -1384,6 +1387,7 @@ static void d_walk(struct dentry *parent, void *data,
- 	seq = 1;
- 	goto again;
- }
-+EXPORT_SYMBOL_GPL(d_walk);
- 
- struct check_mount {
- 	struct vfsmount *mnt;
-@@ -2899,6 +2903,7 @@ void d_exchange(struct dentry *dentry1, struct dentry *dentry2)
- 
- 	write_sequnlock(&rename_lock);
- }
-+EXPORT_SYMBOL_GPL(d_exchange);
- 
- /**
-  * d_ancestor - search for an ancestor
-diff --git a/fs/exec.c b/fs/exec.c
-index 1f5fdd2e0..34d831a77 100644
---- a/fs/exec.c
-+++ b/fs/exec.c
-@@ -117,6 +117,7 @@ bool path_noexec(const struct path *path)
- 	return (path->mnt->mnt_flags & MNT_NOEXEC) ||
- 	       (path->mnt->mnt_sb->s_iflags & SB_I_NOEXEC);
- }
-+EXPORT_SYMBOL_GPL(path_noexec);
- 
- #ifdef CONFIG_MMU
- /*
 diff --git a/fs/fcntl.c b/fs/fcntl.c
-index 5598e4d57..7d4eaaff1 100644
+index 5598e4d57..90af6a47f 100644
 --- a/fs/fcntl.c
 +++ b/fs/fcntl.c
 @@ -36,7 +36,7 @@
@@ -39171,31 +37768,11 @@ index 5598e4d57..7d4eaaff1 100644
  	if (error)
  		return error;
  
-@@ -87,6 +89,7 @@ static int setfl(int fd, struct file * filp, unsigned int arg)
-  out:
- 	return error;
- }
-+EXPORT_SYMBOL_GPL(setfl);
- 
- /*
-  * Allocate an file->f_owner struct if it doesn't exist, handling racing
-diff --git a/fs/file_table.c b/fs/file_table.c
-index 138114d64..1b95604f1 100644
---- a/fs/file_table.c
-+++ b/fs/file_table.c
-@@ -253,6 +253,7 @@ struct file *alloc_empty_file(int flags, const struct cred *cred)
- 	}
- 	return ERR_PTR(-ENFILE);
- }
-+EXPORT_SYMBOL_GPL(alloc_empty_file);
- 
- /*
-  * Variant of alloc_empty_file() that doesn't check and modify nr_files.
 diff --git a/fs/namespace.c b/fs/namespace.c
-index e13d9ab4f..3359fe694 100644
+index 54c59e091..fca52af06 100644
 --- a/fs/namespace.c
 +++ b/fs/namespace.c
-@@ -1004,6 +1004,13 @@ static inline int check_mnt(struct mount *mnt)
+@@ -1004,6 +1004,12 @@ static inline int check_mnt(struct mount *mnt)
  	return mnt->mnt_ns == current->nsproxy->mnt_ns;
  }
  
@@ -39204,71 +37781,10 @@ index e13d9ab4f..3359fe694 100644
 +{
 +	return check_mnt(real_mount(mnt));
 +}
-+EXPORT_SYMBOL_GPL(is_current_mnt_ns);
 +
  static inline bool check_anonymous_mnt(struct mount *mnt)
  {
  	u64 seq;
-@@ -2326,6 +2333,7 @@ struct vfsmount *collect_mounts(const struct path *path)
- 		return ERR_CAST(tree);
- 	return &tree->mnt;
- }
-+EXPORT_SYMBOL_GPL(collect_mounts);
- 
- static void free_mnt_ns(struct mnt_namespace *);
- static struct mnt_namespace *alloc_mnt_ns(struct user_namespace *, bool);
-@@ -2409,6 +2417,7 @@ void drop_collected_mounts(struct vfsmount *mnt)
- 	unlock_mount_hash();
- 	namespace_unlock();
- }
-+EXPORT_SYMBOL_GPL(drop_collected_mounts);
- 
- static bool __has_locked_children(struct mount *mnt, struct dentry *dentry)
- {
-@@ -2525,6 +2534,7 @@ int iterate_mounts(int (*f)(struct vfsmount *, void *), void *arg,
- 	}
- 	return 0;
- }
-+EXPORT_SYMBOL_GPL(iterate_mounts);
- 
- static void lock_mnt_tree(struct mount *mnt)
- {
-diff --git a/fs/notify/fsnotify.c b/fs/notify/fsnotify.c
-index e2b4f17a4..7a411ea72 100644
---- a/fs/notify/fsnotify.c
-+++ b/fs/notify/fsnotify.c
-@@ -225,6 +225,7 @@ int fsnotify_pre_content(const struct path *path, const loff_t *ppos,
- 	return fsnotify_parent(path->dentry, FS_PRE_ACCESS, &range,
- 			       FSNOTIFY_EVENT_FILE_RANGE);
- }
-+EXPORT_SYMBOL_GPL(fsnotify_pre_content);
- 
- /*
-  * Notify this dentry's parent about a child's events with child name info
-diff --git a/fs/notify/group.c b/fs/notify/group.c
-index 18446b7b0..09138e0b8 100644
---- a/fs/notify/group.c
-+++ b/fs/notify/group.c
-@@ -100,6 +100,7 @@ void fsnotify_get_group(struct fsnotify_group *group)
- {
- 	refcount_inc(&group->refcnt);
- }
-+EXPORT_SYMBOL_GPL(fsnotify_get_group);
- 
- /*
-  * Drop a reference to a group.  Free it if it's through.
-diff --git a/fs/open.c b/fs/open.c
-index 7828234a7..bdc55f69a 100644
---- a/fs/open.c
-+++ b/fs/open.c
-@@ -69,6 +69,7 @@ int do_truncate(struct mnt_idmap *idmap, struct dentry *dentry,
- 	inode_unlock(dentry->d_inode);
- 	return ret;
- }
-+EXPORT_SYMBOL_GPL(do_truncate);
- 
- int vfs_truncate(const struct path *path, loff_t length)
- {
 diff --git a/fs/proc/base.c b/fs/proc/base.c
 index c667702dc..3ea53a8ca 100644
 --- a/fs/proc/base.c
@@ -39299,7 +37815,7 @@ index c6e7ebc63..d7ccfd909 100644
  		ino = inode->i_ino;
  	}
 diff --git a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
-index 27972c074..ec6ccbbe4 100644
+index 751479eb1..7f26002f4 100644
 --- a/fs/proc/task_mmu.c
 +++ b/fs/proc/task_mmu.c
 @@ -264,7 +264,8 @@ static void get_vma_name(struct vm_area_struct *vma,
@@ -39347,31 +37863,11 @@ index 59bfd61d6..95dc16733 100644
  		dev = inode->i_sb->s_dev;
  		ino = inode->i_ino;
  		pgoff = (loff_t)vma->vm_pgoff << PAGE_SHIFT;
-diff --git a/fs/read_write.c b/fs/read_write.c
-index 0ef70e128..52806554f 100644
---- a/fs/read_write.c
-+++ b/fs/read_write.c
-@@ -579,6 +579,7 @@ ssize_t vfs_read(struct file *file, char __user *buf, size_t count, loff_t *pos)
- 	inc_syscr(current);
- 	return ret;
- }
-+EXPORT_SYMBOL_GPL(vfs_read);
- 
- static ssize_t new_sync_write(struct file *filp, const char __user *buf, size_t len, loff_t *ppos)
- {
-@@ -694,6 +695,7 @@ ssize_t vfs_write(struct file *file, const char __user *buf, size_t count, loff_
- 	file_end_write(file);
- 	return ret;
- }
-+EXPORT_SYMBOL_GPL(vfs_write);
- 
- /* file_ppos returns &file->f_pos or NULL if file is stream */
- static inline loff_t *file_ppos(struct file *file)
 diff --git a/fs/splice.c b/fs/splice.c
-index 4d6df083e..eb7b4d93a 100644
+index 4d6df083e..73cd917c8 100644
 --- a/fs/splice.c
 +++ b/fs/splice.c
-@@ -927,13 +927,14 @@ static int warn_unsupported(struct file *file, const char *op)
+@@ -927,7 +927,7 @@ static int warn_unsupported(struct file *file, const char *op)
  /*
   * Attempt to initiate a splice from pipe to file.
   */
@@ -39380,30 +37876,11 @@ index 4d6df083e..eb7b4d93a 100644
  			      loff_t *ppos, size_t len, unsigned int flags)
  {
  	if (unlikely(!out->f_op->splice_write))
- 		return warn_unsupported(out, "write");
- 	return out->f_op->splice_write(pipe, out, ppos, len, flags);
- }
-+EXPORT_SYMBOL_GPL(do_splice_from);
- 
- /*
-  * Indicate to the caller that there was a premature EOF when reading from the
-diff --git a/fs/xattr.c b/fs/xattr.c
-index 8ec5b0204..29b754a86 100644
---- a/fs/xattr.c
-+++ b/fs/xattr.c
-@@ -405,6 +405,7 @@ vfs_getxattr_alloc(struct mnt_idmap *idmap, struct dentry *dentry,
- 	*xattr_value = value;
- 	return error;
- }
-+EXPORT_SYMBOL_GPL(vfs_getxattr_alloc);
- 
- ssize_t
- __vfs_getxattr(struct dentry *dentry, struct inode *inode, const char *name,
 diff --git a/include/linux/fs.h b/include/linux/fs.h
-index 4ec77da65..51c15a124 100644
+index 040c00363..5a4ba4c04 100644
 --- a/include/linux/fs.h
 +++ b/include/linux/fs.h
-@@ -1221,6 +1221,7 @@ extern void fasync_free(struct fasync_struct *);
+@@ -1223,6 +1223,7 @@ extern void fasync_free(struct fasync_struct *);
  /* can be called from interrupts */
  extern void kill_fasync(struct fasync_struct **, int, int);
  
@@ -39411,7 +37888,7 @@ index 4ec77da65..51c15a124 100644
  extern void __f_setown(struct file *filp, struct pid *, enum pid_type, int force);
  extern int f_setown(struct file *filp, int who, int force);
  extern void f_delown(struct file *filp);
-@@ -2169,6 +2170,7 @@ struct file_operations {
+@@ -2171,6 +2172,7 @@ struct file_operations {
  	int (*lock) (struct file *, int, struct file_lock *);
  	unsigned long (*get_unmapped_area)(struct file *, unsigned long, unsigned long, unsigned long, unsigned long);
  	int (*check_flags)(int);
@@ -39419,18 +37896,6 @@ index 4ec77da65..51c15a124 100644
  	int (*flock) (struct file *, int, struct file_lock *);
  	ssize_t (*splice_write)(struct pipe_inode_info *, struct file *, loff_t *, size_t, unsigned int);
  	ssize_t (*splice_read)(struct file *, loff_t *, struct pipe_inode_info *, size_t, unsigned int);
-@@ -2366,6 +2368,11 @@ struct super_operations {
- 	long (*free_cached_objects)(struct super_block *,
- 				    struct shrink_control *);
- 	void (*shutdown)(struct super_block *sb);
-+
-+#if IS_ENABLED(CONFIG_BLK_DEV_LOOP) || IS_ENABLED(CONFIG_BLK_DEV_LOOP_MODULE)
-+	/* and aufs */
-+	struct file *(*real_loop)(struct file *);
-+#endif
- };
- 
- /*
 diff --git a/include/linux/lockdep.h b/include/linux/lockdep.h
 index 67964dc4d..517ef3ea8 100644
 --- a/include/linux/lockdep.h
@@ -39445,14 +37910,14 @@ index 67964dc4d..517ef3ea8 100644
   * Acquire a lock.
   *
 diff --git a/include/linux/mm.h b/include/linux/mm.h
-index 0ef2ba0c6..2d5a27790 100644
+index 985ff6ee9..6e4ae082a 100644
 --- a/include/linux/mm.h
 +++ b/include/linux/mm.h
-@@ -2438,6 +2438,54 @@ static inline void unmap_shared_mapping_range(struct address_space *mapping,
+@@ -2446,6 +2446,54 @@ static inline void unmap_shared_mapping_range(struct address_space *mapping,
  static inline struct vm_area_struct *vma_lookup(struct mm_struct *mm,
  						unsigned long addr);
  
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +static inline struct file *vma_prfile_value(struct vm_area_struct *vma)
 +{
 +	return vma->vm_prfile;
@@ -39504,14 +37969,14 @@ index 0ef2ba0c6..2d5a27790 100644
  		void *buf, int len, unsigned int gup_flags);
  extern int access_remote_vm(struct mm_struct *mm, unsigned long addr,
 diff --git a/include/linux/mm_types.h b/include/linux/mm_types.h
-index d6b91e8a6..e4ad45500 100644
+index d6b91e8a6..811190b21 100644
 --- a/include/linux/mm_types.h
 +++ b/include/linux/mm_types.h
 @@ -682,6 +682,9 @@ struct vm_region {
  	unsigned long	vm_top;		/* region allocated to here */
  	unsigned long	vm_pgoff;	/* the offset in vm_file corresponding to vm_start */
  	struct file	*vm_file;	/* the backing file or NULL */
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +	struct file	*vm_prfile;	/* the virtual backing file or NULL */
 +#endif
  
@@ -39521,7 +37986,7 @@ index d6b91e8a6..e4ad45500 100644
  	unsigned long vm_pgoff;		/* Offset (within vm_file) in PAGE_SIZE
  					   units */
  	struct file * vm_file;		/* File we map to (can be NULL). */
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +	struct file *vm_prfile;		/* shadow of vm_file */
 +#endif
  	void * vm_private_data;		/* was vm_pte (shared mem) */
@@ -39562,26 +38027,13 @@ index 9dec4861d..14583d846 100644
  #endif
 diff --git a/include/uapi/linux/aufs_type.h b/include/uapi/linux/aufs_type.h
 new file mode 100644
-index 000000000..bee32959e
+index 000000000..b35c78661
 --- /dev/null
 +++ b/include/uapi/linux/aufs_type.h
-@@ -0,0 +1,452 @@
+@@ -0,0 +1,439 @@
 +/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
 +/*
 + * Copyright (C) 2005-2025 Junjiro R. Okajima
-+ *
-+ * This program is free software; you can redistribute it and/or modify
-+ * it under the terms of the GNU General Public License as published by
-+ * the Free Software Foundation; either version 2 of the License, or
-+ * (at your option) any later version.
-+ *
-+ * This program is distributed in the hope that it will be useful,
-+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-+ * GNU General Public License for more details.
-+ *
-+ * You should have received a copy of the GNU General Public License
-+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 + */
 +
 +#ifndef __AUFS_TYPE_H__
@@ -39608,7 +38060,7 @@ index 000000000..bee32959e
 +#include <limits.h>
 +#endif /* __KERNEL__ */
 +
-+#define AUFS_VERSION	"6.x-rcN-20250616"
++#define AUFS_VERSION	"6.16"
 +
 +/* todo? move this to linux-2.6.19/include/magic.h */
 +#define AUFS_SUPER_MAGIC	('a' << 24 | 'u' << 16 | 'f' << 8 | 's')
@@ -40019,7 +38471,7 @@ index 000000000..bee32959e
 +
 +#endif /* __AUFS_TYPE_H__ */
 diff --git a/kernel/locking/lockdep.c b/kernel/locking/lockdep.c
-index dd2bbf737..d82ca73a5 100644
+index dd2bbf737..e3a5bfdb8 100644
 --- a/kernel/locking/lockdep.c
 +++ b/kernel/locking/lockdep.c
 @@ -224,7 +224,7 @@ unsigned long max_lock_class_idx;
@@ -40031,33 +38483,23 @@ index dd2bbf737..d82ca73a5 100644
  {
  	unsigned int class_idx = hlock->class_idx;
  
-@@ -245,6 +245,8 @@ static inline struct lock_class *hlock_class(struct held_lock *hlock)
+@@ -245,6 +245,7 @@ static inline struct lock_class *hlock_class(struct held_lock *hlock)
  	 */
  	return lock_classes + class_idx;
  }
-+EXPORT_SYMBOL_GPL(lockdep_hlock_class);
 +#define hlock_class(hlock) lockdep_hlock_class(hlock)
  
  #ifdef CONFIG_LOCK_STAT
  static DEFINE_PER_CPU(struct lock_class_stats[MAX_LOCKDEP_KEYS], cpu_lock_stats);
-diff --git a/kernel/task_work.c b/kernel/task_work.c
-index d1efec571..eed18cc26 100644
---- a/kernel/task_work.c
-+++ b/kernel/task_work.c
-@@ -230,3 +230,4 @@ void task_work_run(void)
- 		} while (work);
- 	}
- }
-+EXPORT_SYMBOL_GPL(task_work_run);
 diff --git a/mm/Makefile b/mm/Makefile
-index 1a7a11d49..844e0c2e1 100644
+index 1a7a11d49..27728e2ba 100644
 --- a/mm/Makefile
 +++ b/mm/Makefile
 @@ -148,3 +148,4 @@ obj-$(CONFIG_SHRINKER_DEBUG) += shrinker_debug.o
  obj-$(CONFIG_EXECMEM) += execmem.o
  obj-$(CONFIG_TMPFS_QUOTA) += shmem_quota.o
  obj-$(CONFIG_PT_RECLAIM) += pt_reclaim.o
-+obj-y += prfile.o
++obj-$(CONFIG_AUFS_FS:m=y) += prfile.o
 diff --git a/mm/filemap.c b/mm/filemap.c
 index bada249b9..661211f75 100644
 --- a/mm/filemap.c
@@ -40072,7 +38514,7 @@ index bada249b9..661211f75 100644
  	if (folio->mapping != mapping) {
  		folio_unlock(folio);
 diff --git a/mm/mmap.c b/mm/mmap.c
-index 09c563c95..fca540d42 100644
+index 09c563c95..670327a26 100644
 --- a/mm/mmap.c
 +++ b/mm/mmap.c
 @@ -1098,6 +1098,7 @@ SYSCALL_DEFINE5(remap_file_pages, unsigned long, start, unsigned long, size,
@@ -40115,7 +38557,7 @@ index 09c563c95..fca540d42 100644
  
  	ret = do_mmap(vma->vm_file, start, size,
  			prot, flags, 0, pgoff, &populate, NULL);
-+#if 1 /* IS_ENABLED(CONFIG_AUFS_FS) */
++#if IS_ENABLED(CONFIG_AUFS_FS)
 +	if (!IS_ERR_VALUE(ret) && file && prfile) {
 +		struct vm_area_struct *new_vma;
 +
@@ -40344,74 +38786,3 @@ index 8e53c7943..13fb5979c 100644
  	dest->vm_private_data = src->vm_private_data;
  	vm_flags_init(dest, src->vm_flags);
  	memcpy(&dest->vm_page_prot, &src->vm_page_prot,
-diff --git a/security/security.c b/security/security.c
-index 596d41818..19fd676e5 100644
---- a/security/security.c
-+++ b/security/security.c
-@@ -1948,6 +1948,7 @@ int security_path_rmdir(const struct path *dir, struct dentry *dentry)
- 		return 0;
- 	return call_int_hook(path_rmdir, dir, dentry);
- }
-+EXPORT_SYMBOL_GPL(security_path_rmdir);
- 
- /**
-  * security_path_unlink() - Check if removing a hard link is allowed
-@@ -1983,6 +1984,7 @@ int security_path_symlink(const struct path *dir, struct dentry *dentry,
- 		return 0;
- 	return call_int_hook(path_symlink, dir, dentry, old_name);
- }
-+EXPORT_SYMBOL_GPL(security_path_symlink);
- 
- /**
-  * security_path_link - Check if creating a hard link is allowed
-@@ -2001,6 +2003,7 @@ int security_path_link(struct dentry *old_dentry, const struct path *new_dir,
- 		return 0;
- 	return call_int_hook(path_link, old_dentry, new_dir, new_dentry);
- }
-+EXPORT_SYMBOL_GPL(security_path_link);
- 
- /**
-  * security_path_rename() - Check if renaming a file is allowed
-@@ -2062,6 +2065,7 @@ int security_path_chmod(const struct path *path, umode_t mode)
- 		return 0;
- 	return call_int_hook(path_chmod, path, mode);
- }
-+EXPORT_SYMBOL_GPL(security_path_chmod);
- 
- /**
-  * security_path_chown() - Check if changing the file's owner/group is allowed
-@@ -2079,6 +2083,7 @@ int security_path_chown(const struct path *path, kuid_t uid, kgid_t gid)
- 		return 0;
- 	return call_int_hook(path_chown, path, uid, gid);
- }
-+EXPORT_SYMBOL_GPL(security_path_chown);
- 
- /**
-  * security_path_chroot() - Check if changing the root directory is allowed
-@@ -2323,6 +2328,7 @@ int security_inode_permission(struct inode *inode, int mask)
- 		return 0;
- 	return call_int_hook(inode_permission, inode, mask);
- }
-+EXPORT_SYMBOL_GPL(security_inode_permission);
- 
- /**
-  * security_inode_setattr() - Check if setting file attributes is allowed
-@@ -2843,6 +2849,7 @@ int security_file_permission(struct file *file, int mask)
- {
- 	return call_int_hook(file_permission, file, mask);
- }
-+EXPORT_SYMBOL_GPL(security_file_permission);
- 
- /**
-  * security_file_alloc() - Allocate and init a file's LSM blob
-@@ -3145,6 +3152,7 @@ int security_file_truncate(struct file *file)
- {
- 	return call_int_hook(file_truncate, file);
- }
-+EXPORT_SYMBOL_GPL(security_file_truncate);
- 
- /**
-  * security_task_alloc() - Allocate a task's LSM blob
--- 
-2.49.0
-

--- a/6.16/misc/0001-aufs-6.16-merge-v20250821.patch
+++ b/6.16/misc/0001-aufs-6.16-merge-v20250821.patch
@@ -1,6 +1,6 @@
-From 08f224d4f9350f82d4342fe4872d79e11436c381 Mon Sep 17 00:00:00 2001
-From: Yang Kun <193369907+nukyan@users.noreply.github.com>
-Date: Thu, 21 Aug 2025 12:22:29 +0800
+From eaf8e257242bed3903a9d50f73a943ac9fadc046 Mon Sep 17 00:00:00 2001
+From: Piotr Gorski <lucjan.lucjanov@gmail.com>
+Date: Mon, 16 Jun 2025 15:29:18 +0200
 Subject: [PATCH] aufs-6.16: merge v20250821
 
 ---
@@ -2009,7 +2009,7 @@ index c0b444e5f..65367aa97 100644
  M:	Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  R:	Dave Ertman <david.m.ertman@intel.com>
 diff --git a/drivers/block/loop.c b/drivers/block/loop.c
-index 8d994cae3..f4fbdf6c6 100644
+index 1b6ee91f8..55eab3561 100644
 --- a/drivers/block/loop.c
 +++ b/drivers/block/loop.c
 @@ -620,6 +620,26 @@ static int loop_change_fd(struct loop_device *lo, struct block_device *bdev,
@@ -37815,7 +37815,7 @@ index c6e7ebc63..d7ccfd909 100644
  		ino = inode->i_ino;
  	}
 diff --git a/fs/proc/task_mmu.c b/fs/proc/task_mmu.c
-index 751479eb1..7f26002f4 100644
+index 0102ab3aa..8bf4e4888 100644
 --- a/fs/proc/task_mmu.c
 +++ b/fs/proc/task_mmu.c
 @@ -264,7 +264,8 @@ static void get_vma_name(struct vm_area_struct *vma,
@@ -37838,7 +37838,7 @@ index 751479eb1..7f26002f4 100644
  
  		dev = inode->i_sb->s_dev;
  		ino = inode->i_ino;
-@@ -3037,7 +3039,7 @@ static int show_numa_map(struct seq_file *m, void *v)
+@@ -3041,7 +3043,7 @@ static int show_numa_map(struct seq_file *m, void *v)
  	struct proc_maps_private *proc_priv = &numa_priv->proc_maps;
  	struct vm_area_struct *vma = v;
  	struct numa_maps *md = &numa_priv->md;

--- a/6.16/misc/0001-handheld.patch
+++ b/6.16/misc/0001-handheld.patch
@@ -1,4 +1,4 @@
-From c4cb2e06f2d72fb591e90cdde3e6a1c410585d6e Mon Sep 17 00:00:00 2001
+From 37e4cd88fce798622a137f9b5c85e2ed3f09de35 Mon Sep 17 00:00:00 2001
 From: Eric Naim <dnaim@cachyos.org>
 Date: Mon, 28 Jul 2025 13:41:37 +0700
 Subject: [PATCH] handheld
@@ -111,7 +111,7 @@ Signed-off-by: Eric Naim <dnaim@cachyos.org>
 
 diff --git a/Documentation/wmi/devices/lenovo-wmi-gamezone.rst b/Documentation/wmi/devices/lenovo-wmi-gamezone.rst
 new file mode 100644
-index 000000000000..997263e51a7d
+index 000000000..997263e51
 --- /dev/null
 +++ b/Documentation/wmi/devices/lenovo-wmi-gamezone.rst
 @@ -0,0 +1,203 @@
@@ -320,7 +320,7 @@ index 000000000000..997263e51a7d
 +  };
 diff --git a/Documentation/wmi/devices/lenovo-wmi-other.rst b/Documentation/wmi/devices/lenovo-wmi-other.rst
 new file mode 100644
-index 000000000000..d7928b8dfb4b
+index 000000000..d7928b8df
 --- /dev/null
 +++ b/Documentation/wmi/devices/lenovo-wmi-other.rst
 @@ -0,0 +1,108 @@
@@ -433,7 +433,7 @@ index 000000000000..d7928b8dfb4b
 +    [WmiDataId(4), read, Description("Default Value"), WmiSizeIs("DataSize")] uint8 DefaultValue[];
 +  };
 diff --git a/Documentation/wmi/devices/msi-wmi-platform.rst b/Documentation/wmi/devices/msi-wmi-platform.rst
-index 73197b31926a..704bfdac5203 100644
+index 73197b319..704bfdac5 100644
 --- a/Documentation/wmi/devices/msi-wmi-platform.rst
 +++ b/Documentation/wmi/devices/msi-wmi-platform.rst
 @@ -169,6 +169,32 @@ The fan RPM readings can be calculated with the following formula:
@@ -470,7 +470,7 @@ index 73197b31926a..704bfdac5203 100644
  --------------------
  
 diff --git a/MAINTAINERS b/MAINTAINERS
-index c0b444e5fd5a..0e4095c91bd8 100644
+index c0b444e5f..0e4095c91 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
 @@ -13676,12 +13676,35 @@ S:	Maintained
@@ -510,7 +510,7 @@ index c0b444e5fd5a..0e4095c91bd8 100644
  M:	Hans de Goede <hansg@kernel.org>
  L:	linux-input@vger.kernel.org
 diff --git a/drivers/bus/mhi/host/boot.c b/drivers/bus/mhi/host/boot.c
-index efa3b6dddf4d..bc8459798bbe 100644
+index efa3b6ddd..bc8459798 100644
 --- a/drivers/bus/mhi/host/boot.c
 +++ b/drivers/bus/mhi/host/boot.c
 @@ -584,10 +584,17 @@ void mhi_fw_load_handler(struct mhi_controller *mhi_cntrl)
@@ -536,7 +536,7 @@ index efa3b6dddf4d..bc8459798bbe 100644
  
  		/* Load the firmware into BHIE vec table */
 diff --git a/drivers/bus/mhi/host/init.c b/drivers/bus/mhi/host/init.c
-index 13e7a55f54ff..8419ea8a5419 100644
+index 13e7a55f5..8419ea8a5 100644
 --- a/drivers/bus/mhi/host/init.c
 +++ b/drivers/bus/mhi/host/init.c
 @@ -1173,8 +1173,9 @@ int mhi_prepare_for_power_up(struct mhi_controller *mhi_cntrl)
@@ -579,7 +579,7 @@ index 13e7a55f54ff..8419ea8a5419 100644
  EXPORT_SYMBOL_GPL(mhi_unprepare_after_power_down);
  
 diff --git a/drivers/bus/mhi/host/internal.h b/drivers/bus/mhi/host/internal.h
-index ce566f7d2e92..41b3fb835880 100644
+index ce566f7d2..41b3fb835 100644
 --- a/drivers/bus/mhi/host/internal.h
 +++ b/drivers/bus/mhi/host/internal.h
 @@ -427,4 +427,6 @@ void mhi_unmap_single_no_bb(struct mhi_controller *mhi_cntrl,
@@ -590,7 +590,7 @@ index ce566f7d2e92..41b3fb835880 100644
 +
  #endif /* _MHI_INT_H */
 diff --git a/drivers/bus/mhi/host/pm.c b/drivers/bus/mhi/host/pm.c
-index 33d92bf2fc3e..c9640c8be5bc 100644
+index 33d92bf2f..c9640c8be 100644
 --- a/drivers/bus/mhi/host/pm.c
 +++ b/drivers/bus/mhi/host/pm.c
 @@ -1263,6 +1263,7 @@ void mhi_power_down_keep_dev(struct mhi_controller *mhi_cntrl,
@@ -602,7 +602,7 @@ index 33d92bf2fc3e..c9640c8be5bc 100644
  EXPORT_SYMBOL_GPL(mhi_power_down_keep_dev);
  
 diff --git a/drivers/extcon/Kconfig b/drivers/extcon/Kconfig
-index a6f6d467aacf..4adec844c4b4 100644
+index a6f6d467a..4adec844c 100644
 --- a/drivers/extcon/Kconfig
 +++ b/drivers/extcon/Kconfig
 @@ -214,4 +214,11 @@ config EXTCON_RTK_TYPE_C
@@ -618,7 +618,7 @@ index a6f6d467aacf..4adec844c4b4 100644
 +
  endif
 diff --git a/drivers/extcon/Makefile b/drivers/extcon/Makefile
-index 0d6d23faf748..6eb613e0bcba 100644
+index 0d6d23faf..6eb613e0b 100644
 --- a/drivers/extcon/Makefile
 +++ b/drivers/extcon/Makefile
 @@ -27,3 +27,4 @@ obj-$(CONFIG_EXTCON_USB_GPIO)	+= extcon-usb-gpio.o
@@ -628,7 +628,7 @@ index 0d6d23faf748..6eb613e0bcba 100644
 +obj-$(CONFIG_EXTCON_STEAMDECK)  += extcon-steamdeck.o
 diff --git a/drivers/extcon/extcon-steamdeck.c b/drivers/extcon/extcon-steamdeck.c
 new file mode 100644
-index 000000000000..49cb5d30bf6b
+index 000000000..49cb5d30b
 --- /dev/null
 +++ b/drivers/extcon/extcon-steamdeck.c
 @@ -0,0 +1,180 @@
@@ -813,7 +813,7 @@ index 000000000000..49cb5d30bf6b
 +MODULE_DESCRIPTION("Steam Deck extcon driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h b/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
-index 6da4f946cac0..5b639276939d 100644
+index 6da4f946c..5b6392769 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h
 @@ -435,8 +435,6 @@ struct amdgpu_mode_info {
@@ -826,7 +826,7 @@ index 6da4f946cac0..5b639276939d 100644
  	struct amdgpu_encoder *encoder;
  	uint8_t negative;
 diff --git a/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c b/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
-index a51f3414b65d..bc0f9759c5c5 100644
+index a51f3414b..bc0f9759c 100644
 --- a/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
 +++ b/drivers/gpu/drm/amd/amdgpu/atombios_encoders.c
 @@ -39,6 +39,10 @@
@@ -861,7 +861,7 @@ index a51f3414b65d..bc0f9759c5c5 100644
  	snprintf(bl_name, sizeof(bl_name),
  		 "amdgpu_bl%d", dev->primary->index);
 diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
-index 3a39877bd790..5cc6a82fb32e 100644
+index ccdf030d4..705ff6429 100644
 --- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
 +++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
 @@ -168,6 +168,9 @@ MODULE_FIRMWARE(FIRMWARE_DCN_401_DMUB);
@@ -874,7 +874,7 @@ index 3a39877bd790..5cc6a82fb32e 100644
  /**
   * DOC: overview
   *
-@@ -9249,7 +9252,7 @@ static void amdgpu_dm_commit_planes(struct drm_atomic_state *state,
+@@ -9261,7 +9264,7 @@ static void amdgpu_dm_commit_planes(struct drm_atomic_state *state,
  	int planes_count = 0, vpos, hpos;
  	unsigned long flags;
  	u32 target_vblank, last_flip_vblank;
@@ -884,7 +884,7 @@ index 3a39877bd790..5cc6a82fb32e 100644
  	bool pflip_present = false;
  	bool dirty_rects_changed = false;
 diff --git a/drivers/gpu/drm/amd/display/dc/dc.h b/drivers/gpu/drm/amd/display/dc/dc.h
-index f41073c0147e..0091a34af917 100644
+index f41073c01..0091a34af 100644
 --- a/drivers/gpu/drm/amd/display/dc/dc.h
 +++ b/drivers/gpu/drm/amd/display/dc/dc.h
 @@ -58,7 +58,7 @@ struct dmub_notification;
@@ -897,7 +897,7 @@ index f41073c0147e..0091a34af917 100644
   * MAX_PLANES - representative of the upper bound of planes that are supported by the HW
   */
 diff --git a/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c b/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
-index 38e17b1796e1..bde89b8e98c8 100644
+index 38e17b179..bde89b8e9 100644
 --- a/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
 +++ b/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
 @@ -96,6 +96,8 @@
@@ -924,7 +924,7 @@ index 38e17b1796e1..bde89b8e98c8 100644
  	/*
  	 * Add the logic to extract BOTH power up and power down sequences
 diff --git a/drivers/gpu/drm/amd/display/dc/link/link_validation.c b/drivers/gpu/drm/amd/display/dc/link/link_validation.c
-index 29606fda029d..ff127f8a405b 100644
+index 29606fda0..ff127f8a4 100644
 --- a/drivers/gpu/drm/amd/display/dc/link/link_validation.c
 +++ b/drivers/gpu/drm/amd/display/dc/link/link_validation.c
 @@ -35,6 +35,8 @@
@@ -953,7 +953,7 @@ index 29606fda029d..ff127f8a405b 100644
  
  	/* TODO: DYNAMIC_VALIDATION needs to be implemented */
 diff --git a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
-index 121a86a59833..60ab2e3a5921 100644
+index 121a86a59..60ab2e3a5 100644
 --- a/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
 +++ b/drivers/gpu/drm/amd/display/dc/resource/dcn301/dcn301_resource.c
 @@ -1437,9 +1437,9 @@ static bool dcn301_resource_construct(
@@ -970,7 +970,7 @@ index 121a86a59833..60ab2e3a5921 100644
  	dc->caps.post_blend_color_processing = true;
  	dc->caps.force_dp_tps4_for_cp2520 = true;
 diff --git a/drivers/gpu/drm/drm_panel_orientation_quirks.c b/drivers/gpu/drm/drm_panel_orientation_quirks.c
-index 7ac0fd5391fe..323dd636352b 100644
+index 7ac0fd539..323dd6363 100644
 --- a/drivers/gpu/drm/drm_panel_orientation_quirks.c
 +++ b/drivers/gpu/drm/drm_panel_orientation_quirks.c
 @@ -485,6 +485,42 @@ static const struct dmi_system_id orientation_data[] = {
@@ -1017,10 +1017,10 @@ index 7ac0fd5391fe..323dd636352b 100644
  		.matches = {
  		  DMI_EXACT_MATCH(DMI_SYS_VENDOR, "OrangePi"),
 diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
-index 1c63bd5e8f5d..b316989d1daa 100644
+index 1c2522d95..1c81b0f26 100644
 --- a/drivers/hid/Kconfig
 +++ b/drivers/hid/Kconfig
-@@ -1419,6 +1419,10 @@ config HID_KUNIT_TEST
+@@ -1428,6 +1428,10 @@ config HID_KUNIT_TEST
  
  	  If in doubt, say "N".
  
@@ -1031,7 +1031,7 @@ index 1c63bd5e8f5d..b316989d1daa 100644
  endmenu
  
  source "drivers/hid/bpf/Kconfig"
-@@ -1445,4 +1449,8 @@ source "drivers/hid/spi-hid/Kconfig"
+@@ -1452,4 +1456,8 @@ source "drivers/hid/spi-hid/Kconfig"
  
  source "drivers/hid/dockchannel-hid/Kconfig"
  
@@ -1041,19 +1041,19 @@ index 1c63bd5e8f5d..b316989d1daa 100644
 +
  endif # HID_SUPPORT
 diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
-index a0f58475434c..6cafb07c7181 100644
+index f67db3d5d..ba29a3b6e 100644
 --- a/drivers/hid/Makefile
 +++ b/drivers/hid/Makefile
-@@ -174,6 +174,8 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
+@@ -173,6 +173,8 @@ obj-$(CONFIG_INTEL_ISH_HID)	+= intel-ish-hid/
  
- obj-$(CONFIG_ASUS_ALLY_HID)  += asus-ally-hid/
+ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
  
 +obj-$(CONFIG_ZOTAC_ZONE_HID)  += zotac-zone-hid/
 +
  obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
  
  obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
-@@ -181,3 +183,7 @@ obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
+@@ -180,3 +182,7 @@ obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
  obj-$(CONFIG_SPI_HID_APPLE_CORE)	+= spi-hid/
  
  obj-$(CONFIG_HID_DOCKCHANNEL)   += dockchannel-hid/
@@ -1062,10 +1062,10 @@ index a0f58475434c..6cafb07c7181 100644
 +
 +obj-$(CONFIG_LENOVO_LEGOS_HID)  += lenovo-legos-hid/
 diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
-index 1b3099685ba0..3c34b230bfb4 100644
+index cd6c1cc7d..36d840677 100644
 --- a/drivers/hid/hid-core.c
 +++ b/drivers/hid/hid-core.c
-@@ -2854,6 +2854,17 @@ static int hid_uevent(const struct device *dev, struct kobj_uevent_env *env)
+@@ -2858,6 +2858,17 @@ static int hid_uevent(const struct device *dev, struct kobj_uevent_env *env)
  	if (add_uevent_var(env, "MODALIAS=hid:b%04Xg%04Xv%08Xp%08X",
  			   hdev->bus, hdev->group, hdev->vendor, hdev->product))
  		return -ENOMEM;
@@ -1084,7 +1084,7 @@ index 1b3099685ba0..3c34b230bfb4 100644
  	return 0;
  }
 diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
-index bc2fba4e7a4d..25e674f6e850 100644
+index bc2fba4e7..25e674f6e 100644
 --- a/drivers/hid/hid-ids.h
 +++ b/drivers/hid/hid-ids.h
 @@ -724,6 +724,10 @@
@@ -1118,7 +1118,7 @@ index bc2fba4e7a4d..25e674f6e850 100644
  #define USB_DEVICE_ID_PRIMAX_MOUSE_4D22	0x4d22
  #define USB_DEVICE_ID_PRIMAX_MOUSE_4E2A	0x4e2a
 diff --git a/drivers/hid/hid-input.c b/drivers/hid/hid-input.c
-index ff1784b5c2a4..0bf4346e3cf3 100644
+index ff1784b5c..0bf4346e3 100644
 --- a/drivers/hid/hid-input.c
 +++ b/drivers/hid/hid-input.c
 @@ -390,6 +390,8 @@ static const struct hid_device_id hid_battery_quirks[] = {
@@ -1132,7 +1132,7 @@ index ff1784b5c2a4..0bf4346e3cf3 100644
  
 diff --git a/drivers/hid/hid-msi-claw.c b/drivers/hid/hid-msi-claw.c
 new file mode 100644
-index 000000000000..2d009bc5f85b
+index 000000000..2d009bc5f
 --- /dev/null
 +++ b/drivers/hid/hid-msi-claw.c
 @@ -0,0 +1,484 @@
@@ -1622,7 +1622,7 @@ index 000000000000..2d009bc5f85b
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/lenovo-legos-hid/Kconfig b/drivers/hid/lenovo-legos-hid/Kconfig
 new file mode 100644
-index 000000000000..6918b25e191c
+index 000000000..6918b25e1
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/Kconfig
 @@ -0,0 +1,11 @@
@@ -1639,7 +1639,7 @@ index 000000000000..6918b25e191c
 +	  be called lenovo-legos-hid.
 diff --git a/drivers/hid/lenovo-legos-hid/Makefile b/drivers/hid/lenovo-legos-hid/Makefile
 new file mode 100644
-index 000000000000..e346f70f78ae
+index 000000000..e346f70f7
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/Makefile
 @@ -0,0 +1,6 @@
@@ -1651,7 +1651,7 @@ index 000000000000..e346f70f78ae
 +obj-$(CONFIG_LENOVO_LEGOS_HID)	:= lenovo-legos-hid.o
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.c b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.c
 new file mode 100644
-index 000000000000..7a42cf5bfd2b
+index 000000000..7a42cf5bf
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.c
 @@ -0,0 +1,1571 @@
@@ -3228,7 +3228,7 @@ index 000000000000..7a42cf5bfd2b
 +}
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.h b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.h
 new file mode 100644
-index 000000000000..3d13744e2692
+index 000000000..3d13744e2
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-config.h
 @@ -0,0 +1,19 @@
@@ -3253,7 +3253,7 @@ index 000000000000..3d13744e2692
 +#endif /* !_LENOVO_LEGOS_HID_CONFIG_*/
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.c b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.c
 new file mode 100644
-index 000000000000..751f4addabd8
+index 000000000..751f4adda
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.c
 @@ -0,0 +1,122 @@
@@ -3381,7 +3381,7 @@ index 000000000000..751f4addabd8
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.h b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.h
 new file mode 100644
-index 000000000000..efbc50896536
+index 000000000..efbc50896
 --- /dev/null
 +++ b/drivers/hid/lenovo-legos-hid/lenovo-legos-hid-core.h
 @@ -0,0 +1,25 @@
@@ -3412,7 +3412,7 @@ index 000000000000..efbc50896536
 +#endif /* !_LENOVO_LEGOS_HID_CORE_*/
 diff --git a/drivers/hid/zotac-zone-hid/Kconfig b/drivers/hid/zotac-zone-hid/Kconfig
 new file mode 100644
-index 000000000000..89fb2ac080bb
+index 000000000..89fb2ac08
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/Kconfig
 @@ -0,0 +1,8 @@
@@ -3426,7 +3426,7 @@ index 000000000000..89fb2ac080bb
 +	Support for the Zotac Zone handheld gaming console.
 diff --git a/drivers/hid/zotac-zone-hid/Makefile b/drivers/hid/zotac-zone-hid/Makefile
 new file mode 100644
-index 000000000000..2f7053b981ac
+index 000000000..2f7053b98
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/Makefile
 @@ -0,0 +1,6 @@
@@ -3438,7 +3438,7 @@ index 000000000000..2f7053b981ac
 +obj-$(CONFIG_ZOTAC_ZONE_HID) := zotac-zone-hid.o
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-config.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-config.c
 new file mode 100644
-index 000000000000..049615194392
+index 000000000..049615194
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-config.c
 @@ -0,0 +1,2231 @@
@@ -5675,7 +5675,7 @@ index 000000000000..049615194392
 +}
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-core.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-core.c
 new file mode 100644
-index 000000000000..6f80ea2f9aad
+index 000000000..6f80ea2f9
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-core.c
 @@ -0,0 +1,597 @@
@@ -6278,7 +6278,7 @@ index 000000000000..6f80ea2f9aad
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-input.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-input.c
 new file mode 100644
-index 000000000000..571eec2df446
+index 000000000..571eec2df
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-input.c
 @@ -0,0 +1,522 @@
@@ -6806,7 +6806,7 @@ index 000000000000..571eec2df446
 +}
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone-hid-rgb.c b/drivers/hid/zotac-zone-hid/zotac-zone-hid-rgb.c
 new file mode 100644
-index 000000000000..0305de2bd549
+index 000000000..0305de2bd
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone-hid-rgb.c
 @@ -0,0 +1,717 @@
@@ -7529,7 +7529,7 @@ index 000000000000..0305de2bd549
 +}
 diff --git a/drivers/hid/zotac-zone-hid/zotac-zone.h b/drivers/hid/zotac-zone-hid/zotac-zone.h
 new file mode 100644
-index 000000000000..31188cee80f8
+index 000000000..31188cee8
 --- /dev/null
 +++ b/drivers/hid/zotac-zone-hid/zotac-zone.h
 @@ -0,0 +1,214 @@
@@ -7748,7 +7748,7 @@ index 000000000000..31188cee80f8
 +
 +#endif /* __HID_ZOTAC_ZONE_H */
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
-index 079620dd4286..c8269ad241c5 100644
+index 079620dd4..c8269ad24 100644
 --- a/drivers/hwmon/Kconfig
 +++ b/drivers/hwmon/Kconfig
 @@ -2118,6 +2118,17 @@ config SENSORS_SCH5636
@@ -7770,7 +7770,7 @@ index 079620dd4286..c8269ad241c5 100644
  	tristate "ST Microelectronics STTS751"
  	depends on I2C
 diff --git a/drivers/hwmon/Makefile b/drivers/hwmon/Makefile
-index 48e5866c0c9a..223147b5c964 100644
+index 48e5866c0..223147b5c 100644
 --- a/drivers/hwmon/Makefile
 +++ b/drivers/hwmon/Makefile
 @@ -214,6 +214,7 @@ obj-$(CONFIG_SENSORS_SMSC47B397)+= smsc47b397.o
@@ -7783,7 +7783,7 @@ index 48e5866c0c9a..223147b5c964 100644
  obj-$(CONFIG_SENSORS_SURFACE_FAN)+= surface_fan.o
 diff --git a/drivers/hwmon/steamdeck-hwmon.c b/drivers/hwmon/steamdeck-hwmon.c
 new file mode 100644
-index 000000000000..9d0a5471b181
+index 000000000..9d0a5471b
 --- /dev/null
 +++ b/drivers/hwmon/steamdeck-hwmon.c
 @@ -0,0 +1,294 @@
@@ -8082,7 +8082,7 @@ index 000000000000..9d0a5471b181
 +MODULE_DESCRIPTION("Steam Deck EC sensors driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/input/joystick/xpad.c b/drivers/input/joystick/xpad.c
-index 1d8c579b5433..89d320dfda87 100644
+index 1d8c579b5..89d320dfd 100644
 --- a/drivers/input/joystick/xpad.c
 +++ b/drivers/input/joystick/xpad.c
 @@ -357,7 +357,9 @@ static const struct xpad_device {
@@ -8106,7 +8106,7 @@ index 1d8c579b5433..89d320dfda87 100644
  	XPAD_XBOXONE_VENDOR(0x20d6),		/* PowerA controllers */
  	XPAD_XBOX360_VENDOR(0x2345),		/* Machenike Controllers */
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
-index 6e3dce7e35a4..531daa275634 100644
+index 6e3dce7e3..531daa275 100644
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
 @@ -1020,6 +1020,13 @@ config LEDS_ACER_A500
@@ -8124,7 +8124,7 @@ index 6e3dce7e35a4..531daa275634 100644
  
  comment "Flash and Torch LED drivers"
 diff --git a/drivers/leds/Makefile b/drivers/leds/Makefile
-index 9a0333ec1a86..e93fa6d6d2b9 100644
+index 9a0333ec1..e93fa6d6d 100644
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
 @@ -86,6 +86,7 @@ obj-$(CONFIG_LEDS_QNAP_MCU)		+= leds-qnap-mcu.o
@@ -8137,7 +8137,7 @@ index 9a0333ec1a86..e93fa6d6d2b9 100644
  obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
 diff --git a/drivers/leds/leds-steamdeck.c b/drivers/leds/leds-steamdeck.c
 new file mode 100644
-index 000000000000..3d56ec4403cd
+index 000000000..3d56ec440
 --- /dev/null
 +++ b/drivers/leds/leds-steamdeck.c
 @@ -0,0 +1,123 @@
@@ -8265,7 +8265,7 @@ index 000000000000..3d56ec4403cd
 +MODULE_DESCRIPTION("Steam Deck LEDs driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/mfd/Kconfig b/drivers/mfd/Kconfig
-index 6fb3768e3d71..8a3d0f75c4c5 100644
+index 6fb3768e3..8a3d0f75c 100644
 --- a/drivers/mfd/Kconfig
 +++ b/drivers/mfd/Kconfig
 @@ -2463,5 +2463,16 @@ config MFD_UPBOARD_FPGA
@@ -8286,7 +8286,7 @@ index 6fb3768e3d71..8a3d0f75c4c5 100644
  endmenu
  endif
 diff --git a/drivers/mfd/Makefile b/drivers/mfd/Makefile
-index 79495f9f3457..d4afa76d37a7 100644
+index 79495f9f3..d4afa76d3 100644
 --- a/drivers/mfd/Makefile
 +++ b/drivers/mfd/Makefile
 @@ -293,4 +293,6 @@ obj-$(CONFIG_MFD_QNAP_MCU)	+= qnap-mcu.o
@@ -8298,7 +8298,7 @@ index 79495f9f3457..d4afa76d37a7 100644
  obj-$(CONFIG_MFD_UPBOARD_FPGA)	+= upboard-fpga.o
 diff --git a/drivers/mfd/steamdeck.c b/drivers/mfd/steamdeck.c
 new file mode 100644
-index 000000000000..a60fa7db9141
+index 000000000..a60fa7db9
 --- /dev/null
 +++ b/drivers/mfd/steamdeck.c
 @@ -0,0 +1,147 @@
@@ -8450,7 +8450,7 @@ index 000000000000..a60fa7db9141
 +MODULE_DESCRIPTION("Steam Deck EC MFD core driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/net/wireless/ath/ath11k/core.c b/drivers/net/wireless/ath/ath11k/core.c
-index 22a101136135..05f970016acf 100644
+index 22a101136..05f970016 100644
 --- a/drivers/net/wireless/ath/ath11k/core.c
 +++ b/drivers/net/wireless/ath/ath11k/core.c
 @@ -732,7 +732,7 @@ static const struct ath11k_hw_params ath11k_hw_params[] = {
@@ -8463,7 +8463,7 @@ index 22a101136135..05f970016acf 100644
  			.cal_offset = 128 * 1024,
  		},
 diff --git a/drivers/net/wireless/ath/ath11k/mhi.c b/drivers/net/wireless/ath/ath11k/mhi.c
-index acd76e9392d3..c5dc776b2364 100644
+index acd76e939..c5dc776b2 100644
 --- a/drivers/net/wireless/ath/ath11k/mhi.c
 +++ b/drivers/net/wireless/ath/ath11k/mhi.c
 @@ -460,12 +460,12 @@ void ath11k_mhi_stop(struct ath11k_pci *ab_pci, bool is_suspend)
@@ -8484,7 +8484,7 @@ index acd76e9392d3..c5dc776b2364 100644
  
  int ath11k_mhi_suspend(struct ath11k_pci *ab_pci)
 diff --git a/drivers/net/wireless/ath/ath12k/mhi.c b/drivers/net/wireless/ath/ath12k/mhi.c
-index 08f44baf182a..3af524ccf4a5 100644
+index 08f44baf1..3af524ccf 100644
 --- a/drivers/net/wireless/ath/ath12k/mhi.c
 +++ b/drivers/net/wireless/ath/ath12k/mhi.c
 @@ -601,6 +601,12 @@ static int ath12k_mhi_set_state(struct ath12k_pci *ab_pci,
@@ -8518,7 +8518,7 @@ index 08f44baf182a..3af524ccf4a5 100644
  
  void ath12k_mhi_suspend(struct ath12k_pci *ab_pci)
 diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
-index 1236303b1f17..147ae2ebe828 100644
+index 1236303b1..147ae2ebe 100644
 --- a/drivers/platform/x86/Kconfig
 +++ b/drivers/platform/x86/Kconfig
 @@ -482,6 +482,47 @@ config IBM_RTL
@@ -8599,7 +8599,7 @@ index 1236303b1f17..147ae2ebe828 100644
  
  config P2SB
 diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index 7e978fa52c2f..44b7d13f6133 100644
+index 7e978fa52..44b7d13f6 100644
 --- a/drivers/platform/x86/Makefile
 +++ b/drivers/platform/x86/Makefile
 @@ -72,6 +72,11 @@ obj-$(CONFIG_THINKPAD_LMI)	+= think-lmi.o
@@ -8624,7 +8624,7 @@ index 7e978fa52c2f..44b7d13f6133 100644
  obj-$(CONFIG_OXP_EC)			+= oxpec.o
 diff --git a/drivers/platform/x86/lenovo-wmi-capdata01.c b/drivers/platform/x86/lenovo-wmi-capdata01.c
 new file mode 100644
-index 000000000000..2bd862a75c71
+index 000000000..2bd862a75
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-capdata01.c
 @@ -0,0 +1,302 @@
@@ -8932,7 +8932,7 @@ index 000000000000..2bd862a75c71
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-capdata01.h b/drivers/platform/x86/lenovo-wmi-capdata01.h
 new file mode 100644
-index 000000000000..bd06c5751f68
+index 000000000..bd06c5751
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-capdata01.h
 @@ -0,0 +1,25 @@
@@ -8963,7 +8963,7 @@ index 000000000000..bd06c5751f68
 +#endif /* !_LENOVO_WMI_CAPDATA01_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-events.c b/drivers/platform/x86/lenovo-wmi-events.c
 new file mode 100644
-index 000000000000..2e0bbda5b976
+index 000000000..2e0bbda5b
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-events.c
 @@ -0,0 +1,196 @@
@@ -9165,7 +9165,7 @@ index 000000000000..2e0bbda5b976
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-events.h b/drivers/platform/x86/lenovo-wmi-events.h
 new file mode 100644
-index 000000000000..cd34e886912c
+index 000000000..cd34e8869
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-events.h
 @@ -0,0 +1,20 @@
@@ -9191,7 +9191,7 @@ index 000000000000..cd34e886912c
 +#endif /* !_LENOVO_WMI_EVENTS_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-gamezone.c b/drivers/platform/x86/lenovo-wmi-gamezone.c
 new file mode 100644
-index 000000000000..261284de22b6
+index 000000000..261284de2
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-gamezone.c
 @@ -0,0 +1,407 @@
@@ -9604,7 +9604,7 @@ index 000000000000..261284de22b6
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-gamezone.h b/drivers/platform/x86/lenovo-wmi-gamezone.h
 new file mode 100644
-index 000000000000..6b163a5eeb95
+index 000000000..6b163a5ee
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-gamezone.h
 @@ -0,0 +1,20 @@
@@ -9630,7 +9630,7 @@ index 000000000000..6b163a5eeb95
 +#endif /* !_LENOVO_WMI_GAMEZONE_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-helpers.c b/drivers/platform/x86/lenovo-wmi-helpers.c
 new file mode 100644
-index 000000000000..4a194aad1ed0
+index 000000000..4a194aad1
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-helpers.c
 @@ -0,0 +1,74 @@
@@ -9710,7 +9710,7 @@ index 000000000000..4a194aad1ed0
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-helpers.h b/drivers/platform/x86/lenovo-wmi-helpers.h
 new file mode 100644
-index 000000000000..20fd21749803
+index 000000000..20fd21749
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-helpers.h
 @@ -0,0 +1,20 @@
@@ -9736,7 +9736,7 @@ index 000000000000..20fd21749803
 +#endif /* !_LENOVO_WMI_HELPERS_H_ */
 diff --git a/drivers/platform/x86/lenovo-wmi-other.c b/drivers/platform/x86/lenovo-wmi-other.c
 new file mode 100644
-index 000000000000..299fc87189ec
+index 000000000..299fc8718
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-other.c
 @@ -0,0 +1,665 @@
@@ -10407,7 +10407,7 @@ index 000000000000..299fc87189ec
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/platform/x86/lenovo-wmi-other.h b/drivers/platform/x86/lenovo-wmi-other.h
 new file mode 100644
-index 000000000000..8ebf5602bb99
+index 000000000..8ebf5602b
 --- /dev/null
 +++ b/drivers/platform/x86/lenovo-wmi-other.h
 @@ -0,0 +1,16 @@
@@ -10428,7 +10428,7 @@ index 000000000000..8ebf5602bb99
 +
 +#endif /* !_LENOVO_WMI_OTHER_H_ */
 diff --git a/drivers/platform/x86/msi-wmi-platform.c b/drivers/platform/x86/msi-wmi-platform.c
-index dc5e9878cb68..b00b2b52e0f2 100644
+index dc5e9878c..b00b2b52e 100644
 --- a/drivers/platform/x86/msi-wmi-platform.c
 +++ b/drivers/platform/x86/msi-wmi-platform.c
 @@ -1,8 +1,9 @@
@@ -11840,7 +11840,7 @@ index dc5e9878cb68..b00b2b52e0f2 100644
  module_wmi_driver(msi_wmi_platform_driver);
 diff --git a/drivers/platform/x86/zotac-zone-platform.c b/drivers/platform/x86/zotac-zone-platform.c
 new file mode 100644
-index 000000000000..d097f7b9c5a0
+index 000000000..d097f7b9c
 --- /dev/null
 +++ b/drivers/platform/x86/zotac-zone-platform.c
 @@ -0,0 +1,1122 @@
@@ -12967,7 +12967,7 @@ index 000000000000..d097f7b9c5a0
 +MODULE_DESCRIPTION("Zotac Handheld Platform Driver");
 +MODULE_LICENSE("GPL");
 diff --git a/drivers/usb/usbip/vhci_hcd.c b/drivers/usb/usbip/vhci_hcd.c
-index e70fba9f55d6..7297d790b664 100644
+index e70fba9f5..7297d790b 100644
 --- a/drivers/usb/usbip/vhci_hcd.c
 +++ b/drivers/usb/usbip/vhci_hcd.c
 @@ -765,6 +765,7 @@ static int vhci_urb_enqueue(struct usb_hcd *hcd, struct urb *urb, gfp_t mem_flag
@@ -13035,7 +13035,7 @@ index e70fba9f55d6..7297d790b664 100644
  
  static int vhci_hcd_resume(struct platform_device *pdev)
 diff --git a/drivers/video/backlight/backlight.c b/drivers/video/backlight/backlight.c
-index 9dc93c5e480b..05d5800c9756 100644
+index 9dc93c5e4..05d5800c9 100644
 --- a/drivers/video/backlight/backlight.c
 +++ b/drivers/video/backlight/backlight.c
 @@ -115,6 +115,7 @@ EXPORT_SYMBOL(backlight_notify_blank_all);
@@ -13055,7 +13055,7 @@ index 9dc93c5e480b..05d5800c9756 100644
  }
  
 diff --git a/include/linux/hid.h b/include/linux/hid.h
-index 7b1ee43d984b..1d6f1d8ac81a 100644
+index 0075b9956..8cc380ef0 100644
 --- a/include/linux/hid.h
 +++ b/include/linux/hid.h
 @@ -669,6 +669,7 @@ struct hid_device {
@@ -13075,7 +13075,7 @@ index 7b1ee43d984b..1d6f1d8ac81a 100644
  	/* debugging support via debugfs */
  	unsigned short debug;
 diff --git a/include/linux/mhi.h b/include/linux/mhi.h
-index dd372b0123a6..6fd218a87785 100644
+index dd372b012..6fd218a87 100644
 --- a/include/linux/mhi.h
 +++ b/include/linux/mhi.h
 @@ -306,6 +306,7 @@ struct mhi_controller_config {
@@ -13095,7 +13095,7 @@ index dd372b0123a6..6fd218a87785 100644
  	size_t rddm_size;
  	size_t sbl_size;
 diff --git a/sound/soc/amd/acp/acp-mach.h b/sound/soc/amd/acp/acp-mach.h
-index f94c30c20f20..c3b3f047969c 100644
+index f94c30c20..c3b3f0479 100644
 --- a/sound/soc/amd/acp/acp-mach.h
 +++ b/sound/soc/amd/acp/acp-mach.h
 @@ -29,8 +29,8 @@
@@ -13109,7 +13109,7 @@ index f94c30c20f20..c3b3f047969c 100644
  
  enum cpu_endpoints {
 diff --git a/sound/soc/codecs/max98388.c b/sound/soc/codecs/max98388.c
-index 99986090b4a6..e259be44ce8f 100644
+index 99986090b..e259be44c 100644
 --- a/sound/soc/codecs/max98388.c
 +++ b/sound/soc/codecs/max98388.c
 @@ -390,27 +390,43 @@ static void max98388_reset(struct max98388_priv *max98388, struct device *dev)
@@ -13190,6 +13190,3 @@ index 99986090b4a6..e259be44ce8f 100644
  	regcache_sync(max98388->regmap);
  
  	return 0;
--- 
-2.50.1
-


### PR DESCRIPTION
This PR intended to

for 6.15:
- Sync patches with 6.15.11 source tree
- Update BORE scheduler to 6.4.0
- Update ADIOS scheduler to 2.5.4
- Update v4l2loopback to 0.5.1
- Update AUFS to latest
- Update ASUS patch
- Pick up 6.16/0003-block.patch
- Backport changes in [drivers/hid/amd-sfh-hid/*](https://github.com/CachyOS/kernel-patches/blob/28e3bd8b232005a81775697a734e93bdb0f339c7/6.16/0004-cachy.patch#L2356-L2450) to 6.15

for 6.16:
- Refresh `6.16/misc/0001-handheld.patch`
- Update AUFS to latest

The ASUS patch is just taken from 6.16. `drivers/platform/x86/asus-wmi.c` and `include/linux/platform_data/x86/asus-wmi.h` were failed to apply so I copied them from 6.16.2 source tree with `6.16/0001-asus.patch` applied. I'm not sure it's ok but I've tested `asus_wmi` and `asus-armoury`, they both works fine on my TUF Gaming laptop.