### PR TITLE
6.18: Add Chrontel CH7218 to the VRR PCON whitelist patch

### DIFF
--- a/6.18/misc/0001-amdgpu-Add-CH7218-PCON-to-the-VRR-whitelist.patch
+++ b/6.18/misc/0001-amdgpu-Add-CH7218-PCON-to-the-VRR-whitelist.patch
@@ -1,0 +1,45 @@
+From 941725c67e25021a4321cf21eed4a69048526b1e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Tomasz=20Paku=C5=82a?= <forest10pl@gmail.com>
+Date: Tue, 9 Dec 2025 14:38:45 +0100
+Subject: [PATCH] amdgpu: Add CH7218 PCON to the VRR whitelist
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Chrontel CH7218 found in Ugreen DP -> HDMI 2.1 adapter (model 85564)
+works perfectly with VRR after testing. VRR and FreeSync compatibility
+is explicitly advertised as a feature so it's addition is a formality.
+
+Signed-off-by: Tomasz Pakuła <tomasz.pakula.oficjalny@gmail.com>
+---
+ drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c | 1 +
+ drivers/gpu/drm/amd/display/include/ddc_service_types.h   | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
+index d0f770dd0a95..f01f30a245ad 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm_helpers.c
+@@ -1374,6 +1374,7 @@ static bool dm_is_freesync_pcon_whitelist(const uint32_t branch_dev_id)
+ 	case DP_BRANCH_DEVICE_ID_0060AD:
+ 	case DP_BRANCH_DEVICE_ID_00E04C:
+ 	case DP_BRANCH_DEVICE_ID_90CC24:
++	case DP_BRANCH_DEVICE_ID_2B02F0:
+ 		ret_val = true;
+ 		break;
+ 	default:
+diff --git a/drivers/gpu/drm/amd/display/include/ddc_service_types.h b/drivers/gpu/drm/amd/display/include/ddc_service_types.h
+index 1c603b12957f..e838f7c1269c 100644
+--- a/drivers/gpu/drm/amd/display/include/ddc_service_types.h
++++ b/drivers/gpu/drm/amd/display/include/ddc_service_types.h
+@@ -36,6 +36,7 @@
+ #define DP_BRANCH_DEVICE_ID_006037 0x006037
+ #define DP_BRANCH_DEVICE_ID_001CF8 0x001CF8
+ #define DP_BRANCH_DEVICE_ID_0060AD 0x0060AD
++#define DP_BRANCH_DEVICE_ID_2B02F0 0x2B02F0 /* Chrontel CH7218 */
+ #define DP_BRANCH_HW_REV_10 0x10
+ #define DP_BRANCH_HW_REV_20 0x20
+ 
+-- 
+2.52.0
+


### PR DESCRIPTION
On behalf of Tomasz Pakuła <tomasz.pakula.oficjalny@gmail.com> (https://www.reddit.com/r/linux_gaming/comments/1pkdfcm/comment/ntq8mgx/), this patch enables VRR support on the [Ugreen DP 1.4 to HDMI 2.1 adapter (model 85564, DP134)](https://amzn.eu/d/7VneOi3) by adding it to the VRR PCON whitelist.
That adapter allows full 4K 120Hz 4:4:4 with VRR with AMD under Linux.

See the related merge request at gitlab.freedesktop.org or the following reddit post for additional information:
https://gitlab.freedesktop.org/drm/amd/-/issues/4773
https://www.reddit.com/r/linux_gaming/comments/1pkdfcm/comment/ntq8mgx/