### PR TITLE
6.12: fix cpufreq_schedutil compatibility

### DIFF
--- a/6.12/sched/0001-prjc-cachy.patch
+++ b/6.12/sched/0001-prjc-cachy.patch
@@ -10107,7 +10107,7 @@ index c6ba15388ea7..56590821f074 100644
  {
 +#ifndef CONFIG_SCHED_ALT
  	if (cpu_bw_dl(cpu_rq(sg_cpu->cpu)) > sg_cpu->bw_min)
- 		sg_cpu->sg_policy->limits_changed = true;
+ 		WRITE_ONCE(sg_cpu->sg_policy->limits_changed, true);
 +#endif
  }
  


### PR DESCRIPTION
Kernel 6.12.52+ changed sg_cpu->sg_policy->limits_changed assignment to use WRITE_ONCE() for proper memory ordering.

Update the BMQ scheduler patch to match this change:
- sg_cpu->sg_policy->limits_changed = true;
+ WRITE_ONCE(sg_cpu->sg_policy->limits_changed, true);

Without this fix, BMQ scheduler fails to build on kernel 6.12.52+.

Tested in Gentoo repo with multi-versions: https://github.com/Szowisz/CachyOS-kernels/blob/8424c1c560cf672896e51e1e90017484426ebc75/sys-kernel/cachyos-sources/cachyos-sources-6.12.63.ebuild#L124