### PR TITLE
6.12: fix prjc patch for 6.12.65+

### DIFF
--- a/6.12/sched/0001-prjc-cachy.patch
+++ b/6.12/sched/0001-prjc-cachy.patch
@@ -10513,14 +10513,15 @@ diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
 index c5d6012794de..6d6f57395907 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -5,6 +5,10 @@
+@@ -5,7 +5,11 @@
  #ifndef _KERNEL_SCHED_SCHED_H
  #define _KERNEL_SCHED_SCHED_H
- 
+
 +#ifdef CONFIG_SCHED_ALT
 +#include "alt_sched.h"
 +#else
 +
+ #include <linux/prandom.h>
  #include <linux/sched/affinity.h>
  #include <linux/sched/autogroup.h>
  #include <linux/sched/cpufreq.h>


### PR DESCRIPTION
Add #include <linux/prandom.h> to sched.h context since it was added in kernel 6.12.65.