### PR TITLE
Fix makefile errors

### DIFF
--- a/6.19/misc/0001-acpi-call.patch
+++ b/6.19/misc/0001-acpi-call.patch
@@ -27,13 +27,6 @@ index 7e9251fc33416..3474a825983c5 100644
  config ACER_WMI
  	tristate "Acer WMI Laptop Extras"
  	depends on BACKLIGHT_CLASS_DEVICE
-diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
-index 1de432e8861ea..6381ff71ab919 100644
---- a/drivers/platform/x86/Makefile
-+++ b/drivers/platform/x86/Makefile
-@@ -4,10 +4,14 @@
- # x86 Platform-Specific Drivers
- #
  
 +# ACPI calls
 +


### PR DESCRIPTION
When I tried to build Kernel 6.19 from Fedora Copr, I found that a certain patch in this Makefile conflicted with the Makefile on Kernel.org. The problem was resolved after removing the patch related to /drivers/platform/x86/Makefile.