### PR TITLE
media: cx231xx: Fix Elgato Video Capture V2 default norm for PAL regions

### DIFF
--- a/6.19/misc/0001-cx231xx-elgato-v2-fix-pal-norm.patch
+++ b/6.19/misc/0001-cx231xx-elgato-v2-fix-pal-norm.patch
@@ -1,0 +1,12 @@
+```
+--- a/drivers/media/usb/cx231xx/cx231xx-cards.c
++++ b/drivers/media/usb/cx231xx/cx231xx-cards.c
+@@ -637,7 +637,7 @@
+ 		.ctl_pin_status_mask = 0xFFFFFFC4,
+ 		.agc_analog_digital_select_gpio = 0x0c,
+ 		.gpio_pin_status_mask = 0x4001000,
+-		.norm = V4L2_STD_NTSC,
++		.norm = V4L2_STD_PAL,
+ 		.no_alt_vanc = 1,
+ 		.external_av = 1,
+ 		.input = {{


### PR DESCRIPTION
The Elgato Video Capture V2 (card=16) has its default norm hardcoded to V4L2_STD_NTSC, causing rainbow-coloured scrambled image for users in PAL regions even when PAL is set via v4l2-ctl at runtime. Change the default norm to V4L2_STD_PAL to fix this. Tested on CachyOS with a JVC HR-J758 VCR in Norway.