### PR TITLE
6.18/fix: handheld patch failed to apply after linux 6.18.22

### DIFF
--- a/6.18/misc/0001-handheld.patch
+++ b/6.18/misc/0001-handheld.patch
@@ -11531,9 +11531,9 @@ index 363d50949386..0944f058b1e6 100644
 +	#if !IS_REACHABLE(CONFIG_ZOTAC_ZONE_HID)
  	{ 0x1ee9, 0x1590, "ZOTAC Gaming Zone", 0, XTYPE_XBOX360 },
 +	#endif /* !IS_REACHABLE(CONFIG_ZOTAC_ZONE_HID) */
+ 	{ 0x20bc, 0x5134, "BETOP BTP-KP50B Xinput Dongle", 0, XTYPE_XBOX360 },
+ 	{ 0x20bc, 0x514a, "BETOP BTP-KP50C Xinput Dongle", 0, XTYPE_XBOX360 },
  	{ 0x20d6, 0x2001, "BDA Xbox Series X Wired Controller", 0, XTYPE_XBOXONE },
- 	{ 0x20d6, 0x2009, "PowerA Enhanced Wired Controller for Xbox Series X|S", 0, XTYPE_XBOXONE },
- 	{ 0x20d6, 0x2064, "PowerA Wired Controller for Xbox", MAP_SHARE_BUTTON, XTYPE_XBOXONE },
 @@ -561,7 +563,9 @@ static const struct usb_device_id xpad_table[] = {
  	XPAD_XBOX360_VENDOR(0x1949),		/* Amazon controllers */
  	XPAD_XBOX360_VENDOR(0x1a86),		/* Nanjing Qinheng Microelectronics (WCH) */
@@ -11541,9 +11541,9 @@ index 363d50949386..0944f058b1e6 100644
 +	#if !IS_REACHABLE(CONFIG_ZOTAC_ZONE_HID)
  	XPAD_XBOX360_VENDOR(0x1ee9),		/* ZOTAC Technology Limited */
 +	#endif /* !IS_REACHABLE(CONFIG_ZOTAC_ZONE_HID) */
+ 	XPAD_XBOX360_VENDOR(0x20bc),		/* BETOP wireless dongles */
  	XPAD_XBOX360_VENDOR(0x20d6),		/* PowerA controllers */
  	XPAD_XBOXONE_VENDOR(0x20d6),		/* PowerA controllers */
- 	XPAD_XBOX360_VENDOR(0x2345),		/* Machenike Controllers */
 diff --git a/drivers/leds/Kconfig b/drivers/leds/Kconfig
 index 06e6291be11b..75a2e8bac4b7 100644
 --- a/drivers/leds/Kconfig


### PR DESCRIPTION
There are multiple areas where this patch should have applied code changes that do not match the 6.18.22 kernel for CachyOS, so I modified manually to make it apply successfully.
Could developer apply this PR? Thanks 🌹