### PR TITLE
Added iowrite8 patch to t2 patch

### DIFF
--- a/6.16/0006-t2.patch
+++ b/6.16/0006-t2.patch
@@ -4741,8 +4741,8 @@ index fc6d6a9053ce..698f44794453 100644
 +
 +	iomem_clear_status(smc);
 +	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
-+	iowrite32(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
-+	iowrite32(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
 +
 +	if (iomem_wait_read(smc))
 +		return -EIO;
@@ -4784,8 +4784,8 @@ index fc6d6a9053ce..698f44794453 100644
 +
 +	iomem_clear_status(smc);
 +	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
-+	iowrite32(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
-+	iowrite32(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
 +
 +	if (iomem_wait_read(smc))
 +		return -EIO;
@@ -4815,9 +4815,9 @@ index fc6d6a9053ce..698f44794453 100644
 +	iomem_clear_status(smc);
 +	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
 +	memcpy_toio(smc->iomem_base + APPLESMC_IOMEM_KEY_DATA, buffer, len);
-+	iowrite32(len, smc->iomem_base + APPLESMC_IOMEM_KEY_DATA_LEN);
-+	iowrite32(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
-+	iowrite32(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	iowrite8(len, smc->iomem_base + APPLESMC_IOMEM_KEY_DATA_LEN);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
 +
 +	if (iomem_wait_read(smc))
 +		return -EIO;
@@ -12957,4 +12957,3 @@ index 000000000000..0b7093935ddf
 +#endif
 -- 
 2.51.2
-

--- a/7.0/Files
+++ b/7.0/Files
@@ -7,6 +7,7 @@
 │   ├── 0001-clang-polly.patch
 │   ├── 0001-handheld.patch
 │   ├── 0001-rt-i915.patch
+│   ├── 0006-t2.patch
 │   ├── dkms-clang.patch
 │   └── nvidia
 │       ├── 0001-Enable-atomic-kernel-modesetting-by-default.patch
@@ -22,4 +23,4 @@
     ├── 0001-prjc-cachy.patch
     └── 0001-prjc.patch
 
-4 directories, 19 files
+4 directories, 20 files

--- a/7.0/misc/0006-t2.patch
+++ b/7.0/misc/0006-t2.patch
@@ -1,0 +1,12960 @@
+From 114321639a24a75f524e9d8032ac45cecf2b89ca Mon Sep 17 00:00:00 2001
+From: Peter Jung <admin@ptr1337.dev>
+Date: Fri, 5 Sep 2025 16:46:52 +0200
+Subject: [PATCH 6/6] t2
+
+Signed-off-by: Peter Jung <admin@ptr1337.dev>
+---
+ drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c       |    3 +
+ drivers/gpu/drm/i915/display/intel_ddi.c      |    3 +
+ drivers/gpu/drm/i915/display/intel_fbdev.c    |    6 +-
+ drivers/gpu/drm/i915/display/intel_quirks.c   |   15 +
+ drivers/gpu/drm/i915/display/intel_quirks.h   |    1 +
+ drivers/gpu/vga/vga_switcheroo.c              |    7 +-
+ drivers/hid/Kconfig                           |   11 +-
+ drivers/hid/Makefile                          |    4 +
+ drivers/hid/dockchannel-hid/Kconfig           |   14 +
+ drivers/hid/dockchannel-hid/Makefile          |    6 +
+ drivers/hid/dockchannel-hid/dockchannel-hid.c | 1213 +++++++++++++++++
+ drivers/hid/hid-apple.c                       |   62 +-
+ drivers/hid/hid-core.c                        |   11 +-
+ drivers/hid/hid-ids.h                         |   25 +-
+ drivers/hid/hid-magicmouse.c                  |  924 +++++++++++--
+ drivers/hid/hid-multitouch.c                  |   17 +
+ drivers/hid/hid-quirks.c                      |    9 +-
+ drivers/hid/spi-hid/Kconfig                   |   26 +
+ drivers/hid/spi-hid/Makefile                  |   10 +
+ drivers/hid/spi-hid/spi-hid-apple-core.c      | 1194 ++++++++++++++++
+ drivers/hid/spi-hid/spi-hid-apple-of.c        |  151 ++
+ drivers/hid/spi-hid/spi-hid-apple.h           |   35 +
+ drivers/hwmon/applesmc.c                      | 1138 ++++++++++++----
+ drivers/pci/vgaarb.c                          |    1 +
+ drivers/platform/x86/apple-gmux.c             |   18 +
+ drivers/soc/apple/Kconfig                     |   24 +
+ drivers/soc/apple/Makefile                    |    6 +
+ drivers/soc/apple/dockchannel.c               |  406 ++++++
+ drivers/soc/apple/rtkit-helper.c              |  151 ++
+ drivers/staging/Kconfig                       |    2 +
+ drivers/staging/Makefile                      |    1 +
+ drivers/staging/apple-bce/Kconfig             |   18 +
+ drivers/staging/apple-bce/Makefile            |   28 +
+ drivers/staging/apple-bce/apple_bce.c         |  445 ++++++
+ drivers/staging/apple-bce/apple_bce.h         |   41 +
+ drivers/staging/apple-bce/audio/audio.c       |  711 ++++++++++
+ drivers/staging/apple-bce/audio/audio.h       |  125 ++
+ drivers/staging/apple-bce/audio/description.h |   42 +
+ drivers/staging/apple-bce/audio/pcm.c         |  308 +++++
+ drivers/staging/apple-bce/audio/pcm.h         |   16 +
+ drivers/staging/apple-bce/audio/protocol.c    |  347 +++++
+ drivers/staging/apple-bce/audio/protocol.h    |  147 ++
+ .../staging/apple-bce/audio/protocol_bce.c    |  226 +++
+ .../staging/apple-bce/audio/protocol_bce.h    |   72 +
+ drivers/staging/apple-bce/mailbox.c           |  155 +++
+ drivers/staging/apple-bce/mailbox.h           |   53 +
+ drivers/staging/apple-bce/queue.c             |  390 ++++++
+ drivers/staging/apple-bce/queue.h             |  177 +++
+ drivers/staging/apple-bce/queue_dma.c         |  220 +++
+ drivers/staging/apple-bce/queue_dma.h         |   50 +
+ drivers/staging/apple-bce/vhci/command.h      |  204 +++
+ drivers/staging/apple-bce/vhci/queue.c        |  268 ++++
+ drivers/staging/apple-bce/vhci/queue.h        |   76 ++
+ drivers/staging/apple-bce/vhci/transfer.c     |  673 +++++++++
+ drivers/staging/apple-bce/vhci/transfer.h     |   75 +
+ drivers/staging/apple-bce/vhci/vhci.c         |  763 +++++++++++
+ drivers/staging/apple-bce/vhci/vhci.h         |   52 +
+ include/linux/hid.h                           |    6 +-
+ include/linux/soc/apple/dockchannel.h         |   26 +
+ 59 files changed, 10755 insertions(+), 453 deletions(-)
+ create mode 100644 drivers/hid/dockchannel-hid/Kconfig
+ create mode 100644 drivers/hid/dockchannel-hid/Makefile
+ create mode 100644 drivers/hid/dockchannel-hid/dockchannel-hid.c
+ create mode 100644 drivers/hid/spi-hid/Kconfig
+ create mode 100644 drivers/hid/spi-hid/Makefile
+ create mode 100644 drivers/hid/spi-hid/spi-hid-apple-core.c
+ create mode 100644 drivers/hid/spi-hid/spi-hid-apple-of.c
+ create mode 100644 drivers/hid/spi-hid/spi-hid-apple.h
+ create mode 100644 drivers/soc/apple/dockchannel.c
+ create mode 100644 drivers/soc/apple/rtkit-helper.c
+ create mode 100644 drivers/staging/apple-bce/Kconfig
+ create mode 100644 drivers/staging/apple-bce/Makefile
+ create mode 100644 drivers/staging/apple-bce/apple_bce.c
+ create mode 100644 drivers/staging/apple-bce/apple_bce.h
+ create mode 100644 drivers/staging/apple-bce/audio/audio.c
+ create mode 100644 drivers/staging/apple-bce/audio/audio.h
+ create mode 100644 drivers/staging/apple-bce/audio/description.h
+ create mode 100644 drivers/staging/apple-bce/audio/pcm.c
+ create mode 100644 drivers/staging/apple-bce/audio/pcm.h
+ create mode 100644 drivers/staging/apple-bce/audio/protocol.c
+ create mode 100644 drivers/staging/apple-bce/audio/protocol.h
+ create mode 100644 drivers/staging/apple-bce/audio/protocol_bce.c
+ create mode 100644 drivers/staging/apple-bce/audio/protocol_bce.h
+ create mode 100644 drivers/staging/apple-bce/mailbox.c
+ create mode 100644 drivers/staging/apple-bce/mailbox.h
+ create mode 100644 drivers/staging/apple-bce/queue.c
+ create mode 100644 drivers/staging/apple-bce/queue.h
+ create mode 100644 drivers/staging/apple-bce/queue_dma.c
+ create mode 100644 drivers/staging/apple-bce/queue_dma.h
+ create mode 100644 drivers/staging/apple-bce/vhci/command.h
+ create mode 100644 drivers/staging/apple-bce/vhci/queue.c
+ create mode 100644 drivers/staging/apple-bce/vhci/queue.h
+ create mode 100644 drivers/staging/apple-bce/vhci/transfer.c
+ create mode 100644 drivers/staging/apple-bce/vhci/transfer.h
+ create mode 100644 drivers/staging/apple-bce/vhci/vhci.c
+ create mode 100644 drivers/staging/apple-bce/vhci/vhci.h
+ create mode 100644 include/linux/soc/apple/dockchannel.h
+
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+index a5db963da610..90d83b721ed3 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+@@ -2315,6 +2315,9 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,
+ 	int ret, retry = 0, i;
+ 	bool supports_atomic = false;
+ 
++	if (vga_switcheroo_client_probe_defer(pdev))
++		return -EPROBE_DEFER;
++
+ 	if ((pdev->class >> 8) == PCI_CLASS_DISPLAY_VGA ||
+ 	    (pdev->class >> 8) == PCI_CLASS_DISPLAY_OTHER) {
+ 		if (drm_firmware_drivers_only() && amdgpu_modeset == -1)
+diff --git a/drivers/gpu/drm/i915/display/intel_ddi.c b/drivers/gpu/drm/i915/display/intel_ddi.c
+index 55b8bfcf364a..6ef943d770eb 100644
+--- a/drivers/gpu/drm/i915/display/intel_ddi.c
++++ b/drivers/gpu/drm/i915/display/intel_ddi.c
+@@ -4833,6 +4833,9 @@ static bool intel_ddi_a_force_4_lanes(struct intel_digital_port *dig_port)
+ 	if (dig_port->ddi_a_4_lanes)
+ 		return false;
+ 
++	if (intel_has_quirk(display, QUIRK_DDI_A_FORCE_4_LANES))
++		return true;
++
+ 	/* Broxton/Geminilake: Bspec says that DDI_A_4_LANES is the only
+ 	 *                     supported configuration
+ 	 */
+diff --git a/drivers/gpu/drm/i915/display/intel_fbdev.c b/drivers/gpu/drm/i915/display/intel_fbdev.c
+index 2dc4029d71ed..eaa82801ef01 100644
+--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
++++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
+@@ -224,10 +224,10 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
+ 	ifbdev->fb = NULL;
+ 
+ 	if (fb &&
+-	    (sizes->fb_width > fb->base.width ||
+-	     sizes->fb_height > fb->base.height)) {
++	    (sizes->fb_width != fb->base.width ||
++	     sizes->fb_height != fb->base.height)) {
+ 		drm_dbg_kms(display->drm,
+-			    "BIOS fb too small (%dx%d), we require (%dx%d),"
++			    "BIOS fb not valid (%dx%d), we require (%dx%d),"
+ 			    " releasing it\n",
+ 			    fb->base.width, fb->base.height,
+ 			    sizes->fb_width, sizes->fb_height);
+diff --git a/drivers/gpu/drm/i915/display/intel_quirks.c b/drivers/gpu/drm/i915/display/intel_quirks.c
+index a32fae510ed2..662465733ddb 100644
+--- a/drivers/gpu/drm/i915/display/intel_quirks.c
++++ b/drivers/gpu/drm/i915/display/intel_quirks.c
+@@ -66,6 +66,18 @@ static void quirk_increase_ddi_disabled_time(struct intel_display *display)
+ 	drm_info(display->drm, "Applying Increase DDI Disabled quirk\n");
+ }
+ 
++/*
++ * In some cases, the firmware might not set the lane count to 4 (for example,
++ * when booting in some dual GPU Macs with the dGPU as the default GPU), this
++ * quirk is used to force it as otherwise it might not be possible to compute a
++ * valid link configuration.
++ */
++static void quirk_ddi_a_force_4_lanes(struct intel_display *display)
++{
++	intel_set_quirk(display, QUIRK_DDI_A_FORCE_4_LANES);
++	drm_info(display->drm, "Applying DDI A Forced 4 Lanes quirk\n");
++}
++
+ static void quirk_no_pps_backlight_power_hook(struct intel_display *display)
+ {
+ 	intel_set_quirk(display, QUIRK_NO_PPS_BACKLIGHT_POWER_HOOK);
+@@ -231,6 +243,9 @@ static struct intel_quirk intel_quirks[] = {
+ 	{ 0x3184, 0x1019, 0xa94d, quirk_increase_ddi_disabled_time },
+ 	/* HP Notebook - 14-r206nv */
+ 	{ 0x0f31, 0x103c, 0x220f, quirk_invert_brightness },
++
++	/* Apple MacBookPro15,1 */
++	{ 0x3e9b, 0x106b, 0x0176, quirk_ddi_a_force_4_lanes },
+ };
+ 
+ static const struct intel_dpcd_quirk intel_dpcd_quirks[] = {
+diff --git a/drivers/gpu/drm/i915/display/intel_quirks.h b/drivers/gpu/drm/i915/display/intel_quirks.h
+index cafdebda7535..a5296f82776e 100644
+--- a/drivers/gpu/drm/i915/display/intel_quirks.h
++++ b/drivers/gpu/drm/i915/display/intel_quirks.h
+@@ -20,6 +20,7 @@ enum intel_quirk_id {
+ 	QUIRK_LVDS_SSC_DISABLE,
+ 	QUIRK_NO_PPS_BACKLIGHT_POWER_HOOK,
+ 	QUIRK_FW_SYNC_LEN,
++	QUIRK_DDI_A_FORCE_4_LANES,
+ };
+ 
+ void intel_init_quirks(struct intel_display *display);
+diff --git a/drivers/gpu/vga/vga_switcheroo.c b/drivers/gpu/vga/vga_switcheroo.c
+index 18f2c92beff8..3de1bca45ed2 100644
+--- a/drivers/gpu/vga/vga_switcheroo.c
++++ b/drivers/gpu/vga/vga_switcheroo.c
+@@ -438,12 +438,7 @@ find_active_client(struct list_head *head)
+ bool vga_switcheroo_client_probe_defer(struct pci_dev *pdev)
+ {
+ 	if ((pdev->class >> 16) == PCI_BASE_CLASS_DISPLAY) {
+-		/*
+-		 * apple-gmux is needed on pre-retina MacBook Pro
+-		 * to probe the panel if pdev is the inactive GPU.
+-		 */
+-		if (apple_gmux_present() && pdev != vga_default_device() &&
+-		    !vgasr_priv.handler_flags)
++		if (apple_gmux_present() && !vgasr_priv.handler_flags)
+ 			return true;
+ 	}
+ 
+diff --git a/drivers/hid/Kconfig b/drivers/hid/Kconfig
+index 2524e55a1096..e2fb06ecea1f 100644
+--- a/drivers/hid/Kconfig
++++ b/drivers/hid/Kconfig
+@@ -129,7 +129,7 @@ config HID_APPLE
+ 	tristate "Apple {i,Power,Mac}Books"
+ 	depends on LEDS_CLASS
+ 	depends on NEW_LEDS
+-	default !EXPERT
++	default !EXPERT || SPI_HID_APPLE
+ 	help
+ 	Support for some Apple devices which less or more break
+ 	HID specification.
+@@ -726,11 +726,13 @@ config LOGIWHEELS_FF
+ 
+ config HID_MAGICMOUSE
+ 	tristate "Apple Magic Mouse/Trackpad multi-touch support"
++	default SPI_HID_APPLE
+ 	help
+ 	Support for the Apple Magic Mouse/Trackpad multi-touch.
+ 
+ 	Say Y here if you want support for the multi-touch features of the
+-	Apple Wireless "Magic" Mouse and the Apple Wireless "Magic" Trackpad.
++	Apple Wireless "Magic" Mouse, the Apple Wireless "Magic" Trackpad and
++	force touch Trackpads in Macbooks starting from 2015.
+ 
+ config HID_MALTRON
+ 	tristate "Maltron L90 keyboard"
+@@ -780,6 +782,7 @@ config HID_MULTITOUCH
+ 	  Say Y here if you have one of the following devices:
+ 	  - 3M PCT touch screens
+ 	  - ActionStar dual touch panels
++	  - Apple Touch Bar on x86 MacBook Pros
+ 	  - Atmel panels
+ 	  - Cando dual touch panels
+ 	  - Chunghwa panels
+@@ -1444,4 +1447,8 @@ endif # HID
+ 
+ source "drivers/hid/usbhid/Kconfig"
+ 
++source "drivers/hid/spi-hid/Kconfig"
++
++source "drivers/hid/dockchannel-hid/Kconfig"
++
+ endif # HID_SUPPORT
+diff --git a/drivers/hid/Makefile b/drivers/hid/Makefile
+index 958f67193c85..f67db3d5d18f 100644
+--- a/drivers/hid/Makefile
++++ b/drivers/hid/Makefile
+@@ -176,3 +176,7 @@ obj-$(CONFIG_AMD_SFH_HID)       += amd-sfh-hid/
+ obj-$(CONFIG_SURFACE_HID_CORE)  += surface-hid/
+ 
+ obj-$(CONFIG_INTEL_THC_HID)     += intel-thc-hid/
++
++obj-$(CONFIG_SPI_HID_APPLE_CORE)	+= spi-hid/
++
++obj-$(CONFIG_HID_DOCKCHANNEL)   += dockchannel-hid/
+diff --git a/drivers/hid/dockchannel-hid/Kconfig b/drivers/hid/dockchannel-hid/Kconfig
+new file mode 100644
+index 000000000000..8a81d551a83d
+--- /dev/null
++++ b/drivers/hid/dockchannel-hid/Kconfig
+@@ -0,0 +1,14 @@
++# SPDX-License-Identifier: GPL-2.0-only OR MIT
++menu "DockChannel HID support"
++	depends on APPLE_DOCKCHANNEL
++
++config HID_DOCKCHANNEL
++	tristate "HID over DockChannel transport layer for Apple Silicon SoCs"
++	default ARCH_APPLE
++	depends on APPLE_DOCKCHANNEL && INPUT && OF && HID
++	help
++	  Say Y here if you use an M2 or later Apple Silicon based laptop.
++	  The keyboard and touchpad are HID based devices connected via the
++	  proprietary DockChannel interface.
++
++endmenu
+diff --git a/drivers/hid/dockchannel-hid/Makefile b/drivers/hid/dockchannel-hid/Makefile
+new file mode 100644
+index 000000000000..7dba766b047f
+--- /dev/null
++++ b/drivers/hid/dockchannel-hid/Makefile
+@@ -0,0 +1,6 @@
++# SPDX-License-Identifier: GPL-2.0-only OR MIT
++#
++# Makefile for DockChannel HID transport drivers
++#
++
++obj-$(CONFIG_HID_DOCKCHANNEL)	+= dockchannel-hid.o
+diff --git a/drivers/hid/dockchannel-hid/dockchannel-hid.c b/drivers/hid/dockchannel-hid/dockchannel-hid.c
+new file mode 100644
+index 000000000000..a712a724ded3
+--- /dev/null
++++ b/drivers/hid/dockchannel-hid/dockchannel-hid.c
+@@ -0,0 +1,1213 @@
++/*
++ * SPDX-License-Identifier: GPL-2.0 OR MIT
++ *
++ * Apple DockChannel HID transport driver
++ *
++ * Copyright The Asahi Linux Contributors
++ */
++#include <linux/bitfield.h>
++#include <linux/delay.h>
++#include <linux/device.h>
++#include <linux/dma-mapping.h>
++#include <linux/firmware.h>
++#include <linux/gpio/consumer.h>
++#include <linux/hid.h>
++#include <linux/platform_device.h>
++#include <linux/slab.h>
++#include <linux/soc/apple/dockchannel.h>
++#include <linux/string.h>
++#include <linux/unaligned.h>
++#include <linux/of.h>
++#include "../hid-ids.h"
++
++#define COMMAND_TIMEOUT_MS 1000
++#define START_TIMEOUT_MS 2000
++
++#define MAX_INTERFACES 16
++
++/* Data + checksum */
++#define MAX_PKT_SIZE (0xffff + 4)
++
++#define DCHID_CHANNEL_CMD 0x11
++#define DCHID_CHANNEL_REPORT 0x12
++
++struct dchid_hdr {
++	u8 hdr_len;
++	u8 channel;
++	u16 length;
++	u8 seq;
++	u8 iface;
++	u16 pad;
++} __packed;
++
++#define IFACE_COMM 0
++
++#define FLAGS_GROUP GENMASK(7, 6)
++#define FLAGS_REQ GENMASK(5, 0)
++
++#define REQ_SET_REPORT 0
++#define REQ_GET_REPORT 1
++
++struct dchid_subhdr {
++	u8 flags;
++	u8 unk;
++	u16 length;
++	u32 retcode;
++} __packed;
++
++#define EVENT_GPIO_CMD	0xa0
++#define EVENT_INIT	0xf0
++#define EVENT_READY	0xf1
++
++struct dchid_init_hdr {
++	u8 type;
++	u8 unk1;
++	u8 unk2;
++	u8 iface;
++	char name[16];
++	u8 more_packets;
++	u8 unkpad;
++} __packed;
++
++#define INIT_HID_DESCRIPTOR	0
++#define INIT_GPIO_REQUEST	1
++#define INIT_TERMINATOR		2
++#define INIT_PRODUCT_NAME	7
++
++#define CMD_RESET_INTERFACE 0x40
++#define CMD_SEND_FIRMWARE 0x95
++#define CMD_ENABLE_INTERFACE 0xb4
++#define CMD_ACK_GPIO_CMD 0xa1
++
++struct dchid_init_block_hdr {
++	u16 type;
++	u16 length;
++} __packed;
++
++#define MAX_GPIO_NAME 32
++
++struct dchid_gpio_request {
++	u16 unk;
++	u16 id;
++	char name[MAX_GPIO_NAME];
++} __packed;
++
++struct dchid_gpio_cmd {
++	u8 type;
++	u8 iface;
++	u8 gpio;
++	u8 unk;
++	u8 cmd;
++} __packed;
++
++struct dchid_gpio_ack {
++	u8 type;
++	u32 retcode;
++	u8 cmd[];
++} __packed;
++
++#define STM_REPORT_ID		0x10
++#define STM_REPORT_SERIAL	0x11
++#define STM_REPORT_KEYBTYPE	0x14
++
++struct dchid_stm_id {
++	u8 unk;
++	u16 vendor_id;
++	u16 product_id;
++	u16 version_number;
++	u8 unk2;
++	u8 unk3;
++	u8 keyboard_type;
++	u8 serial_length;
++	/* Serial follows, but we grab it with a different report. */
++} __packed;
++
++#define FW_MAGIC 0x46444948
++#define FW_VER 1
++
++struct fw_header {
++	u32 magic;
++	u32 version;
++	u32 hdr_length;
++	u32 data_length;
++	u32 iface_offset;
++} __packed;
++
++struct dchid_work {
++	struct work_struct work;
++	struct dchid_iface *iface;
++
++	struct dchid_hdr hdr;
++	u8 data[];
++};
++
++struct dchid_iface {
++	struct dockchannel_hid *dchid;
++	struct hid_device *hid;
++	struct workqueue_struct *wq;
++
++	bool creating;
++	struct work_struct create_work;
++
++	int index;
++	const char *name;
++	const struct device_node *of_node;
++
++	uint8_t tx_seq;
++	bool deferred;
++	bool starting;
++	bool open;
++	struct completion ready;
++
++	void *hid_desc;
++	size_t hid_desc_len;
++
++	struct gpio_desc *gpio;
++	char gpio_name[MAX_GPIO_NAME];
++	int gpio_id;
++
++	struct mutex out_mutex;
++	u32 out_flags;
++	int out_report;
++	u32 retcode;
++	void *resp_buf;
++	size_t resp_size;
++	struct completion out_complete;
++
++	u32 keyboard_layout_id;
++};
++
++struct dockchannel_hid {
++	struct device *dev;
++	struct dockchannel *dc;
++	struct device_link *helper_link;
++
++	bool id_ready;
++	struct dchid_stm_id device_id;
++	char serial[64];
++
++	struct dchid_iface *comm;
++	struct dchid_iface *ifaces[MAX_INTERFACES];
++
++	u8 pkt_buf[MAX_PKT_SIZE];
++
++	/* Workqueue to asynchronously create HID devices */
++	struct workqueue_struct *new_iface_wq;
++};
++
++static ssize_t apple_layout_id_show(struct device *dev,
++				       struct device_attribute *attr,
++				       char *buf)
++{
++	struct hid_device *hdev = to_hid_device(dev);
++	struct dchid_iface *iface = hdev->driver_data;
++
++	return scnprintf(buf, PAGE_SIZE, "%d\n", iface->keyboard_layout_id);
++}
++
++static DEVICE_ATTR_RO(apple_layout_id);
++
++static struct dchid_iface *
++dchid_get_interface(struct dockchannel_hid *dchid, int index, const char *name)
++{
++	struct dchid_iface *iface;
++
++	if (index >= MAX_INTERFACES) {
++		dev_err(dchid->dev, "Interface index %d out of range\n", index);
++		return NULL;
++	}
++
++	if (dchid->ifaces[index])
++		return dchid->ifaces[index];
++
++	iface = devm_kzalloc(dchid->dev, sizeof(struct dchid_iface), GFP_KERNEL);
++	if (!iface)
++		return NULL;
++
++	iface->index = index;
++	iface->name = devm_kstrdup(dchid->dev, name, GFP_KERNEL);
++	iface->dchid = dchid;
++	iface->out_report= -1;
++	init_completion(&iface->out_complete);
++	init_completion(&iface->ready);
++	mutex_init(&iface->out_mutex);
++	iface->wq = alloc_ordered_workqueue("dchid-%s", WQ_MEM_RECLAIM, iface->name);
++	if (!iface->wq)
++		return NULL;
++
++	/* Comm is not a HID subdevice */
++	if (!strcmp(name, "comm")) {
++		dchid->ifaces[index] = iface;
++		return iface;
++	}
++
++	iface->of_node = of_get_child_by_name(dchid->dev->of_node, name);
++	if (!iface->of_node) {
++		dev_warn(dchid->dev, "No OF node for subdevice %s, ignoring.", name);
++		return NULL;
++	}
++
++	dchid->ifaces[index] = iface;
++	return iface;
++}
++
++static u32 dchid_checksum(void *p, size_t length)
++{
++	u32 sum = 0;
++
++	while (length >= 4) {
++		sum += get_unaligned_le32(p);
++		p += 4;
++		length -= 4;
++	}
++
++	WARN_ON_ONCE(length);
++	return sum;
++}
++
++static int dchid_send(struct dchid_iface *iface, u32 flags, void *msg, size_t size)
++{
++	u32 checksum = 0xffffffff;
++	size_t wsize = round_down(size, 4);
++	size_t tsize = size - wsize;
++	int ret;
++	struct {
++		struct dchid_hdr hdr;
++		struct dchid_subhdr sub;
++	} __packed h;
++
++	memset(&h, 0, sizeof(h));
++	h.hdr.hdr_len = sizeof(h.hdr);
++	h.hdr.channel = DCHID_CHANNEL_CMD;
++	h.hdr.length = round_up(size, 4) + sizeof(h.sub);
++	h.hdr.seq = iface->tx_seq;
++	h.hdr.iface = iface->index;
++	h.sub.flags = flags;
++	h.sub.length = size;
++
++	ret = dockchannel_send(iface->dchid->dc, &h, sizeof(h));
++	if (ret < 0)
++		return ret;
++	checksum -= dchid_checksum(&h, sizeof(h));
++
++	ret = dockchannel_send(iface->dchid->dc, msg, wsize);
++	if (ret < 0)
++		return ret;
++	checksum -= dchid_checksum(msg, wsize);
++
++	if (tsize) {
++		u8 tail[4] = {0, 0, 0, 0};
++
++		memcpy(tail, msg + wsize, tsize);
++		ret = dockchannel_send(iface->dchid->dc, tail, sizeof(tail));
++		if (ret < 0)
++			return ret;
++		checksum -= dchid_checksum(tail, sizeof(tail));
++	}
++
++	ret = dockchannel_send(iface->dchid->dc, &checksum, sizeof(checksum));
++	if (ret < 0)
++		return ret;
++
++	return 0;
++}
++
++static int dchid_cmd(struct dchid_iface *iface, u32 type, u32 req,
++		     void *data, size_t size, void *resp_buf, size_t resp_size)
++{
++	int ret;
++	int report_id = *(u8*)data;
++
++	mutex_lock(&iface->out_mutex);
++
++	WARN_ON(iface->out_report != -1);
++	iface->out_report = report_id;
++	iface->out_flags = FIELD_PREP(FLAGS_GROUP, type) | FIELD_PREP(FLAGS_REQ, req);
++	iface->resp_buf = resp_buf;
++	iface->resp_size = resp_size;
++	reinit_completion(&iface->out_complete);
++
++	ret = dchid_send(iface, iface->out_flags, data, size);
++	if (ret < 0)
++		goto done;
++
++	if (!wait_for_completion_timeout(&iface->out_complete, msecs_to_jiffies(COMMAND_TIMEOUT_MS))) {
++		dev_err(iface->dchid->dev, "output report 0x%x to iface  %d (%s) timed out\n",
++			report_id, iface->index, iface->name);
++		ret = -ETIMEDOUT;
++		goto done;
++	}
++
++	ret = iface->resp_size;
++	if (iface->retcode) {
++		dev_err(iface->dchid->dev,
++			"output report 0x%x to iface %d (%s) failed with err 0x%x\n",
++			report_id, iface->index, iface->name, iface->retcode);
++		ret = -EIO;
++	}
++
++done:
++	iface->tx_seq++;
++	iface->out_report = -1;
++	iface->out_flags = 0;
++	iface->resp_buf = NULL;
++	iface->resp_size = 0;
++	mutex_unlock(&iface->out_mutex);
++	return ret;
++}
++
++static int dchid_comm_cmd(struct dockchannel_hid *dchid, void *cmd, size_t size)
++{
++	return dchid_cmd(dchid->comm, HID_FEATURE_REPORT, REQ_SET_REPORT, cmd, size, NULL, 0);
++}
++
++static int dchid_enable_interface(struct dchid_iface *iface)
++{
++	u8 msg[] = { CMD_ENABLE_INTERFACE, iface->index };
++
++	return dchid_comm_cmd(iface->dchid, msg, sizeof(msg));
++}
++
++static int dchid_reset_interface(struct dchid_iface *iface, int state)
++{
++	u8 msg[] = { CMD_RESET_INTERFACE, 1, iface->index, state };
++
++	return dchid_comm_cmd(iface->dchid, msg, sizeof(msg));
++}
++
++static int dchid_send_firmware(struct dchid_iface *iface, void *firmware, size_t size)
++{
++	struct {
++		u8 cmd;
++		u8 unk1;
++		u8 unk2;
++		u8 iface;
++		u64 addr;
++		u32 size;
++	} __packed msg = {
++		.cmd = CMD_SEND_FIRMWARE,
++		.unk1 = 2,
++		.unk2 = 0,
++		.iface = iface->index,
++		.size = size,
++	};
++	dma_addr_t addr;
++	void *buf = dmam_alloc_coherent(iface->dchid->dev, size, &addr, GFP_KERNEL);
++
++	if (IS_ERR_OR_NULL(buf))
++		return buf ? PTR_ERR(buf) : -ENOMEM;
++
++	msg.addr = addr;
++	memcpy(buf, firmware, size);
++	wmb();
++
++	return dchid_comm_cmd(iface->dchid, &msg, sizeof(msg));
++}
++
++static int dchid_get_firmware(struct dchid_iface *iface, void **firmware, size_t *size)
++{
++	int ret;
++	const char *fw_name;
++	const struct firmware *fw;
++	struct fw_header *hdr;
++	u8 *fw_data;
++
++	ret = of_property_read_string(iface->of_node, "firmware-name", &fw_name);
++	if (ret) {
++		/* Firmware is only for some devices */
++		*firmware = NULL;
++		*size = 0;
++		return 0;
++	}
++
++	ret = request_firmware(&fw, fw_name, iface->dchid->dev);
++	if (ret)
++		return ret;
++
++	hdr = (struct fw_header *)fw->data;
++
++	if (hdr->magic != FW_MAGIC || hdr->version != FW_VER ||
++		hdr->hdr_length < sizeof(*hdr) || hdr->hdr_length > fw->size ||
++		(hdr->hdr_length + (size_t)hdr->data_length) > fw->size ||
++		hdr->iface_offset >= hdr->data_length) {
++		dev_warn(iface->dchid->dev, "%s: invalid firmware header\n",
++			 fw_name);
++		ret = -EINVAL;
++		goto done;
++	}
++
++	fw_data = devm_kmemdup(iface->dchid->dev, fw->data + hdr->hdr_length,
++			       hdr->data_length, GFP_KERNEL);
++	if (!fw_data) {
++		ret = -ENOMEM;
++		goto done;
++	}
++
++	if (hdr->iface_offset)
++		fw_data[hdr->iface_offset] = iface->index;
++
++	*firmware = fw_data;
++	*size = hdr->data_length;
++
++done:
++	release_firmware(fw);
++	return ret;
++}
++
++static int dchid_request_gpio(struct dchid_iface *iface)
++{
++	char prop_name[MAX_GPIO_NAME + 16];
++
++	if (iface->gpio)
++		return 0;
++
++	dev_info(iface->dchid->dev, "Requesting GPIO %s#%d: %s\n",
++		 iface->name, iface->gpio_id, iface->gpio_name);
++
++	snprintf(prop_name, sizeof(prop_name), "apple,%s", iface->gpio_name);
++
++	iface->gpio = devm_gpiod_get_index(iface->dchid->dev, prop_name, 0, GPIOD_OUT_LOW);
++
++	if (IS_ERR_OR_NULL(iface->gpio)) {
++		dev_err(iface->dchid->dev, "Failed to request GPIO %s-gpios\n", prop_name);
++		iface->gpio = NULL;
++		return -1;
++	}
++
++	return 0;
++}
++
++static int dchid_start_interface(struct dchid_iface *iface)
++{
++	void *fw;
++	size_t size;
++	int ret;
++
++	if (iface->starting) {
++		dev_warn(iface->dchid->dev, "Interface %s is already starting", iface->name);
++		return -EINPROGRESS;
++	}
++
++	dev_info(iface->dchid->dev, "Starting interface %s\n", iface->name);
++
++	iface->starting = true;
++
++	/* Look to see if we need firmware */
++	ret = dchid_get_firmware(iface, &fw, &size);
++	if (ret < 0)
++		goto err;
++
++	/* If we need a GPIO, make sure we have it. */
++	if (iface->gpio_id) {
++		ret = dchid_request_gpio(iface);
++		if (ret < 0)
++			goto err;
++	}
++
++	/* Only multi-touch has firmware */
++	if (fw && size) {
++
++		/* Send firmware to the device */
++		dev_info(iface->dchid->dev, "Sending firmware for %s\n", iface->name);
++		ret = dchid_send_firmware(iface, fw, size);
++		if (ret < 0) {
++			dev_err(iface->dchid->dev, "Failed to send %s firmwareS", iface->name);
++			goto err;
++		}
++
++		/* After loading firmware, multi-touch needs a reset */
++		dev_info(iface->dchid->dev, "Resetting %s\n", iface->name);
++		dchid_reset_interface(iface, 0);
++		dchid_reset_interface(iface, 2);
++	}
++
++	return 0;
++
++err:
++	iface->starting = false;
++	return ret;
++}
++
++static int dchid_start(struct hid_device *hdev)
++{
++	struct dchid_iface *iface = hdev->driver_data;
++
++	if (iface->keyboard_layout_id) {
++		int ret = device_create_file(&hdev->dev, &dev_attr_apple_layout_id);
++		if (ret) {
++			dev_warn(iface->dchid->dev, "Failed to create apple_layout_id: %d", ret);
++			iface->keyboard_layout_id = 0;
++		}
++	}
++
++	return 0;
++};
++
++static void dchid_stop(struct hid_device *hdev)
++{
++	struct dchid_iface *iface = hdev->driver_data;
++
++	if (iface->keyboard_layout_id)
++		device_remove_file(&hdev->dev, &dev_attr_apple_layout_id);
++}
++
++static int dchid_open(struct hid_device *hdev)
++{
++	struct dchid_iface *iface = hdev->driver_data;
++	int ret;
++
++	if (!completion_done(&iface->ready)) {
++		ret = dchid_start_interface(iface);
++		if (ret < 0)
++			return ret;
++
++		if (!wait_for_completion_timeout(&iface->ready, msecs_to_jiffies(START_TIMEOUT_MS))) {
++			dev_err(iface->dchid->dev, "iface %s start timed out\n", iface->name);
++			return -ETIMEDOUT;
++		}
++	}
++
++	iface->open = true;
++	return 0;
++}
++
++static void dchid_close(struct hid_device *hdev)
++{
++	struct dchid_iface *iface = hdev->driver_data;
++
++	iface->open = false;
++}
++
++static int dchid_parse(struct hid_device *hdev)
++{
++	struct dchid_iface *iface = hdev->driver_data;
++
++	return hid_parse_report(hdev, iface->hid_desc, iface->hid_desc_len);
++}
++
++/* Note: buf excludes report number! For ease of fetching strings/etc. */
++static int dchid_get_report_cmd(struct dchid_iface *iface, u8 reportnum, void *buf, size_t len)
++{
++	int ret = dchid_cmd(iface, HID_FEATURE_REPORT, REQ_GET_REPORT, &reportnum, 1, buf, len);
++
++	return ret <= 0 ? ret : ret - 1;
++}
++
++/* Note: buf includes report number! */
++static int dchid_set_report(struct dchid_iface *iface, void *buf, size_t len)
++{
++	return dchid_cmd(iface, HID_OUTPUT_REPORT, REQ_SET_REPORT, buf, len, NULL, 0);
++}
++
++static int dchid_raw_request(struct hid_device *hdev,
++				unsigned char reportnum, __u8 *buf, size_t len,
++				unsigned char rtype, int reqtype)
++{
++	struct dchid_iface *iface = hdev->driver_data;
++
++	switch (reqtype) {
++	case HID_REQ_GET_REPORT:
++		buf[0] = reportnum;
++		return dchid_cmd(iface, rtype, REQ_GET_REPORT, &reportnum, 1, buf + 1, len - 1);
++	case HID_REQ_SET_REPORT:
++		return dchid_set_report(iface, buf, len);
++	default:
++		return -EIO;
++	}
++
++	return 0;
++}
++
++static struct hid_ll_driver dchid_ll = {
++	.start = &dchid_start,
++	.stop = &dchid_stop,
++	.open = &dchid_open,
++	.close = &dchid_close,
++	.parse = &dchid_parse,
++	.raw_request = &dchid_raw_request,
++};
++
++static void dchid_create_interface_work(struct work_struct *ws)
++{
++	struct dchid_iface *iface = container_of(ws, struct dchid_iface, create_work);
++	struct dockchannel_hid *dchid = iface->dchid;
++	struct hid_device *hid;
++	int ret;
++
++	if (iface->hid) {
++		dev_warn(dchid->dev, "Interface %s already created!\n",
++			 iface->name);
++		return;
++	}
++
++	dev_info(dchid->dev, "New interface %s\n", iface->name);
++
++	/* Start the interface. This is not the entire init process, as firmware is loaded later on device open. */
++	ret = dchid_enable_interface(iface);
++	if (ret < 0) {
++		dev_warn(dchid->dev, "Failed to enable %s: %d\n", iface->name, ret);
++		return;
++	}
++
++	iface->deferred = false;
++
++	hid = hid_allocate_device();
++	if (IS_ERR(hid))
++		return;
++
++	snprintf(hid->name, sizeof(hid->name), "Apple MTP %s", iface->name);
++	snprintf(hid->phys, sizeof(hid->phys), "%s.%d (%s)",
++		 dev_name(dchid->dev), iface->index, iface->name);
++	strscpy(hid->uniq, dchid->serial, sizeof(hid->uniq));
++
++	hid->ll_driver = &dchid_ll;
++	hid->bus = BUS_HOST;
++	hid->vendor = dchid->device_id.vendor_id;
++	hid->product = dchid->device_id.product_id;
++	hid->version = dchid->device_id.version_number;
++	hid->type = HID_TYPE_OTHER;
++	if (!strcmp(iface->name, "multi-touch")) {
++		hid->type = HID_TYPE_SPI_MOUSE;
++	} else if (!strcmp(iface->name, "keyboard")) {
++		u32 country_code = 0;
++
++		hid->type = HID_TYPE_SPI_KEYBOARD;
++
++		/*
++		 * We have to get the country code from the device tree, since the
++		 * device provides no reliable way to get this info.
++		 */
++		if (!of_property_read_u32(iface->of_node, "hid-country-code", &country_code))
++			hid->country = country_code;
++
++		of_property_read_u32(iface->of_node, "apple,keyboard-layout-id",
++			&iface->keyboard_layout_id);
++	}
++
++	hid->dev.parent = iface->dchid->dev;
++	hid->driver_data = iface;
++
++	iface->hid = hid;
++
++	ret = hid_add_device(hid);
++	if (ret < 0) {
++		iface->hid = NULL;
++		hid_destroy_device(hid);
++		dev_warn(iface->dchid->dev, "Failed to register hid device %s", iface->name);
++	}
++}
++
++static int dchid_create_interface(struct dchid_iface *iface)
++{
++	if (iface->creating)
++		return -EBUSY;
++
++	iface->creating = true;
++	INIT_WORK(&iface->create_work, dchid_create_interface_work);
++	return queue_work(iface->dchid->new_iface_wq, &iface->create_work);
++}
++
++static void dchid_handle_descriptor(struct dchid_iface *iface, void *hid_desc, size_t desc_len)
++{
++	if (iface->hid) {
++		dev_warn(iface->dchid->dev, "Tried to initialize already started interface %s!\n",
++			 iface->name);
++		return;
++	}
++
++	iface->hid_desc = devm_kmemdup(iface->dchid->dev, hid_desc, desc_len, GFP_KERNEL);
++	if (!iface->hid_desc)
++		return;
++
++	iface->hid_desc_len = desc_len;
++}
++
++static void dchid_handle_ready(struct dockchannel_hid *dchid, void *data, size_t length)
++{
++	struct dchid_iface *iface;
++	u8 *pkt = data;
++	u8 index;
++	int i, ret;
++
++	if (length < 2) {
++		dev_err(dchid->dev, "Bad length for ready message: %zu\n", length);
++		return;
++	}
++
++	index = pkt[1];
++
++	if (index >= MAX_INTERFACES) {
++		dev_err(dchid->dev, "Got ready notification for bad iface %d\n", index);
++		return;
++	}
++
++	iface = dchid->ifaces[index];
++	if (!iface) {
++		dev_err(dchid->dev, "Got ready notification for unknown iface %d\n", index);
++		return;
++	}
++
++	dev_info(dchid->dev, "Interface %s is now ready\n", iface->name);
++	complete_all(&iface->ready);
++
++	/* When STM is ready, grab global device info */
++	if (!strcmp(iface->name, "stm")) {
++		ret = dchid_get_report_cmd(iface, STM_REPORT_ID, &dchid->device_id,
++					   sizeof(dchid->device_id));
++		if (ret < sizeof(dchid->device_id)) {
++			dev_warn(iface->dchid->dev, "Failed to get device ID from STM!\n");
++			/* Fake it and keep going. Things might still work... */
++			memset(&dchid->device_id, 0, sizeof(dchid->device_id));
++			dchid->device_id.vendor_id = HOST_VENDOR_ID_APPLE;
++		}
++		ret = dchid_get_report_cmd(iface, STM_REPORT_SERIAL, dchid->serial,
++					   sizeof(dchid->serial) - 1);
++		if (ret < 0) {
++			dev_warn(iface->dchid->dev, "Failed to get serial from STM!\n");
++			dchid->serial[0] = 0;
++		}
++
++		dchid->id_ready = true;
++		for (i = 0; i < MAX_INTERFACES; i++) {
++			if (!dchid->ifaces[i] || !dchid->ifaces[i]->deferred)
++				continue;
++			dchid_create_interface(dchid->ifaces[i]);
++		}
++	}
++}
++
++static void dchid_handle_init(struct dockchannel_hid *dchid, void *data, size_t length)
++{
++	struct dchid_init_hdr *hdr = data;
++	struct dchid_iface *iface;
++	struct dchid_init_block_hdr *blk;
++
++	if (length < sizeof(*hdr))
++		return;
++
++	iface = dchid_get_interface(dchid, hdr->iface, hdr->name);
++	if (!iface)
++		return;
++
++	data += sizeof(*hdr);
++	length -= sizeof(*hdr);
++
++	while (length >= sizeof(*blk)) {
++		blk = data;
++		data += sizeof(*blk);
++		length -= sizeof(*blk);
++
++		if (blk->length > length)
++			break;
++
++		switch (blk->type) {
++		case INIT_HID_DESCRIPTOR:
++			dchid_handle_descriptor(iface, data, blk->length);
++			break;
++
++		case INIT_GPIO_REQUEST: {
++			struct dchid_gpio_request *req = data;
++
++			if (sizeof(*req) > length)
++				break;
++
++			if (iface->gpio_id) {
++				dev_err(dchid->dev,
++					"Cannot request more than one GPIO per interface!\n");
++				break;
++			}
++
++			strscpy(iface->gpio_name, req->name, MAX_GPIO_NAME);
++			iface->gpio_id = req->id;
++			break;
++		}
++
++		case INIT_TERMINATOR:
++			break;
++
++		case INIT_PRODUCT_NAME: {
++			char *product = data;
++
++			if (product[blk->length - 1] != 0) {
++				dev_warn(dchid->dev, "Unterminated product name for %s\n",
++					 iface->name);
++			} else {
++				dev_info(dchid->dev, "Product name for %s: %s\n",
++					 iface->name, product);
++			}
++			break;
++		}
++
++		default:
++			dev_warn(dchid->dev, "Unknown init packet %d for %s\n",
++				 blk->type, iface->name);
++			break;
++		}
++
++		data += blk->length;
++		length -= blk->length;
++
++		if (blk->type == INIT_TERMINATOR)
++			break;
++	}
++
++	if (hdr->more_packets)
++		return;
++
++	/* We need to enable STM first, since it'll give us the device IDs */
++	if (iface->dchid->id_ready || !strcmp(iface->name, "stm")) {
++		dchid_create_interface(iface);
++	} else {
++		iface->deferred = true;
++	}
++}
++
++static void dchid_handle_gpio(struct dockchannel_hid *dchid, void *data, size_t length)
++{
++	struct dchid_gpio_cmd *cmd = data;
++	struct dchid_iface *iface;
++	u32 retcode = 0xe000f00d; /* Give it a random Apple-style error code */
++	struct dchid_gpio_ack *ack;
++
++	if (length < sizeof(*cmd))
++		return;
++
++	if (cmd->iface >= MAX_INTERFACES || !(iface = dchid->ifaces[cmd->iface])) {
++		dev_err(dchid->dev, "Got GPIO command for bad inteface %d\n", cmd->iface);
++		goto err;
++	}
++
++	if (dchid_request_gpio(iface) < 0)
++		goto err;
++
++	if (!iface->gpio || cmd->gpio != iface->gpio_id) {
++		dev_err(dchid->dev, "Got GPIO command for bad GPIO %s#%d\n",
++			iface->name, cmd->gpio);
++		goto err;
++	}
++
++	dev_info(dchid->dev, "GPIO command: %s#%d: %d\n", iface->name, cmd->gpio, cmd->cmd);
++
++	switch (cmd->cmd) {
++	case 3:
++		/* Pulse.  */
++		gpiod_set_value_cansleep(iface->gpio, 1);
++		msleep(10); /* Random guess... */
++		gpiod_set_value_cansleep(iface->gpio, 0);
++		retcode = 0;
++		break;
++	default:
++		dev_err(dchid->dev, "Unknown GPIO command %d\n", cmd->cmd	);
++		break;
++	}
++
++err:
++	/* Ack it */
++	ack = kzalloc(sizeof(*ack) + length, GFP_KERNEL);
++	if (!ack)
++		return;
++
++	ack->type = CMD_ACK_GPIO_CMD;
++	ack->retcode = retcode;
++	memcpy(ack->cmd, data, length);
++
++	if (dchid_comm_cmd(dchid, ack, sizeof(*ack) + length) < 0)
++		dev_err(dchid->dev, "Failed to ACK GPIO command\n");
++
++	kfree(ack);
++}
++
++static void dchid_handle_event(struct dockchannel_hid *dchid, void *data, size_t length)
++{
++	u8 *p = data;
++	switch (*p) {
++	case EVENT_INIT:
++		dchid_handle_init(dchid, data, length);
++		break;
++	case EVENT_READY:
++		dchid_handle_ready(dchid, data, length);
++		break;
++	case EVENT_GPIO_CMD:
++		dchid_handle_gpio(dchid, data, length);
++		break;
++	}
++}
++
++static void dchid_handle_report(struct dchid_iface *iface, void *data, size_t length)
++{
++	struct dockchannel_hid *dchid = iface->dchid;
++
++	if (!iface->hid) {
++		dev_warn(dchid->dev, "Report received but %s is not initialized!\n", iface->name);
++		return;
++	}
++
++	if (!iface->open)
++		return;
++
++	hid_input_report(iface->hid, HID_INPUT_REPORT, data, length, 1);
++}
++
++static void dchid_packet_work(struct work_struct *ws)
++{
++	struct dchid_work *work = container_of(ws, struct dchid_work, work);
++	struct dchid_subhdr *shdr = (void *)work->data;
++	struct dockchannel_hid *dchid = work->iface->dchid;
++	int type = FIELD_GET(FLAGS_GROUP, shdr->flags);
++	u8 *payload = work->data + sizeof(*shdr);
++
++	if (shdr->length + sizeof(*shdr) > work->hdr.length) {
++		dev_err(dchid->dev, "Bad sub header length (%d > %zu)\n",
++			shdr->length, work->hdr.length - sizeof(*shdr));
++		return;
++	}
++
++	switch (type) {
++	case HID_INPUT_REPORT:
++		if (work->hdr.iface == IFACE_COMM)
++			dchid_handle_event(dchid, payload, shdr->length);
++		else
++			dchid_handle_report(work->iface, payload, shdr->length);
++		break;
++	default:
++		dev_err(dchid->dev, "Received unknown packet type %d\n", type);
++		break;
++	}
++
++	kfree(work);
++}
++
++static void dchid_handle_ack(struct dchid_iface *iface, struct dchid_hdr *hdr, void *data)
++{
++	struct dchid_subhdr *shdr = (void *)data;
++	u8 *payload = data + sizeof(*shdr);
++
++	if (shdr->length + sizeof(*shdr) > hdr->length) {
++		dev_err(iface->dchid->dev, "Bad sub header length (%d > %ld)\n",
++			shdr->length, hdr->length - sizeof(*shdr));
++		return;
++	}
++	if (shdr->flags != iface->out_flags) {
++		dev_err(iface->dchid->dev,
++			"Received unexpected flags 0x%x on ACK channel (expFected 0x%x)\n",
++			shdr->flags, iface->out_flags);
++		return;
++	}
++
++	if (shdr->length < 1) {
++		dev_err(iface->dchid->dev, "Received length 0 output report ack\n");
++		return;
++	}
++	if (iface->tx_seq != hdr->seq) {
++		dev_err(iface->dchid->dev, "Received ACK with bad seq (expected %d, got %d)\n",
++			iface->tx_seq, hdr->seq);
++		return;
++	}
++	if (iface->out_report != payload[0]) {
++		dev_err(iface->dchid->dev, "Received ACK with bad report (expected %d, got %d\n",
++			iface->out_report, payload[0]);
++		return;
++	}
++
++	if (iface->resp_buf && iface->resp_size)
++		memcpy(iface->resp_buf, payload + 1, min((size_t)shdr->length - 1, iface->resp_size));
++
++	iface->resp_size = shdr->length;
++	iface->out_report = -1;
++	iface->retcode = shdr->retcode;
++	complete(&iface->out_complete);
++}
++
++static void dchid_handle_packet(void *cookie, size_t avail)
++{
++	struct dockchannel_hid *dchid = cookie;
++	struct dchid_hdr hdr;
++	struct dchid_work *work;
++	struct dchid_iface *iface;
++	u32 checksum;
++
++	if (dockchannel_recv(dchid->dc, &hdr, sizeof(hdr)) != sizeof(hdr)) {
++		dev_err(dchid->dev, "Read failed (header)\n");
++		return;
++	}
++
++	if (hdr.hdr_len != sizeof(hdr)) {
++		dev_err(dchid->dev, "Bad header length %d\n", hdr.hdr_len);
++		goto done;
++	}
++
++	if (dockchannel_recv(dchid->dc, dchid->pkt_buf, hdr.length + 4) != (hdr.length + 4)) {
++		dev_err(dchid->dev, "Read failed (body)\n");
++		goto done;
++	}
++
++	checksum = dchid_checksum(&hdr, sizeof(hdr));
++	checksum += dchid_checksum(dchid->pkt_buf, hdr.length + 4);
++
++	if (checksum != 0xffffffff) {
++		dev_err(dchid->dev, "Checksum mismatch (iface %d): 0x%08x != 0xffffffff\n",
++			hdr.iface, checksum);
++		goto done;
++	}
++
++
++	if (hdr.iface >= MAX_INTERFACES) {
++		dev_err(dchid->dev, "Bad iface %d\n", hdr.iface);
++	}
++
++	iface = dchid->ifaces[hdr.iface];
++
++	if (!iface) {
++		dev_err(dchid->dev, "Received packet for uninitialized iface %d\n", hdr.iface);
++		goto done;
++	}
++
++	switch (hdr.channel) {
++		case DCHID_CHANNEL_CMD:
++			dchid_handle_ack(iface, &hdr, dchid->pkt_buf);
++			goto done;
++		case DCHID_CHANNEL_REPORT:
++			break;
++		default:
++			dev_warn(dchid->dev, "Unknown channel 0x%x, treating as report...\n",
++				 hdr.channel);
++			break;
++	}
++
++	work = kzalloc(sizeof(*work) + hdr.length, GFP_KERNEL);
++	if (!work)
++		return;
++
++	work->hdr = hdr;
++	work->iface = iface;
++	memcpy(work->data, dchid->pkt_buf, hdr.length);
++	INIT_WORK(&work->work, dchid_packet_work);
++
++	queue_work(iface->wq, &work->work);
++
++done:
++	dockchannel_await(dchid->dc, dchid_handle_packet, dchid, sizeof(struct dchid_hdr));
++}
++
++static int dockchannel_hid_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct dockchannel_hid *dchid;
++	struct device_node *child, *helper;
++	struct platform_device *helper_pdev;
++	struct property *prop;
++	int ret;
++
++	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
++	if (ret)
++		return ret;
++
++	dchid = devm_kzalloc(dev, sizeof(*dchid), GFP_KERNEL);
++	if (!dchid) {
++		return -ENOMEM;
++	}
++
++	dchid->dev = dev;
++
++	/*
++	 * First make sure all the GPIOs are available, in cased we need to defer.
++	 * This is necessary because MTP will request them by name later, and by then
++	 * it's too late to defer the probe.
++	 */
++
++	for_each_child_of_node(dev->of_node, child) {
++		for_each_property_of_node(child, prop) {
++			size_t len = strlen(prop->name);
++			struct gpio_desc *gpio;
++
++			if (len < 12 || strncmp("apple,", prop->name, 6) ||
++			    strcmp("-gpios", prop->name + len - 6))
++				continue;
++
++			gpio = fwnode_gpiod_get_index(&child->fwnode, prop->name, 0, GPIOD_ASIS,
++						      prop->name);
++			if (IS_ERR_OR_NULL(gpio)) {
++				if (PTR_ERR(gpio) == -EPROBE_DEFER) {
++					of_node_put(child);
++					return -EPROBE_DEFER;
++				}
++			} else {
++				gpiod_put(gpio);
++			}
++		}
++	}
++
++	/*
++	 * Make sure we also have the MTP coprocessor available, and
++	 * defer probe if the helper hasn't probed yet.
++	 */
++	helper = of_parse_phandle(dev->of_node, "apple,helper-cpu", 0);
++	if (!helper) {
++		dev_err(dev, "Missing apple,helper-cpu property");
++		return -EINVAL;
++	}
++
++	helper_pdev = of_find_device_by_node(helper);
++	of_node_put(helper);
++	if (!helper_pdev) {
++		dev_err(dev, "Failed to find helper device");
++		return -EINVAL;
++	}
++
++	dchid->helper_link = device_link_add(dev, &helper_pdev->dev,
++					     DL_FLAG_AUTOREMOVE_CONSUMER);
++	put_device(&helper_pdev->dev);
++	if (!dchid->helper_link) {
++		dev_err(dev, "Failed to link to helper device");
++		return -EINVAL;
++	}
++
++	if (dchid->helper_link->supplier->links.status != DL_DEV_DRIVER_BOUND)
++		return -EPROBE_DEFER;
++
++	/* Now it is safe to begin initializing */
++	dchid->dc = dockchannel_init(pdev);
++	if (IS_ERR_OR_NULL(dchid->dc)) {
++		return PTR_ERR(dchid->dc);
++	}
++	dchid->new_iface_wq = alloc_workqueue("dchid-new", WQ_MEM_RECLAIM, 0);
++	if (!dchid->new_iface_wq)
++		return -ENOMEM;
++
++	dchid->comm = dchid_get_interface(dchid, IFACE_COMM, "comm");
++	if (!dchid->comm) {
++		dev_err(dchid->dev, "Failed to initialize comm interface");
++		return -EIO;
++	}
++
++	dev_info(dchid->dev, "Initialized, awaiting packets\n");
++	dockchannel_await(dchid->dc, dchid_handle_packet, dchid, sizeof(struct dchid_hdr));
++
++	return 0;
++}
++
++static void dockchannel_hid_remove(struct platform_device *pdev)
++{
++	BUG_ON(1);
++}
++
++static const struct of_device_id dockchannel_hid_of_match[] = {
++	{ .compatible = "apple,dockchannel-hid" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, dockchannel_hid_of_match);
++MODULE_FIRMWARE("apple/tpmtfw-*.bin");
++
++static struct platform_driver dockchannel_hid_driver = {
++	.driver = {
++		.name = "dockchannel-hid",
++		.of_match_table = dockchannel_hid_of_match,
++	},
++	.probe = dockchannel_hid_probe,
++	.remove = dockchannel_hid_remove,
++};
++module_platform_driver(dockchannel_hid_driver);
++
++MODULE_DESCRIPTION("Apple DockChannel HID transport driver");
++MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
++MODULE_LICENSE("Dual MIT/GPL");
+diff --git a/drivers/hid/hid-apple.c b/drivers/hid/hid-apple.c
+index 3bed3f0c90c2..21ff5d1da011 100644
+--- a/drivers/hid/hid-apple.c
++++ b/drivers/hid/hid-apple.c
+@@ -486,6 +486,7 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
+ 			table = apple2021_fn_keys;
+ 		else if (hid->product == USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132 ||
+ 			 hid->product == USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680 ||
++			 hid->product == USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT ||
+ 			 hid->product == USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213)
+ 				table = macbookpro_no_esc_fn_keys;
+ 		else if (hid->product == USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K ||
+@@ -498,6 +499,16 @@ static int hidinput_apple_event(struct hid_device *hid, struct input_dev *input,
+ 		else if (hid->product >= USB_DEVICE_ID_APPLE_WELLSPRING4_ANSI &&
+ 				hid->product <= USB_DEVICE_ID_APPLE_WELLSPRING4A_JIS)
+ 			table = macbookair_fn_keys;
++		else if (hid->bus == BUS_HOST || hid->bus == BUS_SPI)
++			switch (hid->product) {
++			case SPI_DEVICE_ID_APPLE_MACBOOK_PRO13_2020:
++			case HOST_DEVICE_ID_APPLE_MACBOOK_PRO13_2022:
++				table = macbookpro_dedicated_esc_fn_keys;
++				break;
++			default:
++				table = apple2021_fn_keys;
++				break;
++			}
+ 		else if (hid->product < 0x21d || hid->product >= 0x300)
+ 			table = powerbook_fn_keys;
+ 		else
+@@ -911,6 +922,13 @@ static int apple_probe(struct hid_device *hdev,
+ 	struct apple_sc *asc;
+ 	int ret;
+ 
++	if ((id->bus == BUS_SPI || id->bus == BUS_HOST) && id->vendor == SPI_VENDOR_ID_APPLE &&
++	    hdev->type != HID_TYPE_SPI_KEYBOARD)
++		return -ENODEV;
++
++	if (quirks & APPLE_IGNORE_MOUSE && hdev->type == HID_TYPE_USBMOUSE)
++		return -ENODEV;
++
+ 	asc = devm_kzalloc(&hdev->dev, sizeof(*asc), GFP_KERNEL);
+ 	if (asc == NULL) {
+ 		hid_err(hdev, "can't alloc apple descriptor\n");
+@@ -934,12 +952,10 @@ static int apple_probe(struct hid_device *hdev,
+ 		return ret;
+ 	}
+ 
+-	if (quirks & APPLE_RDESC_BATTERY) {
+-		timer_setup(&asc->battery_timer, apple_battery_timer_tick, 0);
+-		mod_timer(&asc->battery_timer,
+-			  jiffies + msecs_to_jiffies(APPLE_BATTERY_TIMEOUT_MS));
+-		apple_fetch_battery(hdev);
+-	}
++	timer_setup(&asc->battery_timer, apple_battery_timer_tick, 0);
++	mod_timer(&asc->battery_timer,
++		  jiffies + msecs_to_jiffies(APPLE_BATTERY_TIMEOUT_MS));
++	apple_fetch_battery(hdev);
+ 
+ 	if (quirks & APPLE_BACKLIGHT_CTL)
+ 		apple_backlight_init(hdev);
+@@ -953,9 +969,7 @@ static int apple_probe(struct hid_device *hdev,
+ 	return 0;
+ 
+ out_err:
+-	if (quirks & APPLE_RDESC_BATTERY)
+-		timer_delete_sync(&asc->battery_timer);
+-
++	timer_delete_sync(&asc->battery_timer);
+ 	hid_hw_stop(hdev);
+ 	return ret;
+ }
+@@ -964,8 +978,7 @@ static void apple_remove(struct hid_device *hdev)
+ {
+ 	struct apple_sc *asc = hid_get_drvdata(hdev);
+ 
+-	if (asc->quirks & APPLE_RDESC_BATTERY)
+-		timer_delete_sync(&asc->battery_timer);
++	timer_delete_sync(&asc->battery_timer);
+ 
+ 	hid_hw_stop(hdev);
+ }
+@@ -1133,21 +1146,28 @@ static const struct hid_device_id apple_devices[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS),
+ 		.driver_data = APPLE_HAS_FN | APPLE_RDESC_JIS },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K),
+-		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK |
++				APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132),
+-		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK |
++				APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680),
+-		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK |
++				APPLE_IGNORE_MOUSE },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT),
++		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK |
++				APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213),
+-		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_BACKLIGHT_CTL | APPLE_ISO_TILDE_QUIRK |
++				APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K),
+-		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223),
+-		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K),
+-		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_IGNORE_MOUSE },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F),
+-		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
++		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_IGNORE_MOUSE },
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_ALU_WIRELESS_2009_ANSI),
+ 		.driver_data = APPLE_NUMLOCK_EMULATION | APPLE_HAS_FN },
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_ALU_WIRELESS_2009_ISO),
+@@ -1175,6 +1195,10 @@ static const struct hid_device_id apple_devices[] = {
+ 		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK | APPLE_RDESC_BATTERY },
+ 	{ HID_BLUETOOTH_DEVICE(BT_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_MAGIC_KEYBOARD_NUMPAD_2021),
+ 		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
++	{ HID_SPI_DEVICE(SPI_VENDOR_ID_APPLE, HID_ANY_ID),
++		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
++	{ HID_DEVICE(BUS_HOST, HID_GROUP_ANY, HOST_VENDOR_ID_APPLE, HID_ANY_ID),
++		.driver_data = APPLE_HAS_FN | APPLE_ISO_TILDE_QUIRK },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_TOUCHBAR_BACKLIGHT),
+ 		.driver_data = APPLE_MAGIC_BACKLIGHT },
+ 
+diff --git a/drivers/hid/hid-core.c b/drivers/hid/hid-core.c
+index 4fd3fff4661c..cd6c1cc7d010 100644
+--- a/drivers/hid/hid-core.c
++++ b/drivers/hid/hid-core.c
+@@ -468,7 +468,10 @@ static int hid_parser_global(struct hid_parser *parser, struct hid_item *item)
+ 
+ 	case HID_GLOBAL_ITEM_TAG_REPORT_SIZE:
+ 		parser->global.report_size = item_udata(item);
+-		if (parser->global.report_size > 256) {
++		/* Arbitrary maximum. Some Apple devices have 16384 here.
++		 * This * HID_MAX_USAGES must fit in a signed integer.
++		 */
++		if (parser->global.report_size > 16384) {
+ 			hid_err(parser->device, "invalid report_size %d\n",
+ 					parser->global.report_size);
+ 			return -1;
+@@ -2307,6 +2310,12 @@ int hid_connect(struct hid_device *hdev, unsigned int connect_mask)
+ 	case BUS_I2C:
+ 		bus = "I2C";
+ 		break;
++	case BUS_SPI:
++		bus = "SPI";
++		break;
++	case BUS_HOST:
++		bus = "HOST";
++		break;
+ 	case BUS_VIRTUAL:
+ 		bus = "VIRTUAL";
+ 		break;
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index 784593dd296f..7b47dd2d7c5b 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -93,6 +93,8 @@
+ 
+ #define USB_VENDOR_ID_APPLE		0x05ac
+ #define BT_VENDOR_ID_APPLE		0x004c
++#define SPI_VENDOR_ID_APPLE		0x05ac
++#define HOST_VENDOR_ID_APPLE		0x05ac
+ #define USB_DEVICE_ID_APPLE_MIGHTYMOUSE	0x0304
+ #define USB_DEVICE_ID_APPLE_MAGICMOUSE	0x030d
+ #define USB_DEVICE_ID_APPLE_MAGICMOUSE2	0x0269
+@@ -173,14 +175,15 @@
+ #define USB_DEVICE_ID_APPLE_WELLSPRING9_ANSI	0x0272
+ #define USB_DEVICE_ID_APPLE_WELLSPRING9_ISO		0x0273
+ #define USB_DEVICE_ID_APPLE_WELLSPRING9_JIS		0x0274
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K	0x027a
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132	0x027b
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680	0x027c
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213	0x027d
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K	0x027e
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223	0x027f
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K	0x0280
+-#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F	0x0340
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K		0x027a
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132		0x027b
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680		0x027c
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT	0x0278
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213		0x027d
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K		0x027e
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223		0x027f
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K		0x0280
++#define USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F		0x0340
+ #define USB_DEVICE_ID_APPLE_FOUNTAIN_TP_ONLY	0x030a
+ #define USB_DEVICE_ID_APPLE_GEYSER1_TP_ONLY	0x030b
+ #define USB_DEVICE_ID_APPLE_IRCONTROL	0x8240
+@@ -194,6 +197,12 @@
+ #define USB_DEVICE_ID_APPLE_MAGIC_KEYBOARD_NUMPAD_2021   0x029f
+ #define USB_DEVICE_ID_APPLE_TOUCHBAR_BACKLIGHT 0x8102
+ #define USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY 0x8302
++#define SPI_DEVICE_ID_APPLE_MACBOOK_AIR_2020	0x0281
++#define SPI_DEVICE_ID_APPLE_MACBOOK_PRO13_2020	0x0341
++#define SPI_DEVICE_ID_APPLE_MACBOOK_PRO14_2021	0x0342
++#define SPI_DEVICE_ID_APPLE_MACBOOK_PRO16_2021	0x0343
++#define HOST_DEVICE_ID_APPLE_MACBOOK_AIR13_2022	0x0351
++#define HOST_DEVICE_ID_APPLE_MACBOOK_PRO13_2022	0x0354
+ 
+ #define USB_VENDOR_ID_ASETEK			0x2433
+ #define USB_DEVICE_ID_ASETEK_INVICTA		0xf300
+diff --git a/drivers/hid/hid-magicmouse.c b/drivers/hid/hid-magicmouse.c
+index 226682762db3..328df8118384 100644
+--- a/drivers/hid/hid-magicmouse.c
++++ b/drivers/hid/hid-magicmouse.c
+@@ -60,8 +60,14 @@ MODULE_PARM_DESC(report_undeciphered, "Report undeciphered multi-touch state fie
+ #define MOUSE_REPORT_ID    0x29
+ #define MOUSE2_REPORT_ID   0x12
+ #define DOUBLE_REPORT_ID   0xf7
++#define SPI_REPORT_ID      0x02
++#define SPI_RESET_REPORT_ID 0x60
++#define MTP_REPORT_ID      0x75
++#define SENSOR_DIMENSIONS_REPORT_ID 0xd9
+ #define USB_BATTERY_TIMEOUT_MS 60000
+ 
++#define MAX_CONTACTS 16
++
+ /* These definitions are not precise, but they're close enough.  (Bits
+  * 0x03 seem to indicate the aspect ratio of the touch, bits 0x70 seem
+  * to be some kind of bit mask -- 0x20 may be a near-field reading,
+@@ -112,30 +118,156 @@ MODULE_PARM_DESC(report_undeciphered, "Report undeciphered multi-touch state fie
+ #define TRACKPAD2_RES_Y \
+ 	((TRACKPAD2_MAX_Y - TRACKPAD2_MIN_Y) / (TRACKPAD2_DIMENSION_Y / 100))
+ 
++#define J140K_TP_DIMENSION_X (float)12100
++#define J140K_TP_MIN_X -5318
++#define J140K_TP_MAX_X 5787
++#define J140K_TP_RES_X \
++	((J140K_TP_MAX_X - J140K_TP_MIN_X) / (J140K_TP_DIMENSION_X / 100))
++#define J140K_TP_DIMENSION_Y (float)8200
++#define J140K_TP_MIN_Y -157
++#define J140K_TP_MAX_Y 7102
++#define J140K_TP_RES_Y \
++	((J140K_TP_MAX_Y - J140K_TP_MIN_Y) / (J140K_TP_DIMENSION_Y / 100))
++
++#define J132_TP_DIMENSION_X (float)13500
++#define J132_TP_MIN_X -6243
++#define J132_TP_MAX_X 6749
++#define J132_TP_RES_X \
++	((J132_TP_MAX_X - J132_TP_MIN_X) / (J132_TP_DIMENSION_X / 100))
++#define J132_TP_DIMENSION_Y (float)8400
++#define J132_TP_MIN_Y -170
++#define J132_TP_MAX_Y 7685
++#define J132_TP_RES_Y \
++	((J132_TP_MAX_Y - J132_TP_MIN_Y) / (J132_TP_DIMENSION_Y / 100))
++
++#define J680_TP_DIMENSION_X (float)16000
++#define J680_TP_MIN_X -7456
++#define J680_TP_MAX_X 7976
++#define J680_TP_RES_X \
++	((J680_TP_MAX_X - J680_TP_MIN_X) / (J680_TP_DIMENSION_X / 100))
++#define J680_TP_DIMENSION_Y (float)10000
++#define J680_TP_MIN_Y -163
++#define J680_TP_MAX_Y 9283
++#define J680_TP_RES_Y \
++	((J680_TP_MAX_Y - J680_TP_MIN_Y) / (J680_TP_DIMENSION_Y / 100))
++
++#define J680_ALT_TP_DIMENSION_X (float)16000
++#define J680_ALT_TP_MIN_X -7456
++#define J680_ALT_TP_MAX_X 7976
++#define J680_ALT_TP_RES_X \
++	((J680_ALT_TP_MAX_X - J680_ALT_TP_MIN_X) / (J680_ALT_TP_DIMENSION_X / 100))
++#define J680_ALT_TP_DIMENSION_Y (float)10000
++#define J680_ALT_TP_MIN_Y -163
++#define J680_ALT_TP_MAX_Y 9283
++#define J680_ALT_TP_RES_Y \
++	((J680_ALT_TP_MAX_Y - J680_ALT_TP_MIN_Y) / (J680_ALT_TP_DIMENSION_Y / 100))
++
++#define J213_TP_DIMENSION_X (float)13500
++#define J213_TP_MIN_X -6243
++#define J213_TP_MAX_X 6749
++#define J213_TP_RES_X \
++	((J213_TP_MAX_X - J213_TP_MIN_X) / (J213_TP_DIMENSION_X / 100))
++#define J213_TP_DIMENSION_Y (float)8400
++#define J213_TP_MIN_Y -170
++#define J213_TP_MAX_Y 7685
++#define J213_TP_RES_Y \
++	((J213_TP_MAX_Y - J213_TP_MIN_Y) / (J213_TP_DIMENSION_Y / 100))
++
++#define J214K_TP_DIMENSION_X (float)13200
++#define J214K_TP_MIN_X -6046
++#define J214K_TP_MAX_X 6536
++#define J214K_TP_RES_X \
++	((J214K_TP_MAX_X - J214K_TP_MIN_X) / (J214K_TP_DIMENSION_X / 100))
++#define J214K_TP_DIMENSION_Y (float)8200
++#define J214K_TP_MIN_Y -164
++#define J214K_TP_MAX_Y 7439
++#define J214K_TP_RES_Y \
++	((J214K_TP_MAX_Y - J214K_TP_MIN_Y) / (J214K_TP_DIMENSION_Y / 100))
++
++#define J223_TP_DIMENSION_X (float)13200
++#define J223_TP_MIN_X -6046
++#define J223_TP_MAX_X 6536
++#define J223_TP_RES_X \
++	((J223_TP_MAX_X - J223_TP_MIN_X) / (J223_TP_DIMENSION_X / 100))
++#define J223_TP_DIMENSION_Y (float)8200
++#define J223_TP_MIN_Y -164
++#define J223_TP_MAX_Y 7439
++#define J223_TP_RES_Y \
++	((J223_TP_MAX_Y - J223_TP_MIN_Y) / (J223_TP_DIMENSION_Y / 100))
++
++#define J230K_TP_DIMENSION_X (float)12100
++#define J230K_TP_MIN_X -5318
++#define J230K_TP_MAX_X 5787
++#define J230K_TP_RES_X \
++	((J230K_TP_MAX_X - J230K_TP_MIN_X) / (J230K_TP_DIMENSION_X / 100))
++#define J230K_TP_DIMENSION_Y (float)8200
++#define J230K_TP_MIN_Y -157
++#define J230K_TP_MAX_Y 7102
++#define J230K_TP_RES_Y \
++	((J230K_TP_MAX_Y - J230K_TP_MIN_Y) / (J230K_TP_DIMENSION_Y / 100))
++
++#define J152F_TP_DIMENSION_X (float)16000
++#define J152F_TP_MIN_X -7456
++#define J152F_TP_MAX_X 7976
++#define J152F_TP_RES_X \
++	((J152F_TP_MAX_X - J152F_TP_MIN_X) / (J152F_TP_DIMENSION_X / 100))
++#define J152F_TP_DIMENSION_Y (float)10000
++#define J152F_TP_MIN_Y -163
++#define J152F_TP_MAX_Y 9283
++#define J152F_TP_RES_Y \
++	((J152F_TP_MAX_Y - J152F_TP_MIN_Y) / (J152F_TP_DIMENSION_Y / 100))
++
++/* These are fallback values, since the real values will be queried from the device. */
++#define J314_TP_DIMENSION_X (float)13000
++#define J314_TP_MIN_X -5900
++#define J314_TP_MAX_X 6500
++#define J314_TP_RES_X \
++	((J314_TP_MAX_X - J314_TP_MIN_X) / (J314_TP_DIMENSION_X / 100))
++#define J314_TP_DIMENSION_Y (float)8100
++#define J314_TP_MIN_Y -200
++#define J314_TP_MAX_Y 7400
++#define J314_TP_RES_Y \
++	((J314_TP_MAX_Y - J314_TP_MIN_Y) / (J314_TP_DIMENSION_Y / 100))
++
++#define T2_TOUCHPAD_ENTRY(model) \
++	{ USB_DEVICE_ID_APPLE_WELLSPRINGT2_##model, model##_TP_MIN_X, model##_TP_MIN_Y, \
++model##_TP_MAX_X, model##_TP_MAX_Y, model##_TP_RES_X, model##_TP_RES_Y }
++
++#define INTERNAL_TP_MAX_FINGER_ORIENTATION 16384
++
++struct magicmouse_input_ops {
++	int (*raw_event)(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size);
++	int (*setup_input)(struct input_dev *input, struct hid_device *hdev);
++};
++
+ /**
+  * struct magicmouse_sc - Tracks Magic Mouse-specific data.
+  * @input: Input device through which we report events.
+  * @quirks: Currently unused.
++ * @query_dimensions: Whether to query and update dimensions on first open
+  * @ntouches: Number of touches in most recent touch report.
+  * @scroll_accel: Number of consecutive scroll motions.
+  * @scroll_jiffies: Time of last scroll motion.
++ * @pos: multi touch position data of the last report.
+  * @touches: Most recent data for a touch, indexed by tracking ID.
+  * @tracking_ids: Mapping of current touch input data to @touches.
+  * @hdev: Pointer to the underlying HID device.
+  * @work: Workqueue to handle initialization retry for quirky devices.
+  * @battery_timer: Timer for obtaining battery level information.
++ * @input_ops: Input ops based on device type.
+  */
+ struct magicmouse_sc {
+ 	struct input_dev *input;
+ 	unsigned long quirks;
++	bool query_dimensions;
+ 
+ 	int ntouches;
+ 	int scroll_accel;
+ 	unsigned long scroll_jiffies;
+ 
++	struct input_mt_pos pos[MAX_CONTACTS];
+ 	struct {
+-		short x;
+-		short y;
+ 		short scroll_x;
+ 		short scroll_y;
+ 		short scroll_x_hr;
+@@ -143,14 +275,187 @@ struct magicmouse_sc {
+ 		u8 size;
+ 		bool scroll_x_active;
+ 		bool scroll_y_active;
+-	} touches[16];
+-	int tracking_ids[16];
++	} touches[MAX_CONTACTS];
++	int tracking_ids[MAX_CONTACTS];
+ 
+ 	struct hid_device *hdev;
+ 	struct delayed_work work;
+ 	struct timer_list battery_timer;
++	struct magicmouse_input_ops input_ops;
+ };
+ 
++static inline int le16_to_int(__le16 x)
++{
++	return (signed short)le16_to_cpu(x);
++}
++
++static int magicmouse_enable_multitouch(struct hid_device *hdev)
++{
++	const u8 *feature;
++	const u8 feature_mt[] = { 0xD7, 0x01 };
++	const u8 feature_mt_mouse2[] = { 0xF1, 0x02, 0x01 };
++	const u8 feature_mt_trackpad2_usb[] = { 0x02, 0x01 };
++	const u8 feature_mt_trackpad2_bt[] = { 0xF1, 0x02, 0x01 };
++	u8 *buf;
++	int ret;
++	int feature_size;
++
++	switch (hdev->bus) {
++	case BUS_SPI:
++	case BUS_HOST:
++		feature_size = sizeof(feature_mt_trackpad2_usb);
++		feature = feature_mt_trackpad2_usb;
++		break;
++	default:
++		switch (hdev->product) {
++		case USB_DEVICE_ID_APPLE_MAGICTRACKPAD2:
++		case USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC:
++			switch (hdev->vendor) {
++			case BT_VENDOR_ID_APPLE:
++				feature_size = sizeof(feature_mt_trackpad2_bt);
++				feature = feature_mt_trackpad2_bt;
++				break;
++			default: /* USB_VENDOR_ID_APPLE */
++				feature_size = sizeof(feature_mt_trackpad2_usb);
++				feature = feature_mt_trackpad2_usb;
++			}
++			break;
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F:
++			feature_size = sizeof(feature_mt_trackpad2_usb);
++			feature = feature_mt_trackpad2_usb;
++			break;
++		case USB_DEVICE_ID_APPLE_MAGICMOUSE2:
++		case USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC:
++			feature_size = sizeof(feature_mt_mouse2);
++			feature = feature_mt_mouse2;
++			break;
++		default:
++			feature_size = sizeof(feature_mt);
++			feature = feature_mt;
++		}
++	}
++
++	buf = kmemdup(feature, feature_size, GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	ret = hid_hw_raw_request(hdev, buf[0], buf, feature_size,
++				HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
++	kfree(buf);
++	return ret;
++}
++
++static void magicmouse_enable_mt_work(struct work_struct *work)
++{
++	struct magicmouse_sc *msc =
++		container_of(work, struct magicmouse_sc, work.work);
++	int ret;
++
++	ret = magicmouse_enable_multitouch(msc->hdev);
++	if (ret < 0)
++		hid_err(msc->hdev, "unable to request touch data (%d)\n", ret);
++}
++
++static int magicmouse_open(struct input_dev *dev)
++{
++	struct hid_device *hdev = input_get_drvdata(dev);
++	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++	int ret;
++
++	ret = hid_hw_open(hdev);
++	if (ret)
++		return ret;
++
++	/*
++	 * Some devices repond with 'invalid report id' when feature
++	 * report switching it into multitouch mode is sent to it.
++	 *
++	 * This results in -EIO from the _raw low-level transport callback,
++	 * but there seems to be no other way of switching the mode.
++	 * Thus the super-ugly hacky success check below.
++	 *
++	 * MTP devices do not need this.
++	 */
++	if (hdev->bus != BUS_HOST) {
++		ret = magicmouse_enable_multitouch(hdev);
++		if (ret == -EIO && hdev->product == USB_DEVICE_ID_APPLE_MAGICMOUSE2) {
++			schedule_delayed_work(&msc->work, msecs_to_jiffies(500));
++			return 0;
++		}
++		if (ret < 0)
++			hid_err(hdev, "unable to request touch data (%d)\n", ret);
++	}
++	/*
++	 * MT enable is usually not required after the first time, so don't
++	 * consider it fatal.
++	 */
++
++	/*
++	 * For Apple Silicon trackpads, we want to query the dimensions on
++	 * device open. This is because doing so requires the firmware, but
++	 * we don't want to force a firmware load until the device is opened
++	 * for the first time. So do that here and update the input properties
++	 * just in time before userspace queries them.
++	 */
++	if (msc->query_dimensions) {
++		struct input_dev *input = msc->input;
++		u8 buf[32];
++		struct {
++			__le32 width;
++			__le32 height;
++			__le16 min_x;
++			__le16 min_y;
++			__le16 max_x;
++			__le16 max_y;
++		} dim;
++		uint32_t x_span, y_span;
++
++		ret = hid_hw_raw_request(hdev, SENSOR_DIMENSIONS_REPORT_ID, buf, sizeof(buf), HID_FEATURE_REPORT, HID_REQ_GET_REPORT);
++		if (ret < (int)(1 + sizeof(dim))) {
++			hid_err(hdev, "unable to request dimensions (%d)\n", ret);
++			return ret;
++		}
++
++		memcpy(&dim, buf + 1, sizeof(dim));
++
++		/* finger position */
++		input_set_abs_params(input, ABS_MT_POSITION_X,
++				     le16_to_int(dim.min_x), le16_to_int(dim.max_x), 0, 0);
++		/* Y axis is inverted */
++		input_set_abs_params(input, ABS_MT_POSITION_Y,
++				     -le16_to_int(dim.max_y), -le16_to_int(dim.min_y), 0, 0);
++		x_span = le16_to_int(dim.max_x) - le16_to_int(dim.min_x);
++		y_span = le16_to_int(dim.max_y) - le16_to_int(dim.min_y);
++
++		/* X/Y resolution */
++		input_abs_set_res(input, ABS_MT_POSITION_X, 100 * x_span / le32_to_cpu(dim.width) );
++		input_abs_set_res(input, ABS_MT_POSITION_Y, 100 * y_span / le32_to_cpu(dim.height) );
++
++		/* copy info, as input_mt_init_slots() does */
++		dev->absinfo[ABS_X] = dev->absinfo[ABS_MT_POSITION_X];
++		dev->absinfo[ABS_Y] = dev->absinfo[ABS_MT_POSITION_Y];
++
++		msc->query_dimensions = false;
++	}
++
++	return 0;
++}
++
++static void magicmouse_close(struct input_dev *dev)
++{
++	struct hid_device *hdev = input_get_drvdata(dev);
++
++	hid_hw_close(hdev);
++}
++
+ static int magicmouse_firm_touch(struct magicmouse_sc *msc)
+ {
+ 	int touch = -1;
+@@ -192,7 +497,7 @@ static void magicmouse_emit_buttons(struct magicmouse_sc *msc, int state)
+ 		} else if (last_state != 0) {
+ 			state = last_state;
+ 		} else if ((id = magicmouse_firm_touch(msc)) >= 0) {
+-			int x = msc->touches[id].x;
++			int x = msc->pos[id].x;
+ 			if (x < middle_button_start)
+ 				state = 1;
+ 			else if (x > middle_button_stop)
+@@ -256,8 +561,8 @@ static void magicmouse_emit_touch(struct magicmouse_sc *msc, int raw_id, u8 *tda
+ 
+ 	/* Store tracking ID and other fields. */
+ 	msc->tracking_ids[raw_id] = id;
+-	msc->touches[id].x = x;
+-	msc->touches[id].y = y;
++	msc->pos[id].x = x;
++	msc->pos[id].y = y;
+ 	msc->touches[id].size = size;
+ 
+ 	/* If requested, emulate a scroll wheel by detecting small
+@@ -387,6 +692,14 @@ static int magicmouse_raw_event(struct hid_device *hdev,
+ 		struct hid_report *report, u8 *data, int size)
+ {
+ 	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++
++	return msc->input_ops.raw_event(hdev, report, data, size);
++}
++
++static int magicmouse_raw_event_usb(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size)
++{
++	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
+ 	struct input_dev *input = msc->input;
+ 	int x = 0, y = 0, ii, clicks = 0, npoints;
+ 
+@@ -518,6 +831,191 @@ static int magicmouse_raw_event(struct hid_device *hdev,
+ 	return 1;
+ }
+ 
++/**
++ * struct tp_finger - single trackpad finger structure, le16-aligned
++ *
++ * @unknown1:		unknown
++ * @unknown2:		unknown
++ * @abs_x:		absolute x coordinate
++ * @abs_y:		absolute y coordinate
++ * @rel_x:		relative x coordinate
++ * @rel_y:		relative y coordinate
++ * @tool_major:		tool area, major axis
++ * @tool_minor:		tool area, minor axis
++ * @orientation:	16384 when point, else 15 bit angle
++ * @touch_major:	touch area, major axis
++ * @touch_minor:	touch area, minor axis
++ * @unused:		zeros
++ * @pressure:		pressure on forcetouch touchpad
++ * @multi:		one finger: varies, more fingers: constant
++ * @crc16:		on last finger: crc over the whole message struct
++ *			(i.e. message header + this struct) minus the last
++ *			@crc16 field; unknown on all other fingers.
++ */
++struct tp_finger {
++	__le16 unknown1;
++	__le16 unknown2;
++	__le16 abs_x;
++	__le16 abs_y;
++	__le16 rel_x;
++	__le16 rel_y;
++	__le16 tool_major;
++	__le16 tool_minor;
++	__le16 orientation;
++	__le16 touch_major;
++	__le16 touch_minor;
++	__le16 unused[2];
++	__le16 pressure;
++	__le16 multi;
++} __attribute__((packed, aligned(2)));
++
++/**
++ * vendor trackpad report
++ *
++ * @num_fingers:	the number of fingers being reported in @fingers
++ * @buttons:		same as HID buttons
++ */
++struct tp_header {
++	// HID vendor part, up to 1751 bytes
++	u8 unknown[22];
++	u8 num_fingers;
++	u8 buttons;
++	u8 unknown3[14];
++};
++
++/**
++ * standard HID mouse report
++ *
++ * @report_id:		reportid
++ * @buttons:		HID Usage Buttons 3 1-bit reports
++ */
++struct tp_mouse_report {
++	// HID mouse report
++	u8 report_id;
++	u8 buttons;
++	u8 rel_x;
++	u8 rel_y;
++	u8 padding[4];
++};
++
++static void report_finger_data(struct input_dev *input, int slot,
++			       const struct input_mt_pos *pos,
++			       const struct tp_finger *f)
++{
++	input_mt_slot(input, slot);
++	input_mt_report_slot_state(input, MT_TOOL_FINGER, true);
++
++	input_report_abs(input, ABS_MT_TOUCH_MAJOR,
++			 le16_to_int(f->touch_major) << 1);
++	input_report_abs(input, ABS_MT_TOUCH_MINOR,
++			 le16_to_int(f->touch_minor) << 1);
++	input_report_abs(input, ABS_MT_WIDTH_MAJOR,
++			 le16_to_int(f->tool_major) << 1);
++	input_report_abs(input, ABS_MT_WIDTH_MINOR,
++			 le16_to_int(f->tool_minor) << 1);
++	input_report_abs(input, ABS_MT_ORIENTATION,
++			 INTERNAL_TP_MAX_FINGER_ORIENTATION - le16_to_int(f->orientation));
++	input_report_abs(input, ABS_MT_PRESSURE, le16_to_int(f->pressure));
++	input_report_abs(input, ABS_MT_POSITION_X, pos->x);
++	input_report_abs(input, ABS_MT_POSITION_Y, pos->y);
++}
++
++static int magicmouse_raw_event_mtp(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size)
++{
++	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++	struct input_dev *input = msc->input;
++	struct tp_header *tp_hdr;
++	struct tp_finger *f;
++	int i, n;
++	u32 npoints;
++	const size_t hdr_sz = sizeof(struct tp_header);
++	const size_t touch_sz = sizeof(struct tp_finger);
++	u8 map_contacs[MAX_CONTACTS];
++
++	// hid_warn(hdev, "%s\n", __func__);
++	// print_hex_dump_debug("appleft ev: ", DUMP_PREFIX_OFFSET, 16, 1, data,
++	// 		     size, false);
++
++	/* Expect 46 bytes of prefix, and N * 30 bytes of touch data. */
++	if (size < hdr_sz || ((size - hdr_sz) % touch_sz) != 0)
++		return 0;
++
++	tp_hdr = (struct tp_header *)data;
++
++	npoints = (size - hdr_sz) / touch_sz;
++	if (npoints < tp_hdr->num_fingers || npoints > MAX_CONTACTS) {
++		hid_warn(hdev,
++			 "unexpected number of touches (%u) for "
++			 "report\n",
++			 npoints);
++		return 0;
++	}
++
++	n = 0;
++	for (i = 0; i < tp_hdr->num_fingers; i++) {
++		f = (struct tp_finger *)(data + hdr_sz + i * touch_sz);
++		if (le16_to_int(f->touch_major) == 0)
++			continue;
++
++		hid_dbg(hdev, "ev x:%04x y:%04x\n", le16_to_int(f->abs_x),
++			le16_to_int(f->abs_y));
++		msc->pos[n].x = le16_to_int(f->abs_x);
++		msc->pos[n].y = -le16_to_int(f->abs_y);
++		map_contacs[n] = i;
++		n++;
++	}
++
++	input_mt_assign_slots(input, msc->tracking_ids, msc->pos, n, 0);
++
++	for (i = 0; i < n; i++) {
++		int idx = map_contacs[i];
++		f = (struct tp_finger *)(data + hdr_sz + idx * touch_sz);
++		report_finger_data(input, msc->tracking_ids[i], &msc->pos[i], f);
++	}
++
++	input_mt_sync_frame(input);
++	input_report_key(input, BTN_MOUSE, tp_hdr->buttons & 1);
++
++	input_sync(input);
++	return 1;
++}
++
++static int magicmouse_raw_event_spi(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size)
++{
++	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++	const size_t hdr_sz = sizeof(struct tp_mouse_report);
++
++	if (!size)
++		return 0;
++
++	if (data[0] == SPI_RESET_REPORT_ID) {
++		hid_info(hdev, "Touch controller was reset, re-enabling touch mode\n");
++		schedule_delayed_work(&msc->work, msecs_to_jiffies(10));
++		return 1;
++	}
++
++	if (data[0] != TRACKPAD2_USB_REPORT_ID || size < hdr_sz)
++		return 0;
++
++	return magicmouse_raw_event_mtp(hdev, report, data + hdr_sz, size - hdr_sz);
++}
++
++static int magicmouse_raw_event_t2(struct hid_device *hdev,
++		struct hid_report *report, u8 *data, int size)
++{
++	const size_t hdr_sz = sizeof(struct tp_mouse_report);
++
++	if (!size)
++		return 0;
++
++	if (data[0] != TRACKPAD2_USB_REPORT_ID || size < hdr_sz)
++		return 0;
++
++	return magicmouse_raw_event_mtp(hdev, report, data + hdr_sz, size - hdr_sz);
++}
++
+ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
+ 		struct hid_usage *usage, __s32 value)
+ {
+@@ -536,7 +1034,17 @@ static int magicmouse_event(struct hid_device *hdev, struct hid_field *field,
+ 	return 0;
+ }
+ 
+-static int magicmouse_setup_input(struct input_dev *input, struct hid_device *hdev)
++
++static int magicmouse_setup_input(struct input_dev *input,
++				  struct hid_device *hdev)
++{
++	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++
++	return msc->input_ops.setup_input(input, hdev);
++}
++
++static int magicmouse_setup_input_usb(struct input_dev *input,
++				      struct hid_device *hdev)
+ {
+ 	int error;
+ 	int mt_flags = 0;
+@@ -615,7 +1123,7 @@ static int magicmouse_setup_input(struct input_dev *input, struct hid_device *hd
+ 
+ 	__set_bit(EV_ABS, input->evbit);
+ 
+-	error = input_mt_init_slots(input, 16, mt_flags);
++	error = input_mt_init_slots(input, MAX_CONTACTS, mt_flags);
+ 	if (error)
+ 		return error;
+ 	input_set_abs_params(input, ABS_MT_TOUCH_MAJOR, 0, 255 << 2,
+@@ -695,6 +1203,171 @@ static int magicmouse_setup_input(struct input_dev *input, struct hid_device *hd
+ 	 */
+ 	__clear_bit(EV_REP, input->evbit);
+ 
++	/*
++	 * This isn't strictly speaking needed for USB, but enabling MT on
++	 * device open is probably more robust than only doing it once on probe
++	 * even if USB devices are not known to suffer from the SPI reset issue.
++	 */
++	input->open = magicmouse_open;
++	input->close = magicmouse_close;
++	return 0;
++}
++
++struct magicmouse_t2_properties {
++	u32 id;
++	int min_x;
++	int min_y;
++	int max_x;
++	int max_y;
++	int res_x;
++	int res_y;
++};
++
++static const struct magicmouse_t2_properties magicmouse_t2_configs[] = {
++	T2_TOUCHPAD_ENTRY(J140K),
++	T2_TOUCHPAD_ENTRY(J132),
++	T2_TOUCHPAD_ENTRY(J680),
++	T2_TOUCHPAD_ENTRY(J680_ALT),
++	T2_TOUCHPAD_ENTRY(J213),
++	T2_TOUCHPAD_ENTRY(J214K),
++	T2_TOUCHPAD_ENTRY(J223),
++	T2_TOUCHPAD_ENTRY(J230K),
++	T2_TOUCHPAD_ENTRY(J152F),
++};
++
++static int magicmouse_setup_input_int_tpd(struct input_dev *input,
++					  struct hid_device *hdev, int min_x, int min_y,
++					  int max_x, int max_y, int res_x, int res_y,
++					  bool query_dimensions)
++{
++	int error;
++	int mt_flags = 0;
++	struct magicmouse_sc *msc = hid_get_drvdata(hdev);
++
++	__set_bit(INPUT_PROP_BUTTONPAD, input->propbit);
++	__clear_bit(BTN_0, input->keybit);
++	__clear_bit(BTN_RIGHT, input->keybit);
++	__clear_bit(BTN_MIDDLE, input->keybit);
++	__clear_bit(EV_REL, input->evbit);
++	__clear_bit(REL_X, input->relbit);
++	__clear_bit(REL_Y, input->relbit);
++
++	mt_flags = INPUT_MT_POINTER | INPUT_MT_DROP_UNUSED | INPUT_MT_TRACK;
++
++	/* finger touch area */
++	input_set_abs_params(input, ABS_MT_TOUCH_MAJOR, 0, 5000, 0, 0);
++	input_set_abs_params(input, ABS_MT_TOUCH_MINOR, 0, 5000, 0, 0);
++
++	/* finger approach area */
++	input_set_abs_params(input, ABS_MT_WIDTH_MAJOR, 0, 5000, 0, 0);
++	input_set_abs_params(input, ABS_MT_WIDTH_MINOR, 0, 5000, 0, 0);
++
++	/* Note: Touch Y position from the device is inverted relative
++	 * to how pointer motion is reported (and relative to how USB
++	 * HID recommends the coordinates work).  This driver keeps
++	 * the origin at the same position, and just uses the additive
++	 * inverse of the reported Y.
++	 */
++
++	input_set_abs_params(input, ABS_MT_PRESSURE, 0, 6000, 0, 0);
++
++	/*
++	 * This makes libinput recognize this as a PressurePad and
++	 * stop trying to use pressure for touch size. Pressure unit
++	 * seems to be ~grams on these touchpads.
++	 */
++	input_abs_set_res(input, ABS_MT_PRESSURE, 1);
++
++	/* finger orientation */
++	input_set_abs_params(input, ABS_MT_ORIENTATION, -INTERNAL_TP_MAX_FINGER_ORIENTATION,
++			     INTERNAL_TP_MAX_FINGER_ORIENTATION, 0, 0);
++
++	/* finger position */
++	input_set_abs_params(input, ABS_MT_POSITION_X, min_x, max_x, 0, 0);
++	/* Y axis is inverted */
++	input_set_abs_params(input, ABS_MT_POSITION_Y, -max_y, -min_y, 0, 0);
++
++	/* X/Y resolution */
++	input_abs_set_res(input, ABS_MT_POSITION_X, res_x);
++	input_abs_set_res(input, ABS_MT_POSITION_Y, res_y);
++
++	input_set_events_per_packet(input, 60);
++
++	/* touchpad button */
++	input_set_capability(input, EV_KEY, BTN_MOUSE);
++
++	/*
++	 * hid-input may mark device as using autorepeat, but the trackpad does
++	 * not actually want it.
++	 */
++	__clear_bit(EV_REP, input->evbit);
++
++	error = input_mt_init_slots(input, MAX_CONTACTS, mt_flags);
++	if (error)
++		return error;
++
++	/*
++	 * Override the default input->open function to send the MT
++	 * enable every time the device is opened. This ensures it works
++	 * even if we missed a reset event due to the device being closed.
++	 * input->close is overridden for symmetry.
++	 *
++	 * This also takes care of the dimensions query.
++	 */
++	input->open = magicmouse_open;
++	input->close = magicmouse_close;
++	msc->query_dimensions = query_dimensions;
++
++	return 0;
++}
++
++static int magicmouse_setup_input_mtp(struct input_dev *input,
++				      struct hid_device *hdev)
++{
++	int ret = magicmouse_setup_input_int_tpd(input, hdev, J314_TP_MIN_X,
++						 J314_TP_MIN_Y, J314_TP_MAX_X,
++						 J314_TP_MAX_Y, J314_TP_RES_X,
++						 J314_TP_RES_Y, true);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static int magicmouse_setup_input_spi(struct input_dev *input,
++				      struct hid_device *hdev)
++{
++	int ret = magicmouse_setup_input_int_tpd(input, hdev, J314_TP_MIN_X,
++						 J314_TP_MIN_Y, J314_TP_MAX_X,
++						 J314_TP_MAX_Y, J314_TP_RES_X,
++						 J314_TP_RES_Y, true);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static int magicmouse_setup_input_t2(struct input_dev *input,
++				      struct hid_device *hdev)
++{
++	int min_x, min_y, max_x, max_y, res_x, res_y;
++
++	for (size_t i = 0; i < ARRAY_SIZE(magicmouse_t2_configs); i++) {
++		if (magicmouse_t2_configs[i].id == hdev->product) {
++			min_x = magicmouse_t2_configs[i].min_x;
++			min_y = magicmouse_t2_configs[i].min_y;
++			max_x = magicmouse_t2_configs[i].max_x;
++			max_y = magicmouse_t2_configs[i].max_y;
++			res_x = magicmouse_t2_configs[i].res_x;
++			res_y = magicmouse_t2_configs[i].res_y;
++		}
++	}
++
++	int ret = magicmouse_setup_input_int_tpd(input, hdev, min_x, min_y,
++						 max_x, max_y, res_x, res_y, false);
++	if (ret)
++		return ret;
++
+ 	return 0;
+ }
+ 
+@@ -736,86 +1409,17 @@ static int magicmouse_input_configured(struct hid_device *hdev,
+ 	return 0;
+ }
+ 
+-static int magicmouse_enable_multitouch(struct hid_device *hdev)
+-{
+-	const u8 *feature;
+-	const u8 feature_mt[] = { 0xD7, 0x01 };
+-	const u8 feature_mt_mouse2[] = { 0xF1, 0x02, 0x01 };
+-	const u8 feature_mt_trackpad2_usb[] = { 0x02, 0x01 };
+-	const u8 feature_mt_trackpad2_bt[] = { 0xF1, 0x02, 0x01 };
+-	u8 *buf;
+-	int ret;
+-	int feature_size;
+-
+-	switch (hdev->product) {
+-	case USB_DEVICE_ID_APPLE_MAGICTRACKPAD2:
+-	case USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC:
+-		switch (hdev->vendor) {
+-		case BT_VENDOR_ID_APPLE:
+-			feature_size = sizeof(feature_mt_trackpad2_bt);
+-			feature = feature_mt_trackpad2_bt;
+-			break;
+-		default: /* USB_VENDOR_ID_APPLE */
+-			feature_size = sizeof(feature_mt_trackpad2_usb);
+-			feature = feature_mt_trackpad2_usb;
+-		}
+-		break;
+-	case USB_DEVICE_ID_APPLE_MAGICMOUSE2:
+-	case USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC:
+-		feature_size = sizeof(feature_mt_mouse2);
+-		feature = feature_mt_mouse2;
+-		break;
+-	default:
+-		feature_size = sizeof(feature_mt);
+-		feature = feature_mt;
+-	}
+-
+-	buf = kmemdup(feature, feature_size, GFP_KERNEL);
+-	if (!buf)
+-		return -ENOMEM;
+-
+-	ret = hid_hw_raw_request(hdev, buf[0], buf, feature_size,
+-				HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
+-	kfree(buf);
+-	return ret;
+-}
+-
+-static void magicmouse_enable_mt_work(struct work_struct *work)
+-{
+-	struct magicmouse_sc *msc =
+-		container_of(work, struct magicmouse_sc, work.work);
+-	int ret;
+-
+-	ret = magicmouse_enable_multitouch(msc->hdev);
+-	if (ret < 0)
+-		hid_err(msc->hdev, "unable to request touch data (%d)\n", ret);
+-}
+-
+-static bool is_usb_magicmouse2(__u32 vendor, __u32 product)
+-{
+-	if (vendor != USB_VENDOR_ID_APPLE)
+-		return false;
+-	return product == USB_DEVICE_ID_APPLE_MAGICMOUSE2 ||
+-	       product == USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC;
+-}
+-
+-static bool is_usb_magictrackpad2(__u32 vendor, __u32 product)
+-{
+-	if (vendor != USB_VENDOR_ID_APPLE)
+-		return false;
+-	return product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2 ||
+-	       product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC;
+-}
+-
+ static int magicmouse_fetch_battery(struct hid_device *hdev)
+ {
+ #ifdef CONFIG_HID_BATTERY_STRENGTH
+ 	struct hid_report_enum *report_enum;
+ 	struct hid_report *report;
+ 
+-	if (!hdev->battery ||
+-	    (!is_usb_magicmouse2(hdev->vendor, hdev->product) &&
+-	     !is_usb_magictrackpad2(hdev->vendor, hdev->product)))
++	if (!hdev->battery || hdev->vendor != USB_VENDOR_ID_APPLE ||
++	    (hdev->product != USB_DEVICE_ID_APPLE_MAGICMOUSE2 &&
++	     hdev->product != USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC &&
++	     hdev->product != USB_DEVICE_ID_APPLE_MAGICTRACKPAD2 &&
++	     hdev->product != USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC))
+ 		return -1;
+ 
+ 	report_enum = &hdev->report_enum[hdev->battery_report_type];
+@@ -852,12 +1456,62 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 	struct hid_report *report;
+ 	int ret;
+ 
++	if ((id->bus == BUS_SPI || id->bus == BUS_HOST) && id->vendor == SPI_VENDOR_ID_APPLE &&
++ 	    hdev->type != HID_TYPE_SPI_MOUSE)
++ 		return -ENODEV;
++
++	switch (id->product) {
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F:
++		if (hdev->type != HID_TYPE_USBMOUSE)
++			return -ENODEV;
++		break;
++	}
++
+ 	msc = devm_kzalloc(&hdev->dev, sizeof(*msc), GFP_KERNEL);
+ 	if (msc == NULL) {
+ 		hid_err(hdev, "can't alloc magicmouse descriptor\n");
+ 		return -ENOMEM;
+ 	}
+ 
++	// internal trackpad use a data format use input ops to avoid
++	// conflicts with the report ID.
++	switch (id->bus) {
++	case BUS_HOST:
++		msc->input_ops.raw_event = magicmouse_raw_event_mtp;
++		msc->input_ops.setup_input = magicmouse_setup_input_mtp;
++		break;
++	case BUS_SPI:
++		msc->input_ops.raw_event = magicmouse_raw_event_spi;
++		msc->input_ops.setup_input = magicmouse_setup_input_spi;
++		break;
++	default:
++		switch (id->product) {
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K:
++		case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F:
++			msc->input_ops.raw_event = magicmouse_raw_event_t2;
++			msc->input_ops.setup_input = magicmouse_setup_input_t2;
++			break;
++		default:
++			msc->input_ops.raw_event = magicmouse_raw_event_usb;
++			msc->input_ops.setup_input = magicmouse_setup_input_usb;
++		}
++	}
++
+ 	msc->scroll_accel = SCROLL_ACCEL_DEFAULT;
+ 	msc->hdev = hdev;
+ 	INIT_DEFERRABLE_WORK(&msc->work, magicmouse_enable_mt_work);
+@@ -877,17 +1531,17 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 		return ret;
+ 	}
+ 
+-	if (is_usb_magicmouse2(id->vendor, id->product) ||
+-	    is_usb_magictrackpad2(id->vendor, id->product)) {
+-		timer_setup(&msc->battery_timer, magicmouse_battery_timer_tick, 0);
+-		mod_timer(&msc->battery_timer,
+-			  jiffies + msecs_to_jiffies(USB_BATTERY_TIMEOUT_MS));
+-		magicmouse_fetch_battery(hdev);
+-	}
+-
+-	if (is_usb_magicmouse2(id->vendor, id->product) ||
+-	    (is_usb_magictrackpad2(id->vendor, id->product) &&
+-	     hdev->type != HID_TYPE_USBMOUSE))
++	timer_setup(&msc->battery_timer, magicmouse_battery_timer_tick, 0);
++	mod_timer(&msc->battery_timer,
++		  jiffies + msecs_to_jiffies(USB_BATTERY_TIMEOUT_MS));
++	magicmouse_fetch_battery(hdev);
++
++	if (id->vendor == USB_VENDOR_ID_APPLE &&
++	    (id->product == USB_DEVICE_ID_APPLE_MAGICMOUSE2 ||
++	     id->product == USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC ||
++	     ((id->product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2 ||
++	       id->product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC) &&
++	      hdev->type != HID_TYPE_USBMOUSE)))
+ 		return 0;
+ 
+ 	if (!msc->input) {
+@@ -916,11 +1570,29 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 				TRACKPAD2_USB_REPORT_ID, 0);
+ 		}
+ 		break;
+-	default: /* USB_DEVICE_ID_APPLE_MAGICTRACKPAD */
+-		report = hid_register_report(hdev, HID_INPUT_REPORT,
+-			TRACKPAD_REPORT_ID, 0);
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K:
++	case USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F:
+ 		report = hid_register_report(hdev, HID_INPUT_REPORT,
+-			DOUBLE_REPORT_ID, 0);
++			TRACKPAD2_USB_REPORT_ID, 0);
++		break;
++	default: /* USB_DEVICE_ID_APPLE_MAGICTRACKPAD */
++		if (id->bus == BUS_SPI) {
++			report = hid_register_report(hdev, HID_INPUT_REPORT, SPI_REPORT_ID, 0);
++		} else if (id->bus == BUS_HOST) {
++			report = hid_register_report(hdev, HID_INPUT_REPORT, MTP_REPORT_ID, 0);
++		} else {
++			report = hid_register_report(hdev, HID_INPUT_REPORT,
++				TRACKPAD_REPORT_ID, 0);
++			report = hid_register_report(hdev, HID_INPUT_REPORT,
++				DOUBLE_REPORT_ID, 0);
++		}
+ 	}
+ 
+ 	if (!report) {
+@@ -930,6 +1602,10 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 	}
+ 	report->size = 6;
+ 
++	/* MTP devices do not need the MT enable, this is handled by the MTP driver */
++	if (id->bus == BUS_HOST)
++		return 0;
++
+ 	/*
+ 	 * Some devices repond with 'invalid report id' when feature
+ 	 * report switching it into multitouch mode is sent to it.
+@@ -950,10 +1626,7 @@ static int magicmouse_probe(struct hid_device *hdev,
+ 
+ 	return 0;
+ err_stop_hw:
+-	if (is_usb_magicmouse2(id->vendor, id->product) ||
+-	    is_usb_magictrackpad2(id->vendor, id->product))
+-		timer_delete_sync(&msc->battery_timer);
+-
++	timer_delete_sync(&msc->battery_timer);
+ 	hid_hw_stop(hdev);
+ 	return ret;
+ }
+@@ -964,9 +1637,7 @@ static void magicmouse_remove(struct hid_device *hdev)
+ 
+ 	if (msc) {
+ 		cancel_delayed_work_sync(&msc->work);
+-		if (is_usb_magicmouse2(hdev->vendor, hdev->product) ||
+-		    is_usb_magictrackpad2(hdev->vendor, hdev->product))
+-			timer_delete_sync(&msc->battery_timer);
++		timer_delete_sync(&msc->battery_timer);
+ 	}
+ 
+ 	hid_hw_stop(hdev);
+@@ -983,8 +1654,11 @@ static const __u8 *magicmouse_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	 *   0x05, 0x01,       // Usage Page (Generic Desktop)        0
+ 	 *   0x09, 0x02,       // Usage (Mouse)                       2
+ 	 */
+-	if ((is_usb_magicmouse2(hdev->vendor, hdev->product) ||
+-	     is_usb_magictrackpad2(hdev->vendor, hdev->product)) &&
++	if (hdev->vendor == USB_VENDOR_ID_APPLE &&
++	    (hdev->product == USB_DEVICE_ID_APPLE_MAGICMOUSE2 ||
++	     hdev->product == USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC ||
++	     hdev->product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2 ||
++	     hdev->product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC) &&
+ 	    *rsize == 83 && rdesc[46] == 0x84 && rdesc[58] == 0x85) {
+ 		hid_info(hdev,
+ 			 "fixing up magicmouse battery report descriptor\n");
+@@ -1023,10 +1697,42 @@ static const struct hid_device_id magic_mice[] = {
+ 		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
+ 		USB_DEVICE_ID_APPLE_MAGICTRACKPAD2_USBC), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K), .driver_data = 0 },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++		USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F), .driver_data = 0 },
++	{ HID_SPI_DEVICE(SPI_VENDOR_ID_APPLE, HID_ANY_ID),
++	  .driver_data = 0 },
++	{ HID_DEVICE(BUS_HOST, HID_GROUP_ANY, HOST_VENDOR_ID_APPLE,
++                     HID_ANY_ID), .driver_data = 0 },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(hid, magic_mice);
+ 
++#ifdef CONFIG_PM
++static int magicmouse_reset_resume(struct hid_device *hdev)
++{
++	if (hdev->bus == BUS_SPI)
++		return magicmouse_enable_multitouch(hdev);
++
++	return 0;
++}
++#endif
++
+ static struct hid_driver magicmouse_driver = {
+ 	.name = "magicmouse",
+ 	.id_table = magic_mice,
+@@ -1037,6 +1743,10 @@ static struct hid_driver magicmouse_driver = {
+ 	.event = magicmouse_event,
+ 	.input_mapping = magicmouse_input_mapping,
+ 	.input_configured = magicmouse_input_configured,
++#ifdef CONFIG_PM
++        .reset_resume = magicmouse_reset_resume,
++#endif
++
+ };
+ module_hid_driver(magicmouse_driver);
+ 
+diff --git a/drivers/hid/hid-multitouch.c b/drivers/hid/hid-multitouch.c
+index edb8da49d916..22c6314a8843 100644
+--- a/drivers/hid/hid-multitouch.c
++++ b/drivers/hid/hid-multitouch.c
+@@ -221,6 +221,7 @@ static void mt_post_parse(struct mt_device *td, struct mt_application *app);
+ #define MT_CLS_GOOGLE				0x0111
+ #define MT_CLS_RAZER_BLADE_STEALTH		0x0112
+ #define MT_CLS_SMART_TECH			0x0113
++#define MT_CLS_APPLE_TOUCHBAR			0x0114
+ #define MT_CLS_SIS				0x0457
+ 
+ #define MT_DEFAULT_MAXCONTACT	10
+@@ -406,6 +407,12 @@ static const struct mt_class mt_classes[] = {
+ 			MT_QUIRK_CONTACT_CNT_ACCURATE |
+ 			MT_QUIRK_SEPARATE_APP_REPORT,
+ 	},
++	{ .name = MT_CLS_APPLE_TOUCHBAR,
++		.quirks = MT_QUIRK_HOVERING |
++			MT_QUIRK_SLOT_IS_CONTACTID_MINUS_ONE |
++			MT_QUIRK_APPLE_TOUCHBAR,
++		.maxcontacts = 11,
++	},
+ 	{ .name = MT_CLS_SIS,
+ 		.quirks = MT_QUIRK_NOT_SEEN_MEANS_UP |
+ 			MT_QUIRK_ALWAYS_VALID |
+@@ -1866,6 +1873,11 @@ static int mt_probe(struct hid_device *hdev, const struct hid_device_id *id)
+ 	if (ret != 0)
+ 		return ret;
+ 
++	if (mtclass->name == MT_CLS_APPLE_TOUCHBAR &&
++	    !hid_find_field(hdev, HID_INPUT_REPORT,
++			    HID_DG_TOUCHPAD, HID_DG_TRANSDUCER_INDEX))
++		return -ENODEV;
++
+ 	if (mtclass->quirks & MT_QUIRK_FIX_CONST_CONTACT_ID)
+ 		mt_fix_const_fields(hdev, HID_DG_CONTACTID);
+ 
+@@ -2363,6 +2375,11 @@ static const struct hid_device_id mt_devices[] = {
+ 		MT_USB_DEVICE(USB_VENDOR_ID_XIROKU,
+ 			USB_DEVICE_ID_XIROKU_CSR2) },
+ 
++	/* Apple Touch Bar */
++	{ .driver_data = MT_CLS_APPLE_TOUCHBAR,
++		HID_USB_DEVICE(USB_VENDOR_ID_APPLE,
++			USB_DEVICE_ID_APPLE_TOUCHBAR_DISPLAY) },
++
+ 	/* Google MT devices */
+ 	{ .driver_data = MT_CLS_GOOGLE,
+ 		HID_DEVICE(HID_BUS_ANY, HID_GROUP_ANY, USB_VENDOR_ID_GOOGLE,
+diff --git a/drivers/hid/hid-quirks.c b/drivers/hid/hid-quirks.c
+index 416160cfde77..f619ed10535d 100644
+--- a/drivers/hid/hid-quirks.c
++++ b/drivers/hid/hid-quirks.c
+@@ -316,6 +316,7 @@ static const struct hid_device_id hid_have_special_driver[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680) },
++	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680_ALT) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223) },
+@@ -976,14 +977,6 @@ static const struct hid_device_id hid_mouse_ignore_list[] = {
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_ANSI) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_ISO) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRING9_JIS) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J140K) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J132) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J680) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J213) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J214K) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J223) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J230K) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_WELLSPRINGT2_J152F) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_FOUNTAIN_TP_ONLY) },
+ 	{ HID_USB_DEVICE(USB_VENDOR_ID_APPLE, USB_DEVICE_ID_APPLE_GEYSER1_TP_ONLY) },
+ 	{ }
+diff --git a/drivers/hid/spi-hid/Kconfig b/drivers/hid/spi-hid/Kconfig
+new file mode 100644
+index 000000000000..8e37f0fec28a
+--- /dev/null
++++ b/drivers/hid/spi-hid/Kconfig
+@@ -0,0 +1,26 @@
++# SPDX-License-Identifier: GPL-2.0-only
++menu "SPI HID support"
++	depends on SPI
++
++config SPI_HID_APPLE_OF
++	tristate "HID over SPI transport layer for Apple Silicon SoCs"
++	default ARCH_APPLE
++	depends on SPI && INPUT && OF
++	help
++	  Say Y here if you use Apple Silicon based laptop. The keyboard and
++	  touchpad are HID based devices connected via SPI.
++
++	  If unsure, say N.
++
++	  This support is also available as a module.  If so, the module
++	  will be called spi-hid-apple-of. It will also build/depend on the
++	  module spi-hid-apple.
++
++endmenu
++
++config SPI_HID_APPLE_CORE
++	tristate
++	default y if SPI_HID_APPLE_OF=y
++	default m if SPI_HID_APPLE_OF=m
++	select HID
++	select CRC16
+diff --git a/drivers/hid/spi-hid/Makefile b/drivers/hid/spi-hid/Makefile
+new file mode 100644
+index 000000000000..f276ee12cb94
+--- /dev/null
++++ b/drivers/hid/spi-hid/Makefile
+@@ -0,0 +1,10 @@
++# SPDX-License-Identifier: GPL-2.0-only
++#
++# Makefile for SPI HID tarnsport drivers
++#
++
++obj-$(CONFIG_SPI_HID_APPLE_CORE)		+= spi-hid-apple.o
++
++spi-hid-apple-objs				=  spi-hid-apple-core.o
++
++obj-$(CONFIG_SPI_HID_APPLE_OF)			+= spi-hid-apple-of.o
+diff --git a/drivers/hid/spi-hid/spi-hid-apple-core.c b/drivers/hid/spi-hid/spi-hid-apple-core.c
+new file mode 100644
+index 000000000000..1f8fa64d6d86
+--- /dev/null
++++ b/drivers/hid/spi-hid/spi-hid-apple-core.c
+@@ -0,0 +1,1194 @@
++/*
++ * SPDX-License-Identifier: GPL-2.0
++ *
++ * Apple SPI HID transport driver
++ *
++ * Copyright (C) The Asahi Linux Contributors
++ *
++ * Based on: drivers/input/applespi.c
++ *
++ * MacBook (Pro) SPI keyboard and touchpad driver
++ *
++ * Copyright (c) 2015-2018 Federico Lorenzi
++ * Copyright (c) 2017-2018 Ronald Tschalär
++ *
++ */
++
++//#define DEBUG 2
++
++#include <linux/crc16.h>
++#include <linux/delay.h>
++#include <linux/device/driver.h>
++#include <linux/hid.h>
++#include <linux/jiffies.h>
++#include <linux/module.h>
++#include <linux/mutex.h>
++#include <linux/printk.h>
++#include <linux/platform_device.h>
++#include <linux/spi/spi.h>
++#include <linux/unaligned.h>
++#include <linux/wait.h>
++
++#include "spi-hid-apple.h"
++
++#define SPIHID_DEF_WAIT msecs_to_jiffies(1000)
++
++#define SPIHID_MAX_INPUT_REPORT_SIZE 0x800
++
++/* support only keyboard, trackpad and management dev for now */
++#define SPIHID_MAX_DEVICES 3
++
++#define SPIHID_DEVICE_ID_MNGT 0x0
++#define SPIHID_DEVICE_ID_KBD 0x1
++#define SPIHID_DEVICE_ID_TP 0x2
++#define SPIHID_DEVICE_ID_INFO 0xd0
++
++#define SPIHID_READ_PACKET 0x20
++#define SPIHID_WRITE_PACKET 0x40
++
++#define SPIHID_DESC_MAX 512
++
++#define SPIHID_SET_LEDS 0x0151 /* caps lock */
++
++#define SPI_RW_CHG_DELAY_US 200 /* 'Inter Stage Us'? */
++
++static const u8 spi_hid_apple_booted[4] = { 0xa0, 0x80, 0x00, 0x00 };
++static const u8 spi_hid_apple_status_ok[4] = { 0xac, 0x27, 0x68, 0xd5 };
++
++struct spihid_interface {
++	struct hid_device *hid;
++	u8 *hid_desc;
++	u32 hid_desc_len;
++	u32 id;
++	unsigned country;
++	u32 max_control_report_len;
++	u32 max_input_report_len;
++	u32 max_output_report_len;
++	u8 name[32];
++	u8 reply_buf[SPIHID_DESC_MAX];
++	u32 reply_len;
++	bool ready;
++};
++
++struct spihid_input_report {
++	u8 *buf;
++	u32 length;
++	u32 offset;
++	u8 device;
++	u8 flags;
++};
++
++struct spihid_apple {
++	struct spi_device *spidev;
++
++	struct spihid_apple_ops *ops;
++
++	struct spihid_interface mngt;
++	struct spihid_interface kbd;
++	struct spihid_interface tp;
++
++	wait_queue_head_t wait;
++	struct mutex tx_lock; //< protects against concurrent SPI writes
++
++	struct spi_message rx_msg;
++	struct spi_message tx_msg;
++	struct spi_transfer rx_transfer;
++	struct spi_transfer tx_transfer;
++	struct spi_transfer status_transfer;
++
++	u8 *rx_buf;
++	u8 *tx_buf;
++	u8 *status_buf;
++
++	u8 vendor[32];
++	u8 product[64];
++	u8 serial[32];
++
++	u32 num_devices;
++
++	u32 vendor_id;
++	u32 product_id;
++	u32 version_number;
++
++	u8 msg_id;
++
++	/* fragmented HID report */
++	struct spihid_input_report report;
++
++	/* state tracking flags */
++	bool status_booted;
++
++#ifdef IRQ_WAKE_SUPPORT
++	bool irq_wake_enabled;
++#endif
++};
++
++/**
++ * struct spihid_msg_hdr - common header of protocol messages.
++ *
++ * Each message begins with fixed header, followed by a message-type specific
++ * payload, and ends with a 16-bit crc. Because of the varying lengths of the
++ * payload, the crc is defined at the end of each payload struct, rather than
++ * in this struct.
++ *
++ * @unknown0:	request type? output, input (0x10), feature, protocol
++ * @unknown1:	maybe report id?
++ * @unknown2:	mostly zero, in info request maybe device num
++ * @msgid:	incremented on each message, rolls over after 255; there is a
++ *		separate counter for each message type.
++ * @rsplen:	response length (the exact nature of this field is quite
++ *		speculative). On a request/write this is often the same as
++ *		@length, though in some cases it has been seen to be much larger
++ *		(e.g. 0x400); on a response/read this the same as on the
++ *		request; for reads that are not responses it is 0.
++ * @length:	length of the remainder of the data in the whole message
++ *		structure (after re-assembly in case of being split over
++ *		multiple spi-packets), minus the trailing crc. The total size
++ *		of a message is therefore @length + 10.
++ */
++
++struct spihid_msg_hdr {
++	u8 unknown0;
++	u8 unknown1;
++	u8 unknown2;
++	u8 id;
++	__le16 rsplen;
++	__le16 length;
++};
++
++/**
++ * struct spihid_transfer_packet - a complete spi packet; always 256 bytes. This carries
++ * the (parts of the) message in the data. But note that this does not
++ * necessarily contain a complete message, as in some cases (e.g. many
++ * fingers pressed) the message is split over multiple packets (see the
++ * @offset, @remain, and @length fields). In general the data parts in
++ * spihid_transfer_packet's are concatenated until @remaining is 0, and the
++ * result is an message.
++ *
++ * @flags:	0x40 = write (to device), 0x20 = read (from device); note that
++ *		the response to a write still has 0x40.
++ * @device:	1 = keyboard, 2 = touchpad
++ * @offset:	specifies the offset of this packet's data in the complete
++ *		message; i.e. > 0 indicates this is a continuation packet (in
++ *		the second packet for a message split over multiple packets
++ *		this would then be the same as the @length in the first packet)
++ * @remain:	number of message bytes remaining in subsequents packets (in
++ *		the first packet of a message split over two packets this would
++ *		then be the same as the @length in the second packet)
++ * @length:	length of the valid data in the @data in this packet
++ * @data:	all or part of a message
++ * @crc16:	crc over this whole structure minus this @crc16 field. This
++ *		covers just this packet, even on multi-packet messages (in
++ *		contrast to the crc in the message).
++ */
++struct spihid_transfer_packet {
++	u8 flags;
++	u8 device;
++	__le16 offset;
++	__le16 remain;
++	__le16 length;
++	u8 data[246];
++	__le16 crc16;
++};
++
++/*
++ * how HID is mapped onto the protocol is not fully clear. This are the known
++ * reports/request:
++ *
++ *			pkt.flags	pkt.dev?	msg.u0	msg.u1	msg.u2
++ * info			0x40		0xd0		0x20	0x01	0xd0
++ *
++ * info mngt:		0x40		0xd0		0x20	0x10	0x00
++ * info kbd:		0x40		0xd0		0x20	0x10	0x01
++ * info tp:		0x40		0xd0		0x20	0x10	0x02
++ *
++ * desc kbd:		0x40		0xd0		0x20	0x10	0x01
++ * desc trackpad:	0x40		0xd0		0x20	0x10	0x02
++ *
++ * mt mode:		0x40		0x02		0x52	0x02	0x00	set protocol?
++ * capslock led		0x40		0x01		0x51	0x01	0x00	output report
++ *
++ * report kbd:		0x20		0x01		0x10	0x01	0x00	input report
++ * report tp:		0x20		0x02		0x10	0x02	0x00	input report
++ *
++ */
++
++
++static int spihid_apple_request(struct spihid_apple *spihid, u8 target, u8 unk0,
++				u8 unk1, u8 unk2, u16 resp_len, u8 *buf,
++				    size_t len)
++{
++	struct spihid_transfer_packet *pkt;
++	struct spihid_msg_hdr *hdr;
++	u16 crc;
++	int err;
++
++	/* know reports are small enoug to fit in a single packet */
++	if (len > sizeof(pkt->data) - sizeof(*hdr) - sizeof(__le16))
++		return -EINVAL;
++
++	err = mutex_lock_interruptible(&spihid->tx_lock);
++	if (err < 0)
++		return err;
++
++	pkt = (struct spihid_transfer_packet *)spihid->tx_buf;
++
++	memset(pkt, 0, sizeof(*pkt));
++	pkt->flags = SPIHID_WRITE_PACKET;
++	pkt->device = target;
++	pkt->length = cpu_to_le16(sizeof(*hdr) + len + sizeof(__le16));
++
++	hdr = (struct spihid_msg_hdr *)&pkt->data[0];
++	hdr->unknown0 = unk0;
++	hdr->unknown1 = unk1;
++	hdr->unknown2 = unk2;
++	hdr->id = spihid->msg_id++;
++	hdr->rsplen = cpu_to_le16(resp_len);
++	hdr->length = cpu_to_le16(len);
++
++	if (len)
++		memcpy(pkt->data + sizeof(*hdr), buf, len);
++	crc = crc16(0, &pkt->data[0], sizeof(*hdr) + len);
++	put_unaligned_le16(crc, pkt->data + sizeof(*hdr) + len);
++
++	pkt->crc16 = cpu_to_le16(crc16(0, spihid->tx_buf,
++				 offsetof(struct spihid_transfer_packet, crc16)));
++
++	memset(spihid->status_buf, 0, sizeof(spi_hid_apple_status_ok));
++
++	err = spi_sync(spihid->spidev, &spihid->tx_msg);
++
++	if (memcmp(spihid->status_buf, spi_hid_apple_status_ok,
++		   sizeof(spi_hid_apple_status_ok))) {
++		u8 *b = spihid->status_buf;
++		dev_warn_ratelimited(&spihid->spidev->dev, "status message "
++				     "mismatch: %02x %02x %02x %02x\n",
++				     b[0], b[1], b[2], b[3]);
++	}
++	mutex_unlock(&spihid->tx_lock);
++	if (err < 0)
++		return err;
++
++	return (int)len;
++}
++
++static struct spihid_apple *spihid_get_data(struct spihid_interface *idev)
++{
++	switch (idev->id) {
++	case SPIHID_DEVICE_ID_KBD:
++		return container_of(idev, struct spihid_apple, kbd);
++	case SPIHID_DEVICE_ID_TP:
++		return container_of(idev, struct spihid_apple, tp);
++	default:
++		return NULL;
++	}
++}
++
++static int apple_ll_start(struct hid_device *hdev)
++{
++	/* no-op SPI transport is already setup */
++	return 0;
++};
++
++static void apple_ll_stop(struct hid_device *hdev)
++{
++	/* no-op, devices will be desstroyed on driver destruction */
++}
++
++static int apple_ll_open(struct hid_device *hdev)
++{
++	struct spihid_apple *spihid;
++	struct spihid_interface *idev = hdev->driver_data;
++
++	if (idev->hid_desc_len == 0) {
++		spihid = spihid_get_data(idev);
++		dev_warn(&spihid->spidev->dev,
++			 "HID descriptor missing for dev %u", idev->id);
++	} else
++		idev->ready = true;
++
++	return 0;
++}
++
++static void apple_ll_close(struct hid_device *hdev)
++{
++	struct spihid_interface *idev = hdev->driver_data;
++	idev->ready = false;
++}
++
++static int apple_ll_parse(struct hid_device *hdev)
++{
++	struct spihid_interface *idev = hdev->driver_data;
++
++	return hid_parse_report(hdev, idev->hid_desc, idev->hid_desc_len);
++}
++
++static int apple_ll_raw_request(struct hid_device *hdev,
++				unsigned char reportnum, __u8 *buf, size_t len,
++				unsigned char rtype, int reqtype)
++{
++	struct spihid_interface *idev = hdev->driver_data;
++	struct spihid_apple *spihid = spihid_get_data(idev);
++	int ret;
++
++	dev_dbg(&spihid->spidev->dev,
++		"apple_ll_raw_request: device:%u reportnum:%hhu rtype:%hhu",
++		idev->id, reportnum, rtype);
++
++	switch (reqtype) {
++	case HID_REQ_GET_REPORT:
++		if (rtype != HID_FEATURE_REPORT)
++			return -EINVAL;
++
++		idev->reply_len = 0;
++		ret = spihid_apple_request(spihid, idev->id, 0x32, reportnum, 0x00, len, NULL, 0);
++		if (ret < 0)
++			return ret;
++
++		ret = wait_event_interruptible_timeout(spihid->wait, idev->reply_len,
++						       SPIHID_DEF_WAIT);
++		if (ret == 0)
++			ret = -ETIMEDOUT;
++		if (ret < 0) {
++			dev_err(&spihid->spidev->dev, "waiting for get report failed: %d", ret);
++			return ret;
++		}
++		memcpy(buf, idev->reply_buf, max_t(size_t, len, idev->reply_len));
++		return idev->reply_len;
++
++	case HID_REQ_SET_REPORT:
++		if (buf[0] != reportnum)
++			return -EINVAL;
++		if (reportnum != idev->id) {
++			dev_warn(&spihid->spidev->dev,
++				 "device:%u reportnum:"
++				 "%hhu mismatch",
++				 idev->id, reportnum);
++			return -EINVAL;
++		}
++		return spihid_apple_request(spihid, idev->id, 0x52, reportnum, 0x00, 2, buf, len);
++	default:
++		return -EIO;
++	}
++}
++
++static int apple_ll_output_report(struct hid_device *hdev, __u8 *buf,
++				  size_t len)
++{
++	struct spihid_interface *idev = hdev->driver_data;
++	struct spihid_apple *spihid = spihid_get_data(idev);
++	if (!spihid)
++		return -1;
++
++	dev_dbg(&spihid->spidev->dev,
++		"apple_ll_output_report: device:%u len:%zu:",
++		idev->id, len);
++	// second idev->id should maybe be buf[0]?
++	return spihid_apple_request(spihid, idev->id, 0x51, idev->id, 0x00, 0, buf, len);
++}
++
++static struct hid_ll_driver apple_hid_ll = {
++	.start = &apple_ll_start,
++	.stop = &apple_ll_stop,
++	.open = &apple_ll_open,
++	.close = &apple_ll_close,
++	.parse = &apple_ll_parse,
++	.raw_request = &apple_ll_raw_request,
++	.output_report = &apple_ll_output_report,
++	.max_buffer_size = SPIHID_MAX_INPUT_REPORT_SIZE,
++};
++
++static struct spihid_interface *spihid_get_iface(struct spihid_apple *spihid,
++						 u32 iface)
++{
++	switch (iface) {
++	case SPIHID_DEVICE_ID_MNGT:
++		return &spihid->mngt;
++	case SPIHID_DEVICE_ID_KBD:
++		return &spihid->kbd;
++	case SPIHID_DEVICE_ID_TP:
++		return &spihid->tp;
++	default:
++		return NULL;
++	}
++}
++
++static int spihid_verify_msg(struct spihid_apple *spihid, u8 *buf, size_t len)
++{
++	u16 msg_crc, crc;
++	struct device *dev = &spihid->spidev->dev;
++
++	crc = crc16(0, buf, len - sizeof(__le16));
++	msg_crc = get_unaligned_le16(buf + len - sizeof(__le16));
++	if (crc != msg_crc) {
++		dev_warn_ratelimited(dev, "Read message crc mismatch\n");
++		return 0;
++	}
++	return 1;
++}
++
++static bool spihid_status_report(struct spihid_apple *spihid, u8 *pl,
++				 size_t len)
++{
++	struct device *dev = &spihid->spidev->dev;
++	dev_dbg(dev, "%s: len: %zu", __func__, len);
++	if (len == 5 && pl[0] == 0xe0)
++		return true;
++
++	return false;
++}
++
++static bool spihid_process_input_report(struct spihid_apple *spihid, u32 device,
++					struct spihid_msg_hdr *hdr, u8 *payload,
++					size_t len)
++{
++	//dev_dbg(&spihid>spidev->dev, "input report: req:%hx iface:%u ", hdr->unknown0, device);
++	if (hdr->unknown0 != 0x10)
++		return false;
++
++	/* HID device as well but Vendor usage only, handle it internally for now */
++	if (device == 0) {
++		if (hdr->unknown1 == 0xe0) {
++			return spihid_status_report(spihid, payload, len);
++		}
++	} else if (device < SPIHID_MAX_DEVICES) {
++		struct spihid_interface *iface =
++			spihid_get_iface(spihid, device);
++		if (iface && iface->hid && iface->ready) {
++			hid_input_report(iface->hid, HID_INPUT_REPORT, payload,
++					 len, 1);
++			return true;
++		}
++	} else
++		dev_dbg(&spihid->spidev->dev,
++			"unexpected iface:%u for input report", device);
++
++	return false;
++}
++
++struct spihid_device_info {
++	__le16 u0[2];
++	__le16 num_devices;
++	__le16 vendor_id;
++	__le16 product_id;
++	__le16 version_number;
++	__le16 vendor_str[2]; //< offset and string length
++	__le16 product_str[2]; //< offset and string length
++	__le16 serial_str[2]; //< offset and string length
++};
++
++static bool spihid_process_device_info(struct spihid_apple *spihid, u32 iface,
++				       u8 *payload, size_t len)
++{
++	struct device *dev = &spihid->spidev->dev;
++
++	if (iface != SPIHID_DEVICE_ID_INFO)
++		return false;
++
++	if (spihid->vendor_id == 0 &&
++	    len >= sizeof(struct spihid_device_info)) {
++		struct spihid_device_info *info =
++			(struct spihid_device_info *)payload;
++		u16 voff, vlen, poff, plen, soff, slen;
++		u32 num_devices;
++
++		num_devices = __le16_to_cpu(info->num_devices);
++
++		if (num_devices < SPIHID_MAX_DEVICES) {
++			dev_err(dev,
++				"Device info reports %u devices, expecting at least 3",
++				num_devices);
++			return false;
++		}
++		spihid->num_devices = num_devices;
++
++		if (spihid->num_devices > SPIHID_MAX_DEVICES) {
++			dev_info(
++				dev,
++				"limiting the number of devices to mngt, kbd and mouse");
++			spihid->num_devices = SPIHID_MAX_DEVICES;
++		}
++
++		spihid->vendor_id = __le16_to_cpu(info->vendor_id);
++		spihid->product_id = __le16_to_cpu(info->product_id);
++		spihid->version_number = __le16_to_cpu(info->version_number);
++
++		voff = __le16_to_cpu(info->vendor_str[0]);
++		vlen = __le16_to_cpu(info->vendor_str[1]);
++
++		if (voff < len && vlen <= len - voff &&
++		    vlen < sizeof(spihid->vendor)) {
++			memcpy(spihid->vendor, payload + voff, vlen);
++			spihid->vendor[vlen] = '\0';
++		}
++
++		poff = __le16_to_cpu(info->product_str[0]);
++		plen = __le16_to_cpu(info->product_str[1]);
++
++		if (poff < len && plen <= len - poff &&
++		    plen < sizeof(spihid->product)) {
++			memcpy(spihid->product, payload + poff, plen);
++			spihid->product[plen] = '\0';
++		}
++
++		soff = __le16_to_cpu(info->serial_str[0]);
++		slen = __le16_to_cpu(info->serial_str[1]);
++
++		if (soff < len && slen <= len - soff &&
++		    slen < sizeof(spihid->serial)) {
++			memcpy(spihid->vendor, payload + soff, slen);
++			spihid->serial[slen] = '\0';
++		}
++
++		wake_up_interruptible(&spihid->wait);
++	}
++	return true;
++}
++
++struct spihid_iface_info {
++	u8 u_0;
++	u8 interface_num;
++	u8 u_2;
++	u8 u_3;
++	u8 u_4;
++	u8 country_code;
++	__le16 max_input_report_len;
++	__le16 max_output_report_len;
++	__le16 max_control_report_len;
++	__le16 name_offset;
++	__le16 name_length;
++};
++
++static bool spihid_process_iface_info(struct spihid_apple *spihid, u32 num,
++				      u8 *payload, size_t len)
++{
++	struct spihid_iface_info *info;
++	struct spihid_interface *iface = spihid_get_iface(spihid, num);
++	u32 name_off, name_len;
++
++	if (!iface)
++		return false;
++
++	if (!iface->max_input_report_len) {
++		if (len < sizeof(*info))
++			return false;
++
++		info = (struct spihid_iface_info *)payload;
++
++		iface->max_input_report_len =
++			le16_to_cpu(info->max_input_report_len);
++		iface->max_output_report_len =
++			le16_to_cpu(info->max_output_report_len);
++		iface->max_control_report_len =
++			le16_to_cpu(info->max_control_report_len);
++		iface->country = info->country_code;
++
++		name_off = le16_to_cpu(info->name_offset);
++		name_len = le16_to_cpu(info->name_length);
++
++		if (name_off < len && name_len <= len - name_off &&
++		    name_len < sizeof(iface->name)) {
++			memcpy(iface->name, payload + name_off, name_len);
++			iface->name[name_len] = '\0';
++		}
++
++		dev_dbg(&spihid->spidev->dev, "Info for %s, country code: 0x%x",
++			iface->name, iface->country);
++
++		wake_up_interruptible(&spihid->wait);
++	}
++
++	return true;
++}
++
++static int spihid_register_hid_device(struct spihid_apple *spihid,
++				      struct spihid_interface *idev, u8 device);
++
++static bool spihid_process_iface_hid_report_desc(struct spihid_apple *spihid,
++						 u32 num, u8 *payload,
++						 size_t len)
++{
++	struct spihid_interface *iface = spihid_get_iface(spihid, num);
++
++	if (!iface)
++		return false;
++
++	if (iface->hid_desc_len == 0) {
++		if (len > SPIHID_DESC_MAX)
++			return false;
++		memcpy(iface->hid_desc, payload, len);
++		iface->hid_desc_len = len;
++
++		/* do not register the mngt iface as HID device */
++		if (num > 0)
++			spihid_register_hid_device(spihid, iface, num);
++
++		wake_up_interruptible(&spihid->wait);
++	}
++	return true;
++}
++
++static bool spihid_process_iface_get_report(struct spihid_apple *spihid,
++					    u32 device, u8 report,
++					    u8 *payload, size_t len)
++{
++	struct spihid_interface *iface = spihid_get_iface(spihid, device);
++
++	if (!iface)
++		return false;
++
++	if (len > sizeof(iface->reply_buf) || len < 1)
++		return false;
++
++	memcpy(iface->reply_buf, payload, len);
++	iface->reply_len = len;
++
++	wake_up_interruptible(&spihid->wait);
++
++	return true;
++}
++
++static bool spihid_process_response(struct spihid_apple *spihid, u32 device,
++				    struct spihid_msg_hdr *hdr, u8 *payload,
++				    size_t len)
++{
++	if (hdr->unknown0 == 0x20) {
++		switch (hdr->unknown1) {
++		case 0x01:
++			return spihid_process_device_info(spihid, hdr->unknown2,
++							  payload, len);
++		case 0x02:
++			return spihid_process_iface_info(spihid, hdr->unknown2,
++							 payload, len);
++		case 0x10:
++			return spihid_process_iface_hid_report_desc(
++				spihid, hdr->unknown2, payload, len);
++		default:
++			break;
++		}
++	}
++
++	if (hdr->unknown0 == 0x32) {
++		return spihid_process_iface_get_report(spihid, device, hdr->unknown1, payload, len);
++	}
++
++	return false;
++}
++
++static void spihid_process_message(struct spihid_apple *spihid, u8 *data,
++				   size_t length, u8 device, u8 flags)
++{
++	struct device *dev = &spihid->spidev->dev;
++	struct spihid_msg_hdr *hdr;
++	bool handled = false;
++	size_t payload_len;
++	u8 *payload;
++
++	if (!spihid_verify_msg(spihid, data, length))
++		return;
++
++	hdr = (struct spihid_msg_hdr *)data;
++	payload_len = le16_to_cpu(hdr->length);
++
++	if (payload_len == 0 ||
++		(payload_len + sizeof(struct spihid_msg_hdr) + 2) > length)
++		return;
++
++	payload = data + sizeof(struct spihid_msg_hdr);
++
++	switch (flags) {
++	case SPIHID_READ_PACKET:
++		handled = spihid_process_input_report(spihid, device, hdr,
++						      payload, payload_len);
++		break;
++	case SPIHID_WRITE_PACKET:
++		handled = spihid_process_response(spihid, device, hdr, payload,
++						  payload_len);
++		break;
++	default:
++		break;
++	}
++
++#if defined(DEBUG) && DEBUG > 1
++	{
++		dev_dbg(dev,
++			"R msg: req:%02hhx rep:%02hhx dev:%02hhx id:%hu len:%hu\n",
++			hdr->unknown0, hdr->unknown1, hdr->unknown2, hdr->id,
++			hdr->length);
++		print_hex_dump_debug("spihid msg: ", DUMP_PREFIX_OFFSET, 16, 1,
++				     payload, le16_to_cpu(hdr->length), true);
++	}
++#else
++	if (!handled) {
++		dev_dbg(dev,
++			"R unhandled msg: req:%02hhx rep:%02hhx dev:%02hhx id:%hu len:%hu\n",
++			hdr->unknown0, hdr->unknown1, hdr->unknown2, hdr->id,
++			hdr->length);
++		print_hex_dump_debug("spihid msg: ", DUMP_PREFIX_OFFSET, 16, 1,
++				     payload, le16_to_cpu(hdr->length), true);
++	}
++#endif
++}
++
++static void spihid_assemble_message(struct spihid_apple *spihid,
++				    struct spihid_transfer_packet *pkt)
++{
++	size_t length, offset, remain;
++	struct device *dev = &spihid->spidev->dev;
++	struct spihid_input_report *rep = &spihid->report;
++
++	length = le16_to_cpu(pkt->length);
++	remain = le16_to_cpu(pkt->remain);
++	offset = le16_to_cpu(pkt->offset);
++
++	if (offset + length + remain > U16_MAX) {
++		return;
++	}
++
++	if (pkt->device != rep->device || pkt->flags != rep->flags ||
++	    offset != rep->offset) {
++		rep->device = 0;
++		rep->flags = 0;
++		rep->offset = 0;
++		rep->length = 0;
++	}
++
++	if (offset == 0) {
++		if (rep->offset != 0) {
++			dev_warn(dev, "incomplete report off:%u len:%u",
++				 rep->offset, rep->length);
++		}
++		memcpy(rep->buf, pkt->data, length);
++		rep->offset = length;
++		rep->length = length + remain;
++		rep->device = pkt->device;
++		rep->flags = pkt->flags;
++	} else if (offset == rep->offset) {
++		if (offset + length + remain != rep->length) {
++			dev_warn(dev, "incomplete report off:%u len:%u",
++				 rep->offset, rep->length);
++			return;
++		}
++		memcpy(rep->buf + offset, pkt->data, length);
++		rep->offset += length;
++
++		if (rep->offset == rep->length) {
++			spihid_process_message(spihid, rep->buf, rep->length,
++					       rep->device, rep->flags);
++			rep->device = 0;
++			rep->flags = 0;
++			rep->offset = 0;
++			rep->length = 0;
++		}
++	}
++}
++
++static void spihid_process_read(struct spihid_apple *spihid)
++{
++	u16 crc;
++	size_t length;
++	struct device *dev = &spihid->spidev->dev;
++	struct spihid_transfer_packet *pkt;
++
++	pkt = (struct spihid_transfer_packet *)spihid->rx_buf;
++
++	/* check transfer packet crc */
++	crc = crc16(0, spihid->rx_buf,
++		    offsetof(struct spihid_transfer_packet, crc16));
++	if (crc != le16_to_cpu(pkt->crc16)) {
++		dev_warn_ratelimited(dev, "Read package crc mismatch\n");
++		return;
++	}
++
++	length = le16_to_cpu(pkt->length);
++
++	if (length < sizeof(struct spihid_msg_hdr) + 2) {
++		if (length == sizeof(spi_hid_apple_booted) &&
++		    !memcmp(pkt->data, spi_hid_apple_booted, length)) {
++			if (!spihid->status_booted) {
++				spihid->status_booted = true;
++				wake_up_interruptible(&spihid->wait);
++			}
++		} else {
++			dev_info(dev, "R short packet: len:%zu\n", length);
++			print_hex_dump(KERN_INFO, "spihid pkt:",
++				       DUMP_PREFIX_OFFSET, 16, 1, pkt->data,
++				       length, false);
++		}
++		return;
++	}
++
++#if defined(DEBUG) && DEBUG > 1
++	dev_dbg(dev,
++		"R pkt: flags:%02hhx dev:%02hhx off:%hu remain:%hu, len:%zu\n",
++		pkt->flags, pkt->device, pkt->offset, pkt->remain, length);
++#if defined(DEBUG) && DEBUG > 2
++	print_hex_dump_debug("spihid pkt: ", DUMP_PREFIX_OFFSET, 16, 1,
++			     spihid->rx_buf,
++			     sizeof(struct spihid_transfer_packet), true);
++#endif
++#endif
++
++	if (length > sizeof(pkt->data)) {
++		dev_warn_ratelimited(dev, "Invalid pkt len:%zu", length);
++		return;
++	}
++
++	/* short message */
++	if (pkt->offset == 0 && pkt->remain == 0) {
++		spihid_process_message(spihid, pkt->data, length, pkt->device,
++				       pkt->flags);
++	} else {
++		spihid_assemble_message(spihid, pkt);
++	}
++}
++
++static void spihid_read_packet_sync(struct spihid_apple *spihid)
++{
++	int err;
++
++	err = spi_sync(spihid->spidev, &spihid->rx_msg);
++	if (!err) {
++		spihid_process_read(spihid);
++	} else {
++		dev_warn(&spihid->spidev->dev, "RX failed: %d\n", err);
++	}
++}
++
++irqreturn_t spihid_apple_core_irq(int irq, void *data)
++{
++	struct spi_device *spi = data;
++	struct spihid_apple *spihid = spi_get_drvdata(spi);
++
++	spihid_read_packet_sync(spihid);
++
++	return IRQ_HANDLED;
++}
++EXPORT_SYMBOL_GPL(spihid_apple_core_irq);
++
++static void spihid_apple_setup_spi_msgs(struct spihid_apple *spihid)
++{
++	memset(&spihid->rx_transfer, 0, sizeof(spihid->rx_transfer));
++
++	spihid->rx_transfer.rx_buf = spihid->rx_buf;
++	spihid->rx_transfer.len = sizeof(struct spihid_transfer_packet);
++
++	spi_message_init(&spihid->rx_msg);
++	spi_message_add_tail(&spihid->rx_transfer, &spihid->rx_msg);
++
++	memset(&spihid->tx_transfer, 0, sizeof(spihid->rx_transfer));
++	memset(&spihid->status_transfer, 0, sizeof(spihid->status_transfer));
++
++	spihid->tx_transfer.tx_buf = spihid->tx_buf;
++	spihid->tx_transfer.len = sizeof(struct spihid_transfer_packet);
++	spihid->tx_transfer.delay.unit = SPI_DELAY_UNIT_USECS;
++	spihid->tx_transfer.delay.value = SPI_RW_CHG_DELAY_US;
++
++	spihid->status_transfer.rx_buf = spihid->status_buf;
++	spihid->status_transfer.len = sizeof(spi_hid_apple_status_ok);
++
++	spi_message_init(&spihid->tx_msg);
++	spi_message_add_tail(&spihid->tx_transfer, &spihid->tx_msg);
++	spi_message_add_tail(&spihid->status_transfer, &spihid->tx_msg);
++}
++
++static int spihid_apple_setup_spi(struct spihid_apple *spihid)
++{
++	spihid_apple_setup_spi_msgs(spihid);
++
++	return spihid->ops->power_on(spihid->ops);
++}
++
++static int spihid_register_hid_device(struct spihid_apple *spihid,
++				      struct spihid_interface *iface, u8 device)
++{
++	int ret;
++	char *suffix;
++	struct hid_device *hid;
++
++	iface->id = device;
++
++	hid = hid_allocate_device();
++	if (IS_ERR(hid))
++		return PTR_ERR(hid);
++
++	/*
++	 * Use 'Apple SPI Keyboard' and 'Apple SPI Trackpad' as input device
++	 * names. The device names need to be distinct since at least Kwin uses
++	 * the tripple Vendor ID, Product ID, Name to identify devices.
++	 */
++	snprintf(hid->name, sizeof(hid->name), "Apple SPI %s", iface->name);
++	// strip ' / Boot' suffix from the name
++	suffix = strstr(hid->name, " / Boot");
++	if (suffix)
++		suffix[0] = '\0';
++	snprintf(hid->phys, sizeof(hid->phys), "%s (%hhx)",
++		 dev_name(&spihid->spidev->dev), device);
++	strscpy(hid->uniq, spihid->serial, sizeof(hid->uniq));
++
++	hid->ll_driver = &apple_hid_ll;
++	hid->bus = BUS_SPI;
++	hid->vendor = spihid->vendor_id;
++	hid->product = spihid->product_id;
++	hid->version = spihid->version_number;
++
++	if (device == SPIHID_DEVICE_ID_KBD)
++		hid->type = HID_TYPE_SPI_KEYBOARD;
++	else if (device == SPIHID_DEVICE_ID_TP)
++		hid->type = HID_TYPE_SPI_MOUSE;
++
++	hid->country = iface->country;
++	hid->dev.parent = &spihid->spidev->dev;
++	hid->driver_data = iface;
++
++	ret = hid_add_device(hid);
++	if (ret < 0) {
++		hid_destroy_device(hid);
++		dev_warn(&spihid->spidev->dev,
++			 "Failed to register hid device %hhu", device);
++		return ret;
++	}
++
++	iface->hid = hid;
++
++	return 0;
++}
++
++static void spihid_destroy_hid_device(struct spihid_interface *iface)
++{
++	if (iface->hid) {
++		hid_destroy_device(iface->hid);
++		iface->hid = NULL;
++	}
++	iface->ready = false;
++}
++
++int spihid_apple_core_probe(struct spi_device *spi, struct spihid_apple_ops *ops)
++{
++	struct device *dev = &spi->dev;
++	struct spihid_apple *spihid;
++	int err, i;
++
++	if (!ops || !ops->power_on || !ops->power_off || !ops->enable_irq || !ops->disable_irq)
++		return -EINVAL;
++
++	spihid = devm_kzalloc(dev, sizeof(*spihid), GFP_KERNEL);
++	if (!spihid)
++		return -ENOMEM;
++
++	spihid->ops = ops;
++	spihid->spidev = spi;
++
++	// init spi
++	spi_set_drvdata(spi, spihid);
++
++	/*
++	 * allocate SPI buffers
++	 * Overallocate the receice buffer since it passed directly into
++	 * hid_input_report / hid_report_raw_event. The later expects the buffer
++	 * to be HID_MAX_BUFFER_SIZE (16k) or hid_ll_driver.max_buffer_size if
++	 * set.
++	 */
++	spihid->rx_buf = devm_kmalloc(
++		&spi->dev, SPIHID_MAX_INPUT_REPORT_SIZE, GFP_KERNEL);
++	spihid->tx_buf = devm_kmalloc(
++		&spi->dev, sizeof(struct spihid_transfer_packet), GFP_KERNEL);
++	spihid->status_buf = devm_kmalloc(
++		&spi->dev, sizeof(spi_hid_apple_status_ok), GFP_KERNEL);
++
++	if (!spihid->rx_buf || !spihid->tx_buf || !spihid->status_buf)
++		return -ENOMEM;
++
++	spihid->report.buf =
++		devm_kmalloc(dev, SPIHID_MAX_INPUT_REPORT_SIZE, GFP_KERNEL);
++
++	spihid->kbd.hid_desc = devm_kmalloc(dev, SPIHID_DESC_MAX, GFP_KERNEL);
++	spihid->tp.hid_desc = devm_kmalloc(dev, SPIHID_DESC_MAX, GFP_KERNEL);
++
++	if (!spihid->report.buf || !spihid->kbd.hid_desc ||
++	    !spihid->tp.hid_desc)
++		return -ENOMEM;
++
++	init_waitqueue_head(&spihid->wait);
++
++	mutex_init(&spihid->tx_lock);
++
++	/* Init spi transfer buffers and power device on */
++	err = spihid_apple_setup_spi(spihid);
++	if (err < 0)
++		goto error;
++
++	/* enable HID irq */
++	spihid->ops->enable_irq(spihid->ops);
++
++	// wait for boot message
++	err = wait_event_interruptible_timeout(spihid->wait,
++					       spihid->status_booted,
++					       msecs_to_jiffies(1000));
++	if (err == 0)
++		err = -ENODEV;
++	if (err < 0) {
++		dev_err(dev, "waiting for device boot failed: %d", err);
++		goto error;
++	}
++
++	/* request device information */
++	dev_dbg(dev, "request device info");
++	spihid_apple_request(spihid, 0xd0, 0x20, 0x01, 0xd0, 0, NULL, 0);
++	err = wait_event_interruptible_timeout(spihid->wait, spihid->vendor_id,
++					       SPIHID_DEF_WAIT);
++	if (err == 0)
++		err = -ENODEV;
++	if (err < 0) {
++		dev_err(dev, "waiting for device info failed: %d", err);
++		goto error;
++	}
++
++	/* request interface information */
++	for (i = 0; i < spihid->num_devices; i++) {
++		struct spihid_interface *iface = spihid_get_iface(spihid, i);
++		if (!iface)
++			continue;
++		dev_dbg(dev, "request interface info 0x%02x", i);
++		spihid_apple_request(spihid, 0xd0, 0x20, 0x02, i,
++				     SPIHID_DESC_MAX, NULL, 0);
++		err = wait_event_interruptible_timeout(
++			spihid->wait, iface->max_input_report_len,
++			SPIHID_DEF_WAIT);
++	}
++
++	/* request HID report descriptors */
++	for (i = 1; i < spihid->num_devices; i++) {
++		struct spihid_interface *iface = spihid_get_iface(spihid, i);
++		if (!iface)
++			continue;
++		dev_dbg(dev, "request hid report desc 0x%02x", i);
++		spihid_apple_request(spihid, 0xd0, 0x20, 0x10, i,
++				     SPIHID_DESC_MAX, NULL, 0);
++		wait_event_interruptible_timeout(
++			spihid->wait, iface->hid_desc_len, SPIHID_DEF_WAIT);
++	}
++
++	return 0;
++error:
++	return err;
++}
++EXPORT_SYMBOL_GPL(spihid_apple_core_probe);
++
++void spihid_apple_core_remove(struct spi_device *spi)
++{
++	struct spihid_apple *spihid = spi_get_drvdata(spi);
++
++	/* destroy input devices */
++
++	spihid_destroy_hid_device(&spihid->tp);
++	spihid_destroy_hid_device(&spihid->kbd);
++
++	/* disable irq */
++	spihid->ops->disable_irq(spihid->ops);
++
++	/* power SPI device down */
++	spihid->ops->power_off(spihid->ops);
++}
++EXPORT_SYMBOL_GPL(spihid_apple_core_remove);
++
++void spihid_apple_core_shutdown(struct spi_device *spi)
++{
++	struct spihid_apple *spihid = spi_get_drvdata(spi);
++
++	/* disable irq */
++	spihid->ops->disable_irq(spihid->ops);
++
++	/* power SPI device down */
++	spihid->ops->power_off(spihid->ops);
++}
++EXPORT_SYMBOL_GPL(spihid_apple_core_shutdown);
++
++#ifdef CONFIG_PM_SLEEP
++static int spihid_apple_core_suspend(struct device *dev)
++{
++	int ret;
++#ifdef IRQ_WAKE_SUPPORT
++	int wake_status;
++#endif
++	struct spihid_apple *spihid = spi_get_drvdata(to_spi_device(dev));
++
++	if (spihid->tp.hid) {
++		ret = hid_driver_suspend(spihid->tp.hid, PMSG_SUSPEND);
++		if (ret < 0)
++			return ret;
++	}
++
++	if (spihid->kbd.hid) {
++		ret = hid_driver_suspend(spihid->kbd.hid, PMSG_SUSPEND);
++		if (ret < 0) {
++			if (spihid->tp.hid)
++				hid_driver_resume(spihid->tp.hid);
++			return ret;
++		}
++	}
++
++	/* Save some power */
++	spihid->ops->disable_irq(spihid->ops);
++
++#ifdef IRQ_WAKE_SUPPORT
++	if (device_may_wakeup(dev)) {
++		wake_status = spihid->ops->enable_irq_wake(spihid->ops);
++		if (!wake_status)
++			spihid->irq_wake_enabled = true;
++		else
++			dev_warn(dev, "Failed to enable irq wake: %d\n",
++				wake_status);
++	} else {
++		spihid->ops->power_off(spihid->ops);
++	}
++#else
++	spihid->ops->power_off(spihid->ops);
++#endif
++
++	return 0;
++}
++
++static int spihid_apple_core_resume(struct device *dev)
++{
++	int ret_tp = 0, ret_kbd = 0;
++	struct spihid_apple *spihid = spi_get_drvdata(to_spi_device(dev));
++#ifdef IRQ_WAKE_SUPPORT
++	int wake_status;
++
++	if (!device_may_wakeup(dev)) {
++		spihid->ops->power_on(spihid->ops);
++	} else if (spihid->irq_wake_enabled) {
++		wake_status = spihid->ops->disable_irq_wake(spihid->ops);
++		if (!wake_status)
++			spihid->irq_wake_enabled = false;
++		else
++			dev_warn(dev, "Failed to disable irq wake: %d\n",
++				wake_status);
++	}
++#endif
++
++	spihid->ops->enable_irq(spihid->ops);
++	spihid->ops->power_on(spihid->ops);
++
++	if (spihid->tp.hid)
++		ret_tp = hid_driver_reset_resume(spihid->tp.hid);
++	if (spihid->kbd.hid)
++		ret_kbd = hid_driver_reset_resume(spihid->kbd.hid);
++
++	if (ret_tp < 0)
++		return ret_tp;
++
++	return ret_kbd;
++}
++#endif
++
++const struct dev_pm_ops spihid_apple_core_pm = {
++	SET_SYSTEM_SLEEP_PM_OPS(spihid_apple_core_suspend,
++				spihid_apple_core_resume)
++};
++EXPORT_SYMBOL_GPL(spihid_apple_core_pm);
++
++MODULE_DESCRIPTION("Apple SPI HID transport driver");
++MODULE_AUTHOR("Janne Grunau <j@jannau.net>");
++MODULE_LICENSE("GPL");
+diff --git a/drivers/hid/spi-hid/spi-hid-apple-of.c b/drivers/hid/spi-hid/spi-hid-apple-of.c
+new file mode 100644
+index 000000000000..3f87b299351d
+--- /dev/null
++++ b/drivers/hid/spi-hid/spi-hid-apple-of.c
+@@ -0,0 +1,151 @@
++/*
++ * SPDX-License-Identifier: GPL-2.0
++ *
++ * Apple SPI HID transport driver - Open Firmware
++ *
++ * Copyright (C) The Asahi Linux Contributors
++ */
++
++#include <linux/delay.h>
++#include <linux/interrupt.h>
++#include <linux/of.h>
++#include <linux/of_irq.h>
++
++#include "spi-hid-apple.h"
++
++
++struct spihid_apple_of {
++	struct spihid_apple_ops ops;
++
++	struct gpio_desc *enable_gpio;
++	int irq;
++};
++
++static int spihid_apple_of_power_on(struct spihid_apple_ops *ops)
++{
++	struct spihid_apple_of *sh_of = container_of(ops, struct spihid_apple_of, ops);
++
++	/* reset the controller on boot */
++	gpiod_direction_output(sh_of->enable_gpio, 1);
++	msleep(5);
++	gpiod_direction_output(sh_of->enable_gpio, 0);
++	msleep(5);
++	/* turn SPI device on */
++	gpiod_direction_output(sh_of->enable_gpio, 1);
++	msleep(50);
++
++	return 0;
++}
++
++static int spihid_apple_of_power_off(struct spihid_apple_ops *ops)
++{
++	struct spihid_apple_of *sh_of = container_of(ops, struct spihid_apple_of, ops);
++
++	/* turn SPI device off */
++	gpiod_direction_output(sh_of->enable_gpio, 0);
++
++	return 0;
++}
++
++static int spihid_apple_of_enable_irq(struct spihid_apple_ops *ops)
++{
++	struct spihid_apple_of *sh_of = container_of(ops, struct spihid_apple_of, ops);
++
++	enable_irq(sh_of->irq);
++
++	return 0;
++}
++
++static int spihid_apple_of_disable_irq(struct spihid_apple_ops *ops)
++{
++	struct spihid_apple_of *sh_of = container_of(ops, struct spihid_apple_of, ops);
++
++	disable_irq(sh_of->irq);
++
++	return 0;
++}
++
++static int spihid_apple_of_enable_irq_wake(struct spihid_apple_ops *ops)
++{
++	struct spihid_apple_of *sh_of = container_of(ops, struct spihid_apple_of, ops);
++
++	return enable_irq_wake(sh_of->irq);
++}
++
++static int spihid_apple_of_disable_irq_wake(struct spihid_apple_ops *ops)
++{
++	struct spihid_apple_of *sh_of = container_of(ops, struct spihid_apple_of, ops);
++
++	return disable_irq_wake(sh_of->irq);
++}
++
++static int spihid_apple_of_probe(struct spi_device *spi)
++{
++	struct device *dev = &spi->dev;
++	struct spihid_apple_of *spihid_of;
++	int err;
++
++	spihid_of = devm_kzalloc(dev, sizeof(*spihid_of), GFP_KERNEL);
++	if (!spihid_of)
++		return -ENOMEM;
++
++	spihid_of->ops.power_on = spihid_apple_of_power_on;
++	spihid_of->ops.power_off = spihid_apple_of_power_off;
++	spihid_of->ops.enable_irq = spihid_apple_of_enable_irq;
++	spihid_of->ops.disable_irq = spihid_apple_of_disable_irq;
++	spihid_of->ops.enable_irq_wake = spihid_apple_of_enable_irq_wake;
++	spihid_of->ops.disable_irq_wake = spihid_apple_of_disable_irq_wake;
++
++	spihid_of->enable_gpio = devm_gpiod_get_index(dev, "spien", 0, 0);
++	if (IS_ERR(spihid_of->enable_gpio)) {
++		err = PTR_ERR(spihid_of->enable_gpio);
++		dev_err(dev, "failed to get 'spien' gpio pin: %d", err);
++		return err;
++	}
++
++	spihid_of->irq = of_irq_get(dev->of_node, 0);
++	if (spihid_of->irq < 0) {
++		err = spihid_of->irq;
++		dev_err(dev, "failed to get 'extended-irq': %d", err);
++		return err;
++	}
++	err = devm_request_threaded_irq(dev, spihid_of->irq, NULL,
++					spihid_apple_core_irq, IRQF_ONESHOT | IRQF_NO_AUTOEN,
++					"spi-hid-apple-irq", spi);
++	if (err < 0) {
++		dev_err(dev, "failed to request extended-irq %d: %d",
++			spihid_of->irq, err);
++		return err;
++	}
++
++	return spihid_apple_core_probe(spi, &spihid_of->ops);
++}
++
++static const struct of_device_id spihid_apple_of_match[] = {
++	{ .compatible = "apple,spi-hid-transport" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, spihid_apple_of_match);
++
++static struct spi_device_id spihid_apple_of_id[] = {
++	{ "spi-hid-transport", 0 },
++	{}
++};
++MODULE_DEVICE_TABLE(spi, spihid_apple_of_id);
++
++static struct spi_driver spihid_apple_of_driver = {
++	.driver = {
++		.name	= "spi-hid-apple-of",
++		.pm	= &spihid_apple_core_pm,
++		.of_match_table = of_match_ptr(spihid_apple_of_match),
++	},
++
++	.id_table	= spihid_apple_of_id,
++	.probe		= spihid_apple_of_probe,
++	.remove		= spihid_apple_core_remove,
++	.shutdown	= spihid_apple_core_shutdown,
++};
++
++module_spi_driver(spihid_apple_of_driver);
++
++MODULE_LICENSE("GPL");
+diff --git a/drivers/hid/spi-hid/spi-hid-apple.h b/drivers/hid/spi-hid/spi-hid-apple.h
+new file mode 100644
+index 000000000000..9abecd1ba780
+--- /dev/null
++++ b/drivers/hid/spi-hid/spi-hid-apple.h
+@@ -0,0 +1,35 @@
++/* SPDX-License-Identifier: GPL-2.0-only OR MIT */
++
++#ifndef SPI_HID_APPLE_H
++#define SPI_HID_APPLE_H
++
++#include <linux/interrupt.h>
++#include <linux/spi/spi.h>
++
++/**
++ * struct spihid_apple_ops - Ops to control the device from the core driver.
++ *
++ * @power_on: reset and power the device on.
++ * @power_off: power the device off.
++ * @enable_irq: enable irq or ACPI gpe.
++ * @disable_irq: disable irq or ACPI gpe.
++ */
++
++struct spihid_apple_ops {
++    int (*power_on)(struct spihid_apple_ops *ops);
++    int (*power_off)(struct spihid_apple_ops *ops);
++    int (*enable_irq)(struct spihid_apple_ops *ops);
++    int (*disable_irq)(struct spihid_apple_ops *ops);
++    int (*enable_irq_wake)(struct spihid_apple_ops *ops);
++    int (*disable_irq_wake)(struct spihid_apple_ops *ops);
++};
++
++irqreturn_t spihid_apple_core_irq(int irq, void *data);
++
++int spihid_apple_core_probe(struct spi_device *spi, struct spihid_apple_ops *ops);
++void spihid_apple_core_remove(struct spi_device *spi);
++void spihid_apple_core_shutdown(struct spi_device *spi);
++
++extern const struct dev_pm_ops spihid_apple_core_pm;
++
++#endif /* SPI_HID_APPLE_H */
+diff --git a/drivers/hwmon/applesmc.c b/drivers/hwmon/applesmc.c
+index fc6d6a9053ce..698f44794453 100644
+--- a/drivers/hwmon/applesmc.c
++++ b/drivers/hwmon/applesmc.c
+@@ -6,6 +6,7 @@
+  *
+  * Copyright (C) 2007 Nicolas Boichat <nicolas@boichat.ch>
+  * Copyright (C) 2010 Henrik Rydberg <rydberg@euromail.se>
++ * Copyright (C) 2019 Paul Pawlowski <paul@mrarm.io>
+  *
+  * Based on hdaps.c driver:
+  * Copyright (C) 2005 Robert Love <rml@novell.com>
+@@ -18,7 +19,7 @@
+ #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+ 
+ #include <linux/delay.h>
+-#include <linux/platform_device.h>
++#include <linux/acpi.h>
+ #include <linux/input.h>
+ #include <linux/kernel.h>
+ #include <linux/slab.h>
+@@ -35,12 +36,24 @@
+ #include <linux/bits.h>
+ 
+ /* data port used by Apple SMC */
+-#define APPLESMC_DATA_PORT	0x300
++#define APPLESMC_DATA_PORT	0
+ /* command/status port used by Apple SMC */
+-#define APPLESMC_CMD_PORT	0x304
++#define APPLESMC_CMD_PORT	4
+ 
+ #define APPLESMC_NR_PORTS	32 /* 0x300-0x31f */
+ 
++#define APPLESMC_IOMEM_KEY_DATA	0
++#define APPLESMC_IOMEM_KEY_STATUS	0x4005
++#define APPLESMC_IOMEM_KEY_NAME	0x78
++#define APPLESMC_IOMEM_KEY_DATA_LEN	0x7D
++#define APPLESMC_IOMEM_KEY_SMC_ID	0x7E
++#define APPLESMC_IOMEM_KEY_CMD		0x7F
++#define APPLESMC_IOMEM_MIN_SIZE	0x4006
++
++#define APPLESMC_IOMEM_KEY_TYPE_CODE		0
++#define APPLESMC_IOMEM_KEY_TYPE_DATA_LEN	5
++#define APPLESMC_IOMEM_KEY_TYPE_FLAGS		6
++
+ #define APPLESMC_MAX_DATA_LENGTH 32
+ 
+ /* Apple SMC status bits */
+@@ -74,6 +87,7 @@
+ #define FAN_ID_FMT		"F%dID" /* r-o char[16] */
+ 
+ #define TEMP_SENSOR_TYPE	"sp78"
++#define FLOAT_TYPE		"flt "
+ 
+ /* List of keys used to read/write fan speeds */
+ static const char *const fan_speed_fmt[] = {
+@@ -83,6 +97,7 @@ static const char *const fan_speed_fmt[] = {
+ 	"F%dSf",		/* safe speed - not all models */
+ 	"F%dTg",		/* target speed (manual: rw) */
+ };
++#define FAN_MANUAL_FMT "F%dMd"
+ 
+ #define INIT_TIMEOUT_MSECS	5000	/* wait up to 5s for device init ... */
+ #define INIT_WAIT_MSECS		50	/* ... in 50ms increments */
+@@ -119,7 +134,7 @@ struct applesmc_entry {
+ };
+ 
+ /* Register lookup and registers common to all SMCs */
+-static struct applesmc_registers {
++struct applesmc_registers {
+ 	struct mutex mutex;		/* register read/write mutex */
+ 	unsigned int key_count;		/* number of SMC registers */
+ 	unsigned int fan_count;		/* number of fans */
+@@ -133,26 +148,38 @@ static struct applesmc_registers {
+ 	bool init_complete;		/* true when fully initialized */
+ 	struct applesmc_entry *cache;	/* cached key entries */
+ 	const char **index;		/* temperature key index */
+-} smcreg = {
+-	.mutex = __MUTEX_INITIALIZER(smcreg.mutex),
+ };
+ 
+-static const int debug;
+-static struct platform_device *pdev;
+-static s16 rest_x;
+-static s16 rest_y;
+-static u8 backlight_state[2];
++struct applesmc_device {
++	struct acpi_device *dev;
++	struct device *ldev;
++	struct applesmc_registers reg;
+ 
+-static struct device *hwmon_dev;
+-static struct input_dev *applesmc_idev;
++	bool port_base_set, iomem_base_set;
++	u16 port_base;
++	u8 *__iomem iomem_base;
++	u32 iomem_base_addr, iomem_base_size;
+ 
+-/*
+- * Last index written to key_at_index sysfs file, and value to use for all other
+- * key_at_index_* sysfs files.
+- */
+-static unsigned int key_at_index;
++	s16 rest_x;
++	s16 rest_y;
++
++	u8 backlight_state[2];
++
++	struct device *hwmon_dev;
++	struct input_dev *idev;
++
++	/*
++	 * Last index written to key_at_index sysfs file, and value to use for all other
++	 * key_at_index_* sysfs files.
++	 */
++	unsigned int key_at_index;
+ 
+-static struct workqueue_struct *applesmc_led_wq;
++	struct workqueue_struct *backlight_wq;
++	struct work_struct backlight_work;
++	struct led_classdev backlight_dev;
++};
++
++static const int debug;
+ 
+ /*
+  * Wait for specific status bits with a mask on the SMC.
+@@ -162,7 +189,7 @@ static struct workqueue_struct *applesmc_led_wq;
+  * run out past 500ms.
+  */
+ 
+-static int wait_status(u8 val, u8 mask)
++static int port_wait_status(struct applesmc_device *smc, u8 val, u8 mask)
+ {
+ 	u8 status;
+ 	int us;
+@@ -170,7 +197,7 @@ static int wait_status(u8 val, u8 mask)
+ 
+ 	us = APPLESMC_MIN_WAIT;
+ 	for (i = 0; i < 24 ; i++) {
+-		status = inb(APPLESMC_CMD_PORT);
++		status = inb(smc->port_base + APPLESMC_CMD_PORT);
+ 		if ((status & mask) == val)
+ 			return 0;
+ 		usleep_range(us, us * 2);
+@@ -180,13 +207,13 @@ static int wait_status(u8 val, u8 mask)
+ 	return -EIO;
+ }
+ 
+-/* send_byte - Write to SMC data port. Callers must hold applesmc_lock. */
++/* port_send_byte - Write to SMC data port. Callers must hold applesmc_lock. */
+ 
+-static int send_byte(u8 cmd, u16 port)
++static int port_send_byte(struct applesmc_device *smc, u8 cmd, u16 port)
+ {
+ 	int status;
+ 
+-	status = wait_status(0, SMC_STATUS_IB_CLOSED);
++	status = port_wait_status(smc, 0, SMC_STATUS_IB_CLOSED);
+ 	if (status)
+ 		return status;
+ 	/*
+@@ -195,24 +222,25 @@ static int send_byte(u8 cmd, u16 port)
+ 	 * this extra read may not happen if status returns both
+ 	 * simultaneously and this would appear to be required.
+ 	 */
+-	status = wait_status(SMC_STATUS_BUSY, SMC_STATUS_BUSY);
++	status = port_wait_status(smc, SMC_STATUS_BUSY, SMC_STATUS_BUSY);
+ 	if (status)
+ 		return status;
+ 
+-	outb(cmd, port);
++	outb(cmd, smc->port_base + port);
+ 	return 0;
+ }
+ 
+-/* send_command - Write a command to the SMC. Callers must hold applesmc_lock. */
++/* port_send_command - Write a command to the SMC. Callers must hold applesmc_lock. */
+ 
+-static int send_command(u8 cmd)
++static int port_send_command(struct applesmc_device *smc, u8 cmd)
+ {
+ 	int ret;
+ 
+-	ret = wait_status(0, SMC_STATUS_IB_CLOSED);
++	ret = port_wait_status(smc, 0, SMC_STATUS_IB_CLOSED);
+ 	if (ret)
+ 		return ret;
+-	outb(cmd, APPLESMC_CMD_PORT);
++
++	outb(cmd, smc->port_base + APPLESMC_CMD_PORT);
+ 	return 0;
+ }
+ 
+@@ -222,110 +250,304 @@ static int send_command(u8 cmd)
+  * If busy is stuck high after the command then the SMC is jammed.
+  */
+ 
+-static int smc_sane(void)
++static int port_smc_sane(struct applesmc_device *smc)
+ {
+ 	int ret;
+ 
+-	ret = wait_status(0, SMC_STATUS_BUSY);
++	ret = port_wait_status(smc, 0, SMC_STATUS_BUSY);
+ 	if (!ret)
+ 		return ret;
+-	ret = send_command(APPLESMC_READ_CMD);
++	ret = port_send_command(smc, APPLESMC_READ_CMD);
+ 	if (ret)
+ 		return ret;
+-	return wait_status(0, SMC_STATUS_BUSY);
++	return port_wait_status(smc, 0, SMC_STATUS_BUSY);
+ }
+ 
+-static int send_argument(const char *key)
++static int port_send_argument(struct applesmc_device *smc, const char *key)
+ {
+ 	int i;
+ 
+ 	for (i = 0; i < 4; i++)
+-		if (send_byte(key[i], APPLESMC_DATA_PORT))
++		if (port_send_byte(smc, key[i], APPLESMC_DATA_PORT))
+ 			return -EIO;
+ 	return 0;
+ }
+ 
+-static int read_smc(u8 cmd, const char *key, u8 *buffer, u8 len)
++static int port_read_smc(struct applesmc_device *smc, u8 cmd, const char *key,
++	u8 *buffer, u8 len)
+ {
+ 	u8 status, data = 0;
+ 	int i;
+ 	int ret;
+ 
+-	ret = smc_sane();
++	ret = port_smc_sane(smc);
+ 	if (ret)
+ 		return ret;
+ 
+-	if (send_command(cmd) || send_argument(key)) {
++	if (port_send_command(smc, cmd) || port_send_argument(smc, key)) {
+ 		pr_warn("%.4s: read arg fail\n", key);
+ 		return -EIO;
+ 	}
+ 
+ 	/* This has no effect on newer (2012) SMCs */
+-	if (send_byte(len, APPLESMC_DATA_PORT)) {
++	if (port_send_byte(smc, len, APPLESMC_DATA_PORT)) {
+ 		pr_warn("%.4s: read len fail\n", key);
+ 		return -EIO;
+ 	}
+ 
+ 	for (i = 0; i < len; i++) {
+-		if (wait_status(SMC_STATUS_AWAITING_DATA | SMC_STATUS_BUSY,
++		if (port_wait_status(smc,
++				SMC_STATUS_AWAITING_DATA | SMC_STATUS_BUSY,
+ 				SMC_STATUS_AWAITING_DATA | SMC_STATUS_BUSY)) {
+ 			pr_warn("%.4s: read data[%d] fail\n", key, i);
+ 			return -EIO;
+ 		}
+-		buffer[i] = inb(APPLESMC_DATA_PORT);
++		buffer[i] = inb(smc->port_base + APPLESMC_DATA_PORT);
+ 	}
+ 
+ 	/* Read the data port until bit0 is cleared */
+ 	for (i = 0; i < 16; i++) {
+ 		udelay(APPLESMC_MIN_WAIT);
+-		status = inb(APPLESMC_CMD_PORT);
++		status = inb(smc->port_base + APPLESMC_CMD_PORT);
+ 		if (!(status & SMC_STATUS_AWAITING_DATA))
+ 			break;
+-		data = inb(APPLESMC_DATA_PORT);
++		data = inb(smc->port_base + APPLESMC_DATA_PORT);
+ 	}
+ 	if (i)
+ 		pr_warn("flushed %d bytes, last value is: %d\n", i, data);
+ 
+-	return wait_status(0, SMC_STATUS_BUSY);
++	return port_wait_status(smc, 0, SMC_STATUS_BUSY);
+ }
+ 
+-static int write_smc(u8 cmd, const char *key, const u8 *buffer, u8 len)
++static int port_write_smc(struct applesmc_device *smc, u8 cmd, const char *key,
++	const u8 *buffer, u8 len)
+ {
+ 	int i;
+ 	int ret;
+ 
+-	ret = smc_sane();
++	ret = port_smc_sane(smc);
+ 	if (ret)
+ 		return ret;
+ 
+-	if (send_command(cmd) || send_argument(key)) {
++	if (port_send_command(smc, cmd) || port_send_argument(smc, key)) {
+ 		pr_warn("%s: write arg fail\n", key);
+ 		return -EIO;
+ 	}
+ 
+-	if (send_byte(len, APPLESMC_DATA_PORT)) {
++	if (port_send_byte(smc, len, APPLESMC_DATA_PORT)) {
+ 		pr_warn("%.4s: write len fail\n", key);
+ 		return -EIO;
+ 	}
+ 
+ 	for (i = 0; i < len; i++) {
+-		if (send_byte(buffer[i], APPLESMC_DATA_PORT)) {
++		if (port_send_byte(smc, buffer[i], APPLESMC_DATA_PORT)) {
+ 			pr_warn("%s: write data fail\n", key);
+ 			return -EIO;
+ 		}
+ 	}
+ 
+-	return wait_status(0, SMC_STATUS_BUSY);
++	return port_wait_status(smc, 0, SMC_STATUS_BUSY);
+ }
+ 
+-static int read_register_count(unsigned int *count)
++static int port_get_smc_key_info(struct applesmc_device *smc,
++	const char *key, struct applesmc_entry *info)
+ {
+-	__be32 be;
+ 	int ret;
++	u8 raw[6];
+ 
+-	ret = read_smc(APPLESMC_READ_CMD, KEY_COUNT_KEY, (u8 *)&be, 4);
++	ret = port_read_smc(smc, APPLESMC_GET_KEY_TYPE_CMD, key, raw, 6);
+ 	if (ret)
+ 		return ret;
++	info->len = raw[0];
++	memcpy(info->type, &raw[1], 4);
++	info->flags = raw[5];
++	return 0;
++}
++
++
++/*
++ * MMIO based communication.
++ * TODO: Use updated mechanism for cmd timeout/retry
++ */
++
++static void iomem_clear_status(struct applesmc_device *smc)
++{
++	if (ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_STATUS))
++		iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_STATUS);
++}
++
++static int iomem_wait_read(struct applesmc_device *smc)
++{
++	u8 status;
++	int us;
++	int i;
++
++	us = APPLESMC_MIN_WAIT;
++	for (i = 0; i < 24 ; i++) {
++		status = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_STATUS);
++		if (status & 0x20)
++			return 0;
++		usleep_range(us, us * 2);
++		if (i > 9)
++			us <<= 1;
++	}
++
++	dev_warn(smc->ldev, "%s... timeout\n", __func__);
++	return -EIO;
++}
++
++static int iomem_read_smc(struct applesmc_device *smc, u8 cmd, const char *key,
++	u8 *buffer, u8 len)
++{
++	u8 err, remote_len;
++	u32 key_int = *((u32 *) key);
++
++	iomem_clear_status(smc);
++	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++
++	if (iomem_wait_read(smc))
++		return -EIO;
++
++	err = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	if (err != 0) {
++		dev_warn(smc->ldev, "read_smc_mmio(%x %8x/%.4s) failed: %u\n",
++				cmd, key_int, key, err);
++		return -EIO;
++	}
++
++	if (cmd == APPLESMC_READ_CMD) {
++		remote_len = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_DATA_LEN);
++		if (remote_len != len) {
++			dev_warn(smc->ldev,
++				 "read_smc_mmio(%x %8x/%.4s) failed: buffer length mismatch (remote = %u, requested = %u)\n",
++				 cmd, key_int, key, remote_len, len);
++			return -EINVAL;
++		}
++	} else {
++		remote_len = len;
++	}
++
++	memcpy_fromio(buffer, smc->iomem_base + APPLESMC_IOMEM_KEY_DATA,
++			remote_len);
++
++	dev_dbg(smc->ldev, "read_smc_mmio(%x %8x/%.4s): buflen=%u reslen=%u\n",
++			cmd, key_int, key, len, remote_len);
++	print_hex_dump_bytes("read_smc_mmio(): ", DUMP_PREFIX_NONE, buffer, remote_len);
++	return 0;
++}
++
++static int iomem_get_smc_key_type(struct applesmc_device *smc, const char *key,
++	struct applesmc_entry *e)
++{
++	u8 err;
++	u8 cmd = APPLESMC_GET_KEY_TYPE_CMD;
++	u32 key_int = *((u32 *) key);
++
++	iomem_clear_status(smc);
++	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++
++	if (iomem_wait_read(smc))
++		return -EIO;
++
++	err = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	if (err != 0) {
++		dev_warn(smc->ldev, "get_smc_key_type_mmio(%.4s) failed: %u\n", key, err);
++		return -EIO;
++	}
++
++	e->len = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_TYPE_DATA_LEN);
++	*((uint32_t *) e->type) = ioread32(
++			smc->iomem_base + APPLESMC_IOMEM_KEY_TYPE_CODE);
++	e->flags = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_TYPE_FLAGS);
++
++	dev_dbg(smc->ldev, "get_smc_key_type_mmio(%.4s): len=%u type=%.4s flags=%x\n",
++		key, e->len, e->type, e->flags);
++	return 0;
++}
++
++static int iomem_write_smc(struct applesmc_device *smc, u8 cmd, const char *key,
++	const u8 *buffer, u8 len)
++{
++	u8 err;
++	u32 key_int = *((u32 *) key);
++
++	iomem_clear_status(smc);
++	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
++	memcpy_toio(smc->iomem_base + APPLESMC_IOMEM_KEY_DATA, buffer, len);
++	iowrite8(len, smc->iomem_base + APPLESMC_IOMEM_KEY_DATA_LEN);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++
++	if (iomem_wait_read(smc))
++		return -EIO;
++
++	err = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	if (err != 0) {
++		dev_warn(smc->ldev, "write_smc_mmio(%x %.4s) failed: %u\n", cmd, key, err);
++		print_hex_dump_bytes("write_smc_mmio(): ", DUMP_PREFIX_NONE, buffer, len);
++		return -EIO;
++	}
++
++	dev_dbg(smc->ldev, "write_smc_mmio(%x %.4s): buflen=%u\n", cmd, key, len);
++	print_hex_dump_bytes("write_smc_mmio(): ", DUMP_PREFIX_NONE, buffer, len);
++	return 0;
++}
++
++
++static int read_smc(struct applesmc_device *smc, const char *key,
++	u8 *buffer, u8 len)
++{
++	if (smc->iomem_base_set)
++		return iomem_read_smc(smc, APPLESMC_READ_CMD, key, buffer, len);
++	else
++		return port_read_smc(smc, APPLESMC_READ_CMD, key, buffer, len);
++}
++
++static int write_smc(struct applesmc_device *smc, const char *key,
++	const u8 *buffer, u8 len)
++{
++	if (smc->iomem_base_set)
++		return iomem_write_smc(smc, APPLESMC_WRITE_CMD, key, buffer, len);
++	else
++		return port_write_smc(smc, APPLESMC_WRITE_CMD, key, buffer, len);
++}
++
++static int get_smc_key_by_index(struct applesmc_device *smc,
++	unsigned int index, char *key)
++{
++	__be32 be;
++
++	be = cpu_to_be32(index);
++	if (smc->iomem_base_set)
++		return iomem_read_smc(smc, APPLESMC_GET_KEY_BY_INDEX_CMD,
++							  (const char *) &be, (u8 *) key, 4);
++	else
++		return port_read_smc(smc, APPLESMC_GET_KEY_BY_INDEX_CMD,
++							 (const char *) &be, (u8 *) key, 4);
++}
++
++static int get_smc_key_info(struct applesmc_device *smc, const char *key,
++	struct applesmc_entry *info)
++{
++	if (smc->iomem_base_set)
++		return iomem_get_smc_key_type(smc, key, info);
++	else
++		return port_get_smc_key_info(smc, key, info);
++}
++
++static int read_register_count(struct applesmc_device *smc,
++	unsigned int *count)
++{
++	__be32 be;
++	int ret;
++
++	ret = read_smc(smc, KEY_COUNT_KEY, (u8 *)&be, 4);
++	if (ret < 0)
++		return ret;
+ 
+ 	*count = be32_to_cpu(be);
+ 	return 0;
+@@ -338,76 +560,73 @@ static int read_register_count(unsigned int *count)
+  * All functions below are concurrency safe - callers should NOT hold lock.
+  */
+ 
+-static int applesmc_read_entry(const struct applesmc_entry *entry,
+-			       u8 *buf, u8 len)
++static int applesmc_read_entry(struct applesmc_device *smc,
++	const struct applesmc_entry *entry, u8 *buf, u8 len)
+ {
+ 	int ret;
+ 
+ 	if (entry->len != len)
+ 		return -EINVAL;
+-	mutex_lock(&smcreg.mutex);
+-	ret = read_smc(APPLESMC_READ_CMD, entry->key, buf, len);
+-	mutex_unlock(&smcreg.mutex);
++	mutex_lock(&smc->reg.mutex);
++	ret = read_smc(smc, entry->key, buf, len);
++	mutex_unlock(&smc->reg.mutex);
+ 
+ 	return ret;
+ }
+ 
+-static int applesmc_write_entry(const struct applesmc_entry *entry,
+-				const u8 *buf, u8 len)
++static int applesmc_write_entry(struct applesmc_device *smc,
++	const struct applesmc_entry *entry, const u8 *buf, u8 len)
+ {
+ 	int ret;
+ 
+ 	if (entry->len != len)
+ 		return -EINVAL;
+-	mutex_lock(&smcreg.mutex);
+-	ret = write_smc(APPLESMC_WRITE_CMD, entry->key, buf, len);
+-	mutex_unlock(&smcreg.mutex);
++	mutex_lock(&smc->reg.mutex);
++	ret = write_smc(smc, entry->key, buf, len);
++	mutex_unlock(&smc->reg.mutex);
+ 	return ret;
+ }
+ 
+-static const struct applesmc_entry *applesmc_get_entry_by_index(int index)
++static const struct applesmc_entry *applesmc_get_entry_by_index(
++	struct applesmc_device *smc, int index)
+ {
+-	struct applesmc_entry *cache = &smcreg.cache[index];
+-	u8 key[4], info[6];
+-	__be32 be;
++	struct applesmc_entry *cache = &smc->reg.cache[index];
++	char key[4];
+ 	int ret = 0;
+ 
+ 	if (cache->valid)
+ 		return cache;
+ 
+-	mutex_lock(&smcreg.mutex);
++	mutex_lock(&smc->reg.mutex);
+ 
+ 	if (cache->valid)
+ 		goto out;
+-	be = cpu_to_be32(index);
+-	ret = read_smc(APPLESMC_GET_KEY_BY_INDEX_CMD, (u8 *)&be, key, 4);
++	ret = get_smc_key_by_index(smc, index, key);
+ 	if (ret)
+ 		goto out;
+-	ret = read_smc(APPLESMC_GET_KEY_TYPE_CMD, key, info, 6);
++	memcpy(cache->key, key, 4);
++
++	ret = get_smc_key_info(smc, key, cache);
+ 	if (ret)
+ 		goto out;
+-
+-	memcpy(cache->key, key, 4);
+-	cache->len = info[0];
+-	memcpy(cache->type, &info[1], 4);
+-	cache->flags = info[5];
+ 	cache->valid = true;
+ 
+ out:
+-	mutex_unlock(&smcreg.mutex);
++	mutex_unlock(&smc->reg.mutex);
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 	return cache;
+ }
+ 
+-static int applesmc_get_lower_bound(unsigned int *lo, const char *key)
++static int applesmc_get_lower_bound(struct applesmc_device *smc,
++	unsigned int *lo, const char *key)
+ {
+-	int begin = 0, end = smcreg.key_count;
++	int begin = 0, end = smc->reg.key_count;
+ 	const struct applesmc_entry *entry;
+ 
+ 	while (begin != end) {
+ 		int middle = begin + (end - begin) / 2;
+-		entry = applesmc_get_entry_by_index(middle);
++		entry = applesmc_get_entry_by_index(smc, middle);
+ 		if (IS_ERR(entry)) {
+ 			*lo = 0;
+ 			return PTR_ERR(entry);
+@@ -422,16 +641,17 @@ static int applesmc_get_lower_bound(unsigned int *lo, const char *key)
+ 	return 0;
+ }
+ 
+-static int applesmc_get_upper_bound(unsigned int *hi, const char *key)
++static int applesmc_get_upper_bound(struct applesmc_device *smc,
++	unsigned int *hi, const char *key)
+ {
+-	int begin = 0, end = smcreg.key_count;
++	int begin = 0, end = smc->reg.key_count;
+ 	const struct applesmc_entry *entry;
+ 
+ 	while (begin != end) {
+ 		int middle = begin + (end - begin) / 2;
+-		entry = applesmc_get_entry_by_index(middle);
++		entry = applesmc_get_entry_by_index(smc, middle);
+ 		if (IS_ERR(entry)) {
+-			*hi = smcreg.key_count;
++			*hi = smc->reg.key_count;
+ 			return PTR_ERR(entry);
+ 		}
+ 		if (strcmp(key, entry->key) < 0)
+@@ -444,50 +664,54 @@ static int applesmc_get_upper_bound(unsigned int *hi, const char *key)
+ 	return 0;
+ }
+ 
+-static const struct applesmc_entry *applesmc_get_entry_by_key(const char *key)
++static const struct applesmc_entry *applesmc_get_entry_by_key(
++	struct applesmc_device *smc, const char *key)
+ {
+ 	int begin, end;
+ 	int ret;
+ 
+-	ret = applesmc_get_lower_bound(&begin, key);
++	ret = applesmc_get_lower_bound(smc, &begin, key);
+ 	if (ret)
+ 		return ERR_PTR(ret);
+-	ret = applesmc_get_upper_bound(&end, key);
++	ret = applesmc_get_upper_bound(smc, &end, key);
+ 	if (ret)
+ 		return ERR_PTR(ret);
+ 	if (end - begin != 1)
+ 		return ERR_PTR(-EINVAL);
+ 
+-	return applesmc_get_entry_by_index(begin);
++	return applesmc_get_entry_by_index(smc, begin);
+ }
+ 
+-static int applesmc_read_key(const char *key, u8 *buffer, u8 len)
++static int applesmc_read_key(struct applesmc_device *smc,
++	const char *key, u8 *buffer, u8 len)
+ {
+ 	const struct applesmc_entry *entry;
+ 
+-	entry = applesmc_get_entry_by_key(key);
++	entry = applesmc_get_entry_by_key(smc, key);
+ 	if (IS_ERR(entry))
+ 		return PTR_ERR(entry);
+ 
+-	return applesmc_read_entry(entry, buffer, len);
++	return applesmc_read_entry(smc, entry, buffer, len);
+ }
+ 
+-static int applesmc_write_key(const char *key, const u8 *buffer, u8 len)
++static int applesmc_write_key(struct applesmc_device *smc,
++	const char *key, const u8 *buffer, u8 len)
+ {
+ 	const struct applesmc_entry *entry;
+ 
+-	entry = applesmc_get_entry_by_key(key);
++	entry = applesmc_get_entry_by_key(smc, key);
+ 	if (IS_ERR(entry))
+ 		return PTR_ERR(entry);
+ 
+-	return applesmc_write_entry(entry, buffer, len);
++	return applesmc_write_entry(smc, entry, buffer, len);
+ }
+ 
+-static int applesmc_has_key(const char *key, bool *value)
++static int applesmc_has_key(struct applesmc_device *smc,
++	const char *key, bool *value)
+ {
+ 	const struct applesmc_entry *entry;
+ 
+-	entry = applesmc_get_entry_by_key(key);
++	entry = applesmc_get_entry_by_key(smc, key);
+ 	if (IS_ERR(entry) && PTR_ERR(entry) != -EINVAL)
+ 		return PTR_ERR(entry);
+ 
+@@ -498,12 +722,13 @@ static int applesmc_has_key(const char *key, bool *value)
+ /*
+  * applesmc_read_s16 - Read 16-bit signed big endian register
+  */
+-static int applesmc_read_s16(const char *key, s16 *value)
++static int applesmc_read_s16(struct applesmc_device *smc,
++	const char *key, s16 *value)
+ {
+ 	u8 buffer[2];
+ 	int ret;
+ 
+-	ret = applesmc_read_key(key, buffer, 2);
++	ret = applesmc_read_key(smc, key, buffer, 2);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -511,31 +736,68 @@ static int applesmc_read_s16(const char *key, s16 *value)
+ 	return 0;
+ }
+ 
++/**
++ * applesmc_float_to_u32 - Retrieve the integral part of a float.
++ * This is needed because Apple made fans use float values in the T2.
++ * The fractional point is not significantly useful though, and the integral
++ * part can be easily extracted.
++ */
++static inline u32 applesmc_float_to_u32(u32 d)
++{
++	u8 sign = (u8) ((d >> 31) & 1);
++	s32 exp = (s32) ((d >> 23) & 0xff) - 0x7f;
++	u32 fr = d & ((1u << 23) - 1);
++
++	if (sign || exp < 0)
++		return 0;
++
++	return (u32) ((1u << exp) + (fr >> (23 - exp)));
++}
++
++/**
++ * applesmc_u32_to_float - Convert an u32 into a float.
++ * See applesmc_float_to_u32 for a rationale.
++ */
++static inline u32 applesmc_u32_to_float(u32 d)
++{
++	u32 dc = d, bc = 0, exp;
++
++	if (!d)
++		return 0;
++
++	while (dc >>= 1)
++		++bc;
++	exp = 0x7f + bc;
++
++	return (u32) ((exp << 23) |
++		((d << (23 - (exp - 0x7f))) & ((1u << 23) - 1)));
++}
+ /*
+  * applesmc_device_init - initialize the accelerometer.  Can sleep.
+  */
+-static void applesmc_device_init(void)
++static void applesmc_device_init(struct applesmc_device *smc)
+ {
+ 	int total;
+ 	u8 buffer[2];
+ 
+-	if (!smcreg.has_accelerometer)
++	if (!smc->reg.has_accelerometer)
+ 		return;
+ 
+ 	for (total = INIT_TIMEOUT_MSECS; total > 0; total -= INIT_WAIT_MSECS) {
+-		if (!applesmc_read_key(MOTION_SENSOR_KEY, buffer, 2) &&
++		if (!applesmc_read_key(smc, MOTION_SENSOR_KEY, buffer, 2) &&
+ 				(buffer[0] != 0x00 || buffer[1] != 0x00))
+ 			return;
+ 		buffer[0] = 0xe0;
+ 		buffer[1] = 0x00;
+-		applesmc_write_key(MOTION_SENSOR_KEY, buffer, 2);
++		applesmc_write_key(smc, MOTION_SENSOR_KEY, buffer, 2);
+ 		msleep(INIT_WAIT_MSECS);
+ 	}
+ 
+ 	pr_warn("failed to init the device\n");
+ }
+ 
+-static int applesmc_init_index(struct applesmc_registers *s)
++static int applesmc_init_index(struct applesmc_device *smc,
++	struct applesmc_registers *s)
+ {
+ 	const struct applesmc_entry *entry;
+ 	unsigned int i;
+@@ -548,7 +810,7 @@ static int applesmc_init_index(struct applesmc_registers *s)
+ 		return -ENOMEM;
+ 
+ 	for (i = s->temp_begin; i < s->temp_end; i++) {
+-		entry = applesmc_get_entry_by_index(i);
++		entry = applesmc_get_entry_by_index(smc, i);
+ 		if (IS_ERR(entry))
+ 			continue;
+ 		if (strcmp(entry->type, TEMP_SENSOR_TYPE))
+@@ -562,9 +824,9 @@ static int applesmc_init_index(struct applesmc_registers *s)
+ /*
+  * applesmc_init_smcreg_try - Try to initialize register cache. Idempotent.
+  */
+-static int applesmc_init_smcreg_try(void)
++static int applesmc_init_smcreg_try(struct applesmc_device *smc)
+ {
+-	struct applesmc_registers *s = &smcreg;
++	struct applesmc_registers *s = &smc->reg;
+ 	bool left_light_sensor = false, right_light_sensor = false;
+ 	unsigned int count;
+ 	u8 tmp[1];
+@@ -573,7 +835,7 @@ static int applesmc_init_smcreg_try(void)
+ 	if (s->init_complete)
+ 		return 0;
+ 
+-	ret = read_register_count(&count);
++	ret = read_register_count(smc, &count);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -590,35 +852,35 @@ static int applesmc_init_smcreg_try(void)
+ 	if (!s->cache)
+ 		return -ENOMEM;
+ 
+-	ret = applesmc_read_key(FANS_COUNT, tmp, 1);
++	ret = applesmc_read_key(smc, FANS_COUNT, tmp, 1);
+ 	if (ret)
+ 		return ret;
+ 	s->fan_count = tmp[0];
+ 	if (s->fan_count > 10)
+ 		s->fan_count = 10;
+ 
+-	ret = applesmc_get_lower_bound(&s->temp_begin, "T");
++	ret = applesmc_get_lower_bound(smc, &s->temp_begin, "T");
+ 	if (ret)
+ 		return ret;
+-	ret = applesmc_get_lower_bound(&s->temp_end, "U");
++	ret = applesmc_get_lower_bound(smc, &s->temp_end, "U");
+ 	if (ret)
+ 		return ret;
+ 	s->temp_count = s->temp_end - s->temp_begin;
+ 
+-	ret = applesmc_init_index(s);
++	ret = applesmc_init_index(smc, s);
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = applesmc_has_key(LIGHT_SENSOR_LEFT_KEY, &left_light_sensor);
++	ret = applesmc_has_key(smc, LIGHT_SENSOR_LEFT_KEY, &left_light_sensor);
+ 	if (ret)
+ 		return ret;
+-	ret = applesmc_has_key(LIGHT_SENSOR_RIGHT_KEY, &right_light_sensor);
++	ret = applesmc_has_key(smc, LIGHT_SENSOR_RIGHT_KEY, &right_light_sensor);
+ 	if (ret)
+ 		return ret;
+-	ret = applesmc_has_key(MOTION_SENSOR_KEY, &s->has_accelerometer);
++	ret = applesmc_has_key(smc, MOTION_SENSOR_KEY, &s->has_accelerometer);
+ 	if (ret)
+ 		return ret;
+-	ret = applesmc_has_key(BACKLIGHT_KEY, &s->has_key_backlight);
++	ret = applesmc_has_key(smc, BACKLIGHT_KEY, &s->has_key_backlight);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -634,13 +896,13 @@ static int applesmc_init_smcreg_try(void)
+ 	return 0;
+ }
+ 
+-static void applesmc_destroy_smcreg(void)
++static void applesmc_destroy_smcreg(struct applesmc_device *smc)
+ {
+-	kfree(smcreg.index);
+-	smcreg.index = NULL;
+-	kfree(smcreg.cache);
+-	smcreg.cache = NULL;
+-	smcreg.init_complete = false;
++	kfree(smc->reg.index);
++	smc->reg.index = NULL;
++	kfree(smc->reg.cache);
++	smc->reg.cache = NULL;
++	smc->reg.init_complete = false;
+ }
+ 
+ /*
+@@ -649,12 +911,12 @@ static void applesmc_destroy_smcreg(void)
+  * Retries until initialization is successful, or the operation times out.
+  *
+  */
+-static int applesmc_init_smcreg(void)
++static int applesmc_init_smcreg(struct applesmc_device *smc)
+ {
+ 	int ms, ret;
+ 
+ 	for (ms = 0; ms < INIT_TIMEOUT_MSECS; ms += INIT_WAIT_MSECS) {
+-		ret = applesmc_init_smcreg_try();
++		ret = applesmc_init_smcreg_try(smc);
+ 		if (!ret) {
+ 			if (ms)
+ 				pr_info("init_smcreg() took %d ms\n", ms);
+@@ -663,50 +925,223 @@ static int applesmc_init_smcreg(void)
+ 		msleep(INIT_WAIT_MSECS);
+ 	}
+ 
+-	applesmc_destroy_smcreg();
++	applesmc_destroy_smcreg(smc);
+ 
+ 	return ret;
+ }
+ 
+ /* Device model stuff */
+-static int applesmc_probe(struct platform_device *dev)
++
++static int applesmc_init_resources(struct applesmc_device *smc);
++static void applesmc_free_resources(struct applesmc_device *smc);
++static int applesmc_create_modules(struct applesmc_device *smc);
++static void applesmc_destroy_modules(struct applesmc_device *smc);
++
++static int applesmc_add(struct acpi_device *dev)
+ {
++	struct applesmc_device *smc;
+ 	int ret;
+ 
+-	ret = applesmc_init_smcreg();
++	smc = kzalloc(sizeof(struct applesmc_device), GFP_KERNEL);
++	if (!smc)
++		return -ENOMEM;
++	smc->dev = dev;
++	smc->ldev = &dev->dev;
++	mutex_init(&smc->reg.mutex);
++
++	dev_set_drvdata(&dev->dev, smc);
++
++	ret = applesmc_init_resources(smc);
+ 	if (ret)
+-		return ret;
++		goto out_mem;
++
++	ret = applesmc_init_smcreg(smc);
++	if (ret)
++		goto out_res;
++
++	applesmc_device_init(smc);
++
++	ret = applesmc_create_modules(smc);
++	if (ret)
++		goto out_reg;
++
++	return 0;
++
++out_reg:
++	applesmc_destroy_smcreg(smc);
++out_res:
++	applesmc_free_resources(smc);
++out_mem:
++	dev_set_drvdata(&dev->dev, NULL);
++	mutex_destroy(&smc->reg.mutex);
++	kfree(smc);
++
++	return ret;
++}
++
++static void applesmc_remove(struct acpi_device *dev)
++{
++	struct applesmc_device *smc = dev_get_drvdata(&dev->dev);
++
++	applesmc_destroy_modules(smc);
++	applesmc_destroy_smcreg(smc);
++	applesmc_free_resources(smc);
+ 
+-	applesmc_device_init();
++	mutex_destroy(&smc->reg.mutex);
++	kfree(smc);
++
++	return;
++}
++
++static acpi_status applesmc_walk_resources(struct acpi_resource *res,
++	void *data)
++{
++	struct applesmc_device *smc = data;
++
++	switch (res->type) {
++	case ACPI_RESOURCE_TYPE_IO:
++		if (!smc->port_base_set) {
++			if (res->data.io.address_length < APPLESMC_NR_PORTS)
++				return AE_ERROR;
++			smc->port_base = res->data.io.minimum;
++			smc->port_base_set = true;
++		}
++		return AE_OK;
++
++	case ACPI_RESOURCE_TYPE_FIXED_MEMORY32:
++		if (!smc->iomem_base_set) {
++			if (res->data.fixed_memory32.address_length <
++					APPLESMC_IOMEM_MIN_SIZE) {
++				dev_warn(smc->ldev, "found iomem but it's too small: %u\n",
++						 res->data.fixed_memory32.address_length);
++				return AE_OK;
++			}
++			smc->iomem_base_addr = res->data.fixed_memory32.address;
++			smc->iomem_base_size = res->data.fixed_memory32.address_length;
++			smc->iomem_base_set = true;
++		}
++		return AE_OK;
++
++	case ACPI_RESOURCE_TYPE_END_TAG:
++		if (smc->port_base_set)
++			return AE_OK;
++		else
++			return AE_NOT_FOUND;
++
++	default:
++		return AE_OK;
++	}
++}
++
++static int applesmc_try_enable_iomem(struct applesmc_device *smc);
++
++static int applesmc_init_resources(struct applesmc_device *smc)
++{
++	int ret;
++
++	ret = acpi_walk_resources(smc->dev->handle, METHOD_NAME__CRS,
++			applesmc_walk_resources, smc);
++	if (ACPI_FAILURE(ret))
++		return -ENXIO;
++
++	if (!request_region(smc->port_base, APPLESMC_NR_PORTS, "applesmc"))
++		return -ENXIO;
++
++	if (smc->iomem_base_set) {
++		if (applesmc_try_enable_iomem(smc))
++			smc->iomem_base_set = false;
++	}
++
++	return 0;
++}
++
++static int applesmc_try_enable_iomem(struct applesmc_device *smc)
++{
++	u8 test_val, ldkn_version;
++
++	dev_dbg(smc->ldev, "Trying to enable iomem based communication\n");
++	smc->iomem_base = ioremap(smc->iomem_base_addr, smc->iomem_base_size);
++	if (!smc->iomem_base)
++		goto out;
++
++	/* Apple's driver does this check for some reason */
++	test_val = ioread8(smc->iomem_base + APPLESMC_IOMEM_KEY_STATUS);
++	if (test_val == 0xff) {
++		dev_warn(smc->ldev,
++			 "iomem enable failed: initial status is 0xff (is %x)\n",
++			 test_val);
++		goto out_iomem;
++	}
++
++	if (read_smc(smc, "LDKN", &ldkn_version, 1)) {
++		dev_warn(smc->ldev, "iomem enable failed: ldkn read failed\n");
++		goto out_iomem;
++	}
++
++	if (ldkn_version < 2) {
++		dev_warn(smc->ldev,
++			 "iomem enable failed: ldkn version %u is less than minimum (2)\n",
++			 ldkn_version);
++		goto out_iomem;
++	}
+ 
+ 	return 0;
++
++out_iomem:
++	iounmap(smc->iomem_base);
++
++out:
++	return -ENXIO;
++}
++
++static void applesmc_free_resources(struct applesmc_device *smc)
++{
++	if (smc->iomem_base_set)
++		iounmap(smc->iomem_base);
++	release_region(smc->port_base, APPLESMC_NR_PORTS);
+ }
+ 
+ /* Synchronize device with memorized backlight state */
+ static int applesmc_pm_resume(struct device *dev)
+ {
+-	if (smcreg.has_key_backlight)
+-		applesmc_write_key(BACKLIGHT_KEY, backlight_state, 2);
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++
++	if (smc->reg.has_key_backlight)
++		applesmc_write_key(smc, BACKLIGHT_KEY, smc->backlight_state, 2);
++
+ 	return 0;
+ }
+ 
+ /* Reinitialize device on resume from hibernation */
+ static int applesmc_pm_restore(struct device *dev)
+ {
+-	applesmc_device_init();
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++
++	applesmc_device_init(smc);
++
+ 	return applesmc_pm_resume(dev);
+ }
+ 
++static const struct acpi_device_id applesmc_ids[] = {
++	{"APP0001", 0},
++	{"", 0},
++};
++
+ static const struct dev_pm_ops applesmc_pm_ops = {
+ 	.resume = applesmc_pm_resume,
+ 	.restore = applesmc_pm_restore,
+ };
+ 
+-static struct platform_driver applesmc_driver = {
+-	.probe = applesmc_probe,
+-	.driver	= {
+-		.name = "applesmc",
+-		.pm = &applesmc_pm_ops,
++static struct acpi_driver applesmc_driver = {
++	.name = "applesmc",
++	.class = "applesmc",
++	.ids = applesmc_ids,
++	.ops = {
++		.add = applesmc_add,
++		.remove = applesmc_remove
++	},
++	.drv = {
++		.pm = &applesmc_pm_ops
+ 	},
+ };
+ 
+@@ -714,25 +1149,26 @@ static struct platform_driver applesmc_driver = {
+  * applesmc_calibrate - Set our "resting" values.  Callers must
+  * hold applesmc_lock.
+  */
+-static void applesmc_calibrate(void)
++static void applesmc_calibrate(struct applesmc_device *smc)
+ {
+-	applesmc_read_s16(MOTION_SENSOR_X_KEY, &rest_x);
+-	applesmc_read_s16(MOTION_SENSOR_Y_KEY, &rest_y);
+-	rest_x = -rest_x;
++	applesmc_read_s16(smc, MOTION_SENSOR_X_KEY, &smc->rest_x);
++	applesmc_read_s16(smc, MOTION_SENSOR_Y_KEY, &smc->rest_y);
++	smc->rest_x = -smc->rest_x;
+ }
+ 
+ static void applesmc_idev_poll(struct input_dev *idev)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(&idev->dev);
+ 	s16 x, y;
+ 
+-	if (applesmc_read_s16(MOTION_SENSOR_X_KEY, &x))
++	if (applesmc_read_s16(smc, MOTION_SENSOR_X_KEY, &x))
+ 		return;
+-	if (applesmc_read_s16(MOTION_SENSOR_Y_KEY, &y))
++	if (applesmc_read_s16(smc, MOTION_SENSOR_Y_KEY, &y))
+ 		return;
+ 
+ 	x = -x;
+-	input_report_abs(idev, ABS_X, x - rest_x);
+-	input_report_abs(idev, ABS_Y, y - rest_y);
++	input_report_abs(idev, ABS_X, x - smc->rest_x);
++	input_report_abs(idev, ABS_Y, y - smc->rest_y);
+ 	input_sync(idev);
+ }
+ 
+@@ -747,16 +1183,17 @@ static ssize_t applesmc_name_show(struct device *dev,
+ static ssize_t applesmc_position_show(struct device *dev,
+ 				   struct device_attribute *attr, char *buf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	int ret;
+ 	s16 x, y, z;
+ 
+-	ret = applesmc_read_s16(MOTION_SENSOR_X_KEY, &x);
++	ret = applesmc_read_s16(smc, MOTION_SENSOR_X_KEY, &x);
+ 	if (ret)
+ 		goto out;
+-	ret = applesmc_read_s16(MOTION_SENSOR_Y_KEY, &y);
++	ret = applesmc_read_s16(smc, MOTION_SENSOR_Y_KEY, &y);
+ 	if (ret)
+ 		goto out;
+-	ret = applesmc_read_s16(MOTION_SENSOR_Z_KEY, &z);
++	ret = applesmc_read_s16(smc, MOTION_SENSOR_Z_KEY, &z);
+ 	if (ret)
+ 		goto out;
+ 
+@@ -770,6 +1207,7 @@ static ssize_t applesmc_position_show(struct device *dev,
+ static ssize_t applesmc_light_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	const struct applesmc_entry *entry;
+ 	static int data_length;
+ 	int ret;
+@@ -777,7 +1215,7 @@ static ssize_t applesmc_light_show(struct device *dev,
+ 	u8 buffer[10];
+ 
+ 	if (!data_length) {
+-		entry = applesmc_get_entry_by_key(LIGHT_SENSOR_LEFT_KEY);
++		entry = applesmc_get_entry_by_key(smc, LIGHT_SENSOR_LEFT_KEY);
+ 		if (IS_ERR(entry))
+ 			return PTR_ERR(entry);
+ 		if (entry->len > 10)
+@@ -786,7 +1224,7 @@ static ssize_t applesmc_light_show(struct device *dev,
+ 		pr_info("light sensor data length set to %d\n", data_length);
+ 	}
+ 
+-	ret = applesmc_read_key(LIGHT_SENSOR_LEFT_KEY, buffer, data_length);
++	ret = applesmc_read_key(smc, LIGHT_SENSOR_LEFT_KEY, buffer, data_length);
+ 	if (ret)
+ 		goto out;
+ 	/* newer macbooks report a single 10-bit bigendian value */
+@@ -796,7 +1234,7 @@ static ssize_t applesmc_light_show(struct device *dev,
+ 	}
+ 	left = buffer[2];
+ 
+-	ret = applesmc_read_key(LIGHT_SENSOR_RIGHT_KEY, buffer, data_length);
++	ret = applesmc_read_key(smc, LIGHT_SENSOR_RIGHT_KEY, buffer, data_length);
+ 	if (ret)
+ 		goto out;
+ 	right = buffer[2];
+@@ -812,7 +1250,8 @@ static ssize_t applesmc_light_show(struct device *dev,
+ static ssize_t applesmc_show_sensor_label(struct device *dev,
+ 			struct device_attribute *devattr, char *sysfsbuf)
+ {
+-	const char *key = smcreg.index[to_index(devattr)];
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++	const char *key = smc->reg.index[to_index(devattr)];
+ 
+ 	return sysfs_emit(sysfsbuf, "%s\n", key);
+ }
+@@ -821,12 +1260,13 @@ static ssize_t applesmc_show_sensor_label(struct device *dev,
+ static ssize_t applesmc_show_temperature(struct device *dev,
+ 			struct device_attribute *devattr, char *sysfsbuf)
+ {
+-	const char *key = smcreg.index[to_index(devattr)];
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++	const char *key = smc->reg.index[to_index(devattr)];
+ 	int ret;
+ 	s16 value;
+ 	int temp;
+ 
+-	ret = applesmc_read_s16(key, &value);
++	ret = applesmc_read_s16(smc, key, &value);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -838,6 +1278,8 @@ static ssize_t applesmc_show_temperature(struct device *dev,
+ static ssize_t applesmc_show_fan_speed(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++	const struct applesmc_entry *entry;
+ 	int ret;
+ 	unsigned int speed = 0;
+ 	char newkey[5];
+@@ -846,11 +1288,21 @@ static ssize_t applesmc_show_fan_speed(struct device *dev,
+ 	scnprintf(newkey, sizeof(newkey), fan_speed_fmt[to_option(attr)],
+ 		  to_index(attr));
+ 
+-	ret = applesmc_read_key(newkey, buffer, 2);
++	entry = applesmc_get_entry_by_key(smc, newkey);
++	if (IS_ERR(entry))
++		return PTR_ERR(entry);
++
++	if (!strcmp(entry->type, FLOAT_TYPE)) {
++		ret = applesmc_read_entry(smc, entry, (u8 *) &speed, 4);
++		speed = applesmc_float_to_u32(speed);
++	} else {
++		ret = applesmc_read_entry(smc, entry, buffer, 2);
++		speed = ((buffer[0] << 8 | buffer[1]) >> 2);
++	}
++
+ 	if (ret)
+ 		return ret;
+ 
+-	speed = ((buffer[0] << 8 | buffer[1]) >> 2);
+ 	return sysfs_emit(sysfsbuf, "%u\n", speed);
+ }
+ 
+@@ -858,6 +1310,8 @@ static ssize_t applesmc_store_fan_speed(struct device *dev,
+ 					struct device_attribute *attr,
+ 					const char *sysfsbuf, size_t count)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++	const struct applesmc_entry *entry;
+ 	int ret;
+ 	unsigned long speed;
+ 	char newkey[5];
+@@ -869,9 +1323,18 @@ static ssize_t applesmc_store_fan_speed(struct device *dev,
+ 	scnprintf(newkey, sizeof(newkey), fan_speed_fmt[to_option(attr)],
+ 		  to_index(attr));
+ 
+-	buffer[0] = (speed >> 6) & 0xff;
+-	buffer[1] = (speed << 2) & 0xff;
+-	ret = applesmc_write_key(newkey, buffer, 2);
++	entry = applesmc_get_entry_by_key(smc, newkey);
++	if (IS_ERR(entry))
++		return PTR_ERR(entry);
++
++	if (!strcmp(entry->type, FLOAT_TYPE)) {
++		speed = applesmc_u32_to_float(speed);
++		ret = applesmc_write_entry(smc, entry, (u8 *) &speed, 4);
++	} else {
++		buffer[0] = (speed >> 6) & 0xff;
++		buffer[1] = (speed << 2) & 0xff;
++		ret = applesmc_write_key(smc, newkey, buffer, 2);
++	}
+ 
+ 	if (ret)
+ 		return ret;
+@@ -882,15 +1345,30 @@ static ssize_t applesmc_store_fan_speed(struct device *dev,
+ static ssize_t applesmc_show_fan_manual(struct device *dev,
+ 			struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	int ret;
+ 	u16 manual = 0;
+ 	u8 buffer[2];
++	char newkey[5];
++	bool has_newkey = false;
++
++	scnprintf(newkey, sizeof(newkey), FAN_MANUAL_FMT, to_index(attr));
++
++	ret = applesmc_has_key(smc, newkey, &has_newkey);
++	if (ret)
++		return ret;
++
++	if (has_newkey) {
++		ret = applesmc_read_key(smc, newkey, buffer, 1);
++		manual = buffer[0];
++	} else {
++		ret = applesmc_read_key(smc, FANS_MANUAL, buffer, 2);
++		manual = ((buffer[0] << 8 | buffer[1]) >> to_index(attr)) & 0x01;
++	}
+ 
+-	ret = applesmc_read_key(FANS_MANUAL, buffer, 2);
+ 	if (ret)
+ 		return ret;
+ 
+-	manual = ((buffer[0] << 8 | buffer[1]) >> to_index(attr)) & 0x01;
+ 	return sysfs_emit(sysfsbuf, "%d\n", manual);
+ }
+ 
+@@ -898,29 +1376,42 @@ static ssize_t applesmc_store_fan_manual(struct device *dev,
+ 					 struct device_attribute *attr,
+ 					 const char *sysfsbuf, size_t count)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	int ret;
+ 	u8 buffer[2];
++	char newkey[5];
++	bool has_newkey = false;
+ 	unsigned long input;
+ 	u16 val;
+ 
+ 	if (kstrtoul(sysfsbuf, 10, &input) < 0)
+ 		return -EINVAL;
+ 
+-	ret = applesmc_read_key(FANS_MANUAL, buffer, 2);
++	scnprintf(newkey, sizeof(newkey), FAN_MANUAL_FMT, to_index(attr));
++
++	ret = applesmc_has_key(smc, newkey, &has_newkey);
+ 	if (ret)
+-		goto out;
++		return ret;
+ 
+-	val = (buffer[0] << 8 | buffer[1]);
++	if (has_newkey) {
++		buffer[0] = input & 1;
++		ret = applesmc_write_key(smc, newkey, buffer, 1);
++	} else {
++		ret = applesmc_read_key(smc, FANS_MANUAL, buffer, 2);
++		val = (buffer[0] << 8 | buffer[1]);
++		if (ret)
++			goto out;
+ 
+-	if (input)
+-		val = val | (0x01 << to_index(attr));
+-	else
+-		val = val & ~(0x01 << to_index(attr));
++		if (input)
++			val = val | (0x01 << to_index(attr));
++		else
++			val = val & ~(0x01 << to_index(attr));
+ 
+-	buffer[0] = (val >> 8) & 0xFF;
+-	buffer[1] = val & 0xFF;
++		buffer[0] = (val >> 8) & 0xFF;
++		buffer[1] = val & 0xFF;
+ 
+-	ret = applesmc_write_key(FANS_MANUAL, buffer, 2);
++		ret = applesmc_write_key(smc, FANS_MANUAL, buffer, 2);
++	}
+ 
+ out:
+ 	if (ret)
+@@ -932,13 +1423,14 @@ static ssize_t applesmc_store_fan_manual(struct device *dev,
+ static ssize_t applesmc_show_fan_position(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	int ret;
+ 	char newkey[5];
+ 	u8 buffer[17];
+ 
+ 	scnprintf(newkey, sizeof(newkey), FAN_ID_FMT, to_index(attr));
+ 
+-	ret = applesmc_read_key(newkey, buffer, 16);
++	ret = applesmc_read_key(smc, newkey, buffer, 16);
+ 	buffer[16] = 0;
+ 
+ 	if (ret)
+@@ -950,43 +1442,79 @@ static ssize_t applesmc_show_fan_position(struct device *dev,
+ static ssize_t applesmc_calibrate_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
+-	return sysfs_emit(sysfsbuf, "(%d,%d)\n", rest_x, rest_y);
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++
++	return sysfs_emit(sysfsbuf, "(%d,%d)\n", smc->rest_x, smc->rest_y);
+ }
+ 
+ static ssize_t applesmc_calibrate_store(struct device *dev,
+ 	struct device_attribute *attr, const char *sysfsbuf, size_t count)
+ {
+-	applesmc_calibrate();
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++
++	applesmc_calibrate(smc);
+ 
+ 	return count;
+ }
+ 
+ static void applesmc_backlight_set(struct work_struct *work)
+ {
+-	applesmc_write_key(BACKLIGHT_KEY, backlight_state, 2);
++	struct applesmc_device *smc = container_of(work, struct applesmc_device, backlight_work);
++
++	applesmc_write_key(smc, BACKLIGHT_KEY, smc->backlight_state, 2);
+ }
+-static DECLARE_WORK(backlight_work, &applesmc_backlight_set);
+ 
+ static void applesmc_brightness_set(struct led_classdev *led_cdev,
+ 						enum led_brightness value)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(led_cdev->dev);
+ 	int ret;
+ 
+-	backlight_state[0] = value;
+-	ret = queue_work(applesmc_led_wq, &backlight_work);
++	smc->backlight_state[0] = value;
++	ret = queue_work(smc->backlight_wq, &smc->backlight_work);
+ 
+ 	if (debug && (!ret))
+ 		dev_dbg(led_cdev->dev, "work was already on the queue.\n");
+ }
+ 
++static ssize_t applesmc_BCLM_store(struct device *dev,
++		struct device_attribute *attr, char *sysfsbuf, size_t count)
++{
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++	u8 val;
++
++	if (kstrtou8(sysfsbuf, 10, &val) < 0)
++		return -EINVAL;
++
++	if (val < 0 || val > 100)
++		return -EINVAL;
++
++	if (applesmc_write_key(smc, "BCLM", &val, 1))
++		return -ENODEV;
++	return count;
++}
++
++static ssize_t applesmc_BCLM_show(struct device *dev,
++		struct device_attribute *attr, char *sysfsbuf)
++{
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++	u8 val;
++
++	if (applesmc_read_key(smc, "BCLM", &val, 1))
++		return -ENODEV;
++
++	return sysfs_emit(sysfsbuf, "%d\n", val);
++}
++
+ static ssize_t applesmc_key_count_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	int ret;
+ 	u8 buffer[4];
+ 	u32 count;
+ 
+-	ret = applesmc_read_key(KEY_COUNT_KEY, buffer, 4);
++	ret = applesmc_read_key(smc, KEY_COUNT_KEY, buffer, 4);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -998,13 +1526,14 @@ static ssize_t applesmc_key_count_show(struct device *dev,
+ static ssize_t applesmc_key_at_index_read_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	const struct applesmc_entry *entry;
+ 	int ret;
+ 
+-	entry = applesmc_get_entry_by_index(key_at_index);
++	entry = applesmc_get_entry_by_index(smc, smc->key_at_index);
+ 	if (IS_ERR(entry))
+ 		return PTR_ERR(entry);
+-	ret = applesmc_read_entry(entry, sysfsbuf, entry->len);
++	ret = applesmc_read_entry(smc, entry, sysfsbuf, entry->len);
+ 	if (ret)
+ 		return ret;
+ 
+@@ -1014,9 +1543,10 @@ static ssize_t applesmc_key_at_index_read_show(struct device *dev,
+ static ssize_t applesmc_key_at_index_data_length_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	const struct applesmc_entry *entry;
+ 
+-	entry = applesmc_get_entry_by_index(key_at_index);
++	entry = applesmc_get_entry_by_index(smc, smc->key_at_index);
+ 	if (IS_ERR(entry))
+ 		return PTR_ERR(entry);
+ 
+@@ -1026,9 +1556,10 @@ static ssize_t applesmc_key_at_index_data_length_show(struct device *dev,
+ static ssize_t applesmc_key_at_index_type_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	const struct applesmc_entry *entry;
+ 
+-	entry = applesmc_get_entry_by_index(key_at_index);
++	entry = applesmc_get_entry_by_index(smc, smc->key_at_index);
+ 	if (IS_ERR(entry))
+ 		return PTR_ERR(entry);
+ 
+@@ -1038,9 +1569,10 @@ static ssize_t applesmc_key_at_index_type_show(struct device *dev,
+ static ssize_t applesmc_key_at_index_name_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	const struct applesmc_entry *entry;
+ 
+-	entry = applesmc_get_entry_by_index(key_at_index);
++	entry = applesmc_get_entry_by_index(smc, smc->key_at_index);
+ 	if (IS_ERR(entry))
+ 		return PTR_ERR(entry);
+ 
+@@ -1050,28 +1582,25 @@ static ssize_t applesmc_key_at_index_name_show(struct device *dev,
+ static ssize_t applesmc_key_at_index_show(struct device *dev,
+ 				struct device_attribute *attr, char *sysfsbuf)
+ {
+-	return sysfs_emit(sysfsbuf, "%d\n", key_at_index);
++	struct applesmc_device *smc = dev_get_drvdata(dev);
++
++	return sysfs_emit(sysfsbuf, "%d\n", smc->key_at_index);
+ }
+ 
+ static ssize_t applesmc_key_at_index_store(struct device *dev,
+ 	struct device_attribute *attr, const char *sysfsbuf, size_t count)
+ {
++	struct applesmc_device *smc = dev_get_drvdata(dev);
+ 	unsigned long newkey;
+ 
+ 	if (kstrtoul(sysfsbuf, 10, &newkey) < 0
+-	    || newkey >= smcreg.key_count)
++	    || newkey >= smc->reg.key_count)
+ 		return -EINVAL;
+ 
+-	key_at_index = newkey;
++	smc->key_at_index = newkey;
+ 	return count;
+ }
+ 
+-static struct led_classdev applesmc_backlight = {
+-	.name			= "smc::kbd_backlight",
+-	.default_trigger	= "nand-disk",
+-	.brightness_set		= applesmc_brightness_set,
+-};
+-
+ static struct applesmc_node_group info_group[] = {
+ 	{ "name", applesmc_name_show },
+ 	{ "key_count", applesmc_key_count_show },
+@@ -1111,19 +1640,25 @@ static struct applesmc_node_group temp_group[] = {
+ 	{ }
+ };
+ 
++static struct applesmc_node_group BCLM_group[] = {
++	{ "battery_charge_limit", applesmc_BCLM_show, applesmc_BCLM_store },
++	{ }
++};
++
+ /* Module stuff */
+ 
+ /*
+  * applesmc_destroy_nodes - remove files and free associated memory
+  */
+-static void applesmc_destroy_nodes(struct applesmc_node_group *groups)
++static void applesmc_destroy_nodes(struct applesmc_device *smc,
++	struct applesmc_node_group *groups)
+ {
+ 	struct applesmc_node_group *grp;
+ 	struct applesmc_dev_attr *node;
+ 
+ 	for (grp = groups; grp->nodes; grp++) {
+ 		for (node = grp->nodes; node->sda.dev_attr.attr.name; node++)
+-			sysfs_remove_file(&pdev->dev.kobj,
++			sysfs_remove_file(&smc->dev->dev.kobj,
+ 					  &node->sda.dev_attr.attr);
+ 		kfree(grp->nodes);
+ 		grp->nodes = NULL;
+@@ -1133,7 +1668,8 @@ static void applesmc_destroy_nodes(struct applesmc_node_group *groups)
+ /*
+  * applesmc_create_nodes - create a two-dimensional group of sysfs files
+  */
+-static int applesmc_create_nodes(struct applesmc_node_group *groups, int num)
++static int applesmc_create_nodes(struct applesmc_device *smc,
++	struct applesmc_node_group *groups, int num)
+ {
+ 	struct applesmc_node_group *grp;
+ 	struct applesmc_dev_attr *node;
+@@ -1157,7 +1693,7 @@ static int applesmc_create_nodes(struct applesmc_node_group *groups, int num)
+ 			sysfs_attr_init(attr);
+ 			attr->name = node->name;
+ 			attr->mode = 0444 | (grp->store ? 0200 : 0);
+-			ret = sysfs_create_file(&pdev->dev.kobj, attr);
++			ret = sysfs_create_file(&smc->dev->dev.kobj, attr);
+ 			if (ret) {
+ 				attr->name = NULL;
+ 				goto out;
+@@ -1167,57 +1703,56 @@ static int applesmc_create_nodes(struct applesmc_node_group *groups, int num)
+ 
+ 	return 0;
+ out:
+-	applesmc_destroy_nodes(groups);
++	applesmc_destroy_nodes(smc, groups);
+ 	return ret;
+ }
+ 
+ /* Create accelerometer resources */
+-static int applesmc_create_accelerometer(void)
++static int applesmc_create_accelerometer(struct applesmc_device *smc)
+ {
+ 	int ret;
+-
+-	if (!smcreg.has_accelerometer)
++	if (!smc->reg.has_accelerometer)
+ 		return 0;
+ 
+-	ret = applesmc_create_nodes(accelerometer_group, 1);
++	ret = applesmc_create_nodes(smc, accelerometer_group, 1);
+ 	if (ret)
+ 		goto out;
+ 
+-	applesmc_idev = input_allocate_device();
+-	if (!applesmc_idev) {
++	smc->idev = input_allocate_device();
++	if (!smc->idev) {
+ 		ret = -ENOMEM;
+ 		goto out_sysfs;
+ 	}
+ 
+ 	/* initial calibrate for the input device */
+-	applesmc_calibrate();
++	applesmc_calibrate(smc);
+ 
+ 	/* initialize the input device */
+-	applesmc_idev->name = "applesmc";
+-	applesmc_idev->id.bustype = BUS_HOST;
+-	applesmc_idev->dev.parent = &pdev->dev;
+-	input_set_abs_params(applesmc_idev, ABS_X,
++	smc->idev->name = "applesmc";
++	smc->idev->id.bustype = BUS_HOST;
++	smc->idev->dev.parent = &smc->dev->dev;
++	input_set_abs_params(smc->idev, ABS_X,
+ 			-256, 256, APPLESMC_INPUT_FUZZ, APPLESMC_INPUT_FLAT);
+-	input_set_abs_params(applesmc_idev, ABS_Y,
++	input_set_abs_params(smc->idev, ABS_Y,
+ 			-256, 256, APPLESMC_INPUT_FUZZ, APPLESMC_INPUT_FLAT);
+ 
+-	ret = input_setup_polling(applesmc_idev, applesmc_idev_poll);
++	ret = input_setup_polling(smc->idev, applesmc_idev_poll);
+ 	if (ret)
+ 		goto out_idev;
+ 
+-	input_set_poll_interval(applesmc_idev, APPLESMC_POLL_INTERVAL);
++	input_set_poll_interval(smc->idev, APPLESMC_POLL_INTERVAL);
+ 
+-	ret = input_register_device(applesmc_idev);
++	ret = input_register_device(smc->idev);
+ 	if (ret)
+ 		goto out_idev;
+ 
+ 	return 0;
+ 
+ out_idev:
+-	input_free_device(applesmc_idev);
++	input_free_device(smc->idev);
+ 
+ out_sysfs:
+-	applesmc_destroy_nodes(accelerometer_group);
++	applesmc_destroy_nodes(smc, accelerometer_group);
+ 
+ out:
+ 	pr_warn("driver init failed (ret=%d)!\n", ret);
+@@ -1225,44 +1760,55 @@ static int applesmc_create_accelerometer(void)
+ }
+ 
+ /* Release all resources used by the accelerometer */
+-static void applesmc_release_accelerometer(void)
++static void applesmc_release_accelerometer(struct applesmc_device *smc)
+ {
+-	if (!smcreg.has_accelerometer)
++	if (!smc->reg.has_accelerometer)
+ 		return;
+-	input_unregister_device(applesmc_idev);
+-	applesmc_destroy_nodes(accelerometer_group);
++	input_unregister_device(smc->idev);
++	applesmc_destroy_nodes(smc, accelerometer_group);
+ }
+ 
+-static int applesmc_create_light_sensor(void)
++static int applesmc_create_light_sensor(struct applesmc_device *smc)
+ {
+-	if (!smcreg.num_light_sensors)
++	if (!smc->reg.num_light_sensors)
+ 		return 0;
+-	return applesmc_create_nodes(light_sensor_group, 1);
++	return applesmc_create_nodes(smc, light_sensor_group, 1);
+ }
+ 
+-static void applesmc_release_light_sensor(void)
++static void applesmc_release_light_sensor(struct applesmc_device *smc)
+ {
+-	if (!smcreg.num_light_sensors)
++	if (!smc->reg.num_light_sensors)
+ 		return;
+-	applesmc_destroy_nodes(light_sensor_group);
++	applesmc_destroy_nodes(smc, light_sensor_group);
+ }
+ 
+-static int applesmc_create_key_backlight(void)
++static int applesmc_create_key_backlight(struct applesmc_device *smc)
+ {
+-	if (!smcreg.has_key_backlight)
++	int ret;
++
++	if (!smc->reg.has_key_backlight)
+ 		return 0;
+-	applesmc_led_wq = create_singlethread_workqueue("applesmc-led");
+-	if (!applesmc_led_wq)
++	smc->backlight_wq = create_singlethread_workqueue("applesmc-led");
++	if (!smc->backlight_wq)
+ 		return -ENOMEM;
+-	return led_classdev_register(&pdev->dev, &applesmc_backlight);
++
++	INIT_WORK(&smc->backlight_work, applesmc_backlight_set);
++	smc->backlight_dev.name = "smc::kbd_backlight";
++	smc->backlight_dev.default_trigger = "nand-disk";
++	smc->backlight_dev.brightness_set = applesmc_brightness_set;
++	ret = led_classdev_register(&smc->dev->dev, &smc->backlight_dev);
++	if (ret)
++		destroy_workqueue(smc->backlight_wq);
++
++	return ret;
+ }
+ 
+-static void applesmc_release_key_backlight(void)
++static void applesmc_release_key_backlight(struct applesmc_device *smc)
+ {
+-	if (!smcreg.has_key_backlight)
++	if (!smc->reg.has_key_backlight)
+ 		return;
+-	led_classdev_unregister(&applesmc_backlight);
+-	destroy_workqueue(applesmc_led_wq);
++	led_classdev_unregister(&smc->backlight_dev);
++	destroy_workqueue(smc->backlight_wq);
+ }
+ 
+ static int applesmc_dmi_match(const struct dmi_system_id *id)
+@@ -1291,6 +1837,10 @@ static const struct dmi_system_id applesmc_whitelist[] __initconst = {
+ 	  DMI_MATCH(DMI_BOARD_VENDOR, "Apple"),
+ 	  DMI_MATCH(DMI_PRODUCT_NAME, "Macmini") },
+ 	},
++	{ applesmc_dmi_match, "Apple iMacPro", {
++	  DMI_MATCH(DMI_BOARD_VENDOR, "Apple"),
++	  DMI_MATCH(DMI_PRODUCT_NAME, "iMacPro") },
++	},
+ 	{ applesmc_dmi_match, "Apple MacPro", {
+ 	  DMI_MATCH(DMI_BOARD_VENDOR, "Apple"),
+ 	  DMI_MATCH(DMI_PRODUCT_NAME, "MacPro") },
+@@ -1306,90 +1856,91 @@ static const struct dmi_system_id applesmc_whitelist[] __initconst = {
+ 	{ .ident = NULL }
+ };
+ 
+-static int __init applesmc_init(void)
++static int applesmc_create_modules(struct applesmc_device *smc)
+ {
+ 	int ret;
+ 
+-	if (!dmi_check_system(applesmc_whitelist)) {
+-		pr_warn("supported laptop not found!\n");
+-		ret = -ENODEV;
+-		goto out;
+-	}
+-
+-	if (!request_region(APPLESMC_DATA_PORT, APPLESMC_NR_PORTS,
+-								"applesmc")) {
+-		ret = -ENXIO;
+-		goto out;
+-	}
+-
+-	ret = platform_driver_register(&applesmc_driver);
+-	if (ret)
+-		goto out_region;
+-
+-	pdev = platform_device_register_simple("applesmc", APPLESMC_DATA_PORT,
+-					       NULL, 0);
+-	if (IS_ERR(pdev)) {
+-		ret = PTR_ERR(pdev);
+-		goto out_driver;
+-	}
+-
+-	/* create register cache */
+-	ret = applesmc_init_smcreg();
++	ret = applesmc_create_nodes(smc, info_group, 1);
+ 	if (ret)
+-		goto out_device;
+-
+-	ret = applesmc_create_nodes(info_group, 1);
++		goto out;
++	ret = applesmc_create_nodes(smc, BCLM_group, 1);
+ 	if (ret)
+-		goto out_smcreg;
++		goto out_info;
+ 
+-	ret = applesmc_create_nodes(fan_group, smcreg.fan_count);
++	ret = applesmc_create_nodes(smc, fan_group, smc->reg.fan_count);
+ 	if (ret)
+-		goto out_info;
++		goto out_bclm;
+ 
+-	ret = applesmc_create_nodes(temp_group, smcreg.index_count);
++	ret = applesmc_create_nodes(smc, temp_group, smc->reg.index_count);
+ 	if (ret)
+ 		goto out_fans;
+ 
+-	ret = applesmc_create_accelerometer();
++	ret = applesmc_create_accelerometer(smc);
+ 	if (ret)
+ 		goto out_temperature;
+ 
+-	ret = applesmc_create_light_sensor();
++	ret = applesmc_create_light_sensor(smc);
+ 	if (ret)
+ 		goto out_accelerometer;
+ 
+-	ret = applesmc_create_key_backlight();
++	ret = applesmc_create_key_backlight(smc);
+ 	if (ret)
+ 		goto out_light_sysfs;
+ 
+-	hwmon_dev = hwmon_device_register(&pdev->dev);
+-	if (IS_ERR(hwmon_dev)) {
+-		ret = PTR_ERR(hwmon_dev);
++	smc->hwmon_dev = hwmon_device_register(&smc->dev->dev);
++	if (IS_ERR(smc->hwmon_dev)) {
++		ret = PTR_ERR(smc->hwmon_dev);
+ 		goto out_light_ledclass;
+ 	}
+ 
+ 	return 0;
+ 
+ out_light_ledclass:
+-	applesmc_release_key_backlight();
++	applesmc_release_key_backlight(smc);
+ out_light_sysfs:
+-	applesmc_release_light_sensor();
++	applesmc_release_light_sensor(smc);
+ out_accelerometer:
+-	applesmc_release_accelerometer();
++	applesmc_release_accelerometer(smc);
+ out_temperature:
+-	applesmc_destroy_nodes(temp_group);
++	applesmc_destroy_nodes(smc, temp_group);
+ out_fans:
+-	applesmc_destroy_nodes(fan_group);
++	applesmc_destroy_nodes(smc, fan_group);
++out_bclm:
++	applesmc_destroy_nodes(smc, BCLM_group);
+ out_info:
+-	applesmc_destroy_nodes(info_group);
+-out_smcreg:
+-	applesmc_destroy_smcreg();
+-out_device:
+-	platform_device_unregister(pdev);
+-out_driver:
+-	platform_driver_unregister(&applesmc_driver);
+-out_region:
+-	release_region(APPLESMC_DATA_PORT, APPLESMC_NR_PORTS);
++	applesmc_destroy_nodes(smc, info_group);
++out:
++	return ret;
++}
++
++static void applesmc_destroy_modules(struct applesmc_device *smc)
++{
++	hwmon_device_unregister(smc->hwmon_dev);
++	applesmc_release_key_backlight(smc);
++	applesmc_release_light_sensor(smc);
++	applesmc_release_accelerometer(smc);
++	applesmc_destroy_nodes(smc, temp_group);
++	applesmc_destroy_nodes(smc, fan_group);
++	applesmc_destroy_nodes(smc, BCLM_group);
++	applesmc_destroy_nodes(smc, info_group);
++}
++
++static int __init applesmc_init(void)
++{
++	int ret;
++
++	if (!dmi_check_system(applesmc_whitelist)) {
++		pr_warn("supported laptop not found!\n");
++		ret = -ENODEV;
++		goto out;
++	}
++
++	ret = acpi_bus_register_driver(&applesmc_driver);
++	if (ret)
++		goto out;
++
++	return 0;
++
+ out:
+ 	pr_warn("driver init failed (ret=%d)!\n", ret);
+ 	return ret;
+@@ -1397,23 +1948,14 @@ static int __init applesmc_init(void)
+ 
+ static void __exit applesmc_exit(void)
+ {
+-	hwmon_device_unregister(hwmon_dev);
+-	applesmc_release_key_backlight();
+-	applesmc_release_light_sensor();
+-	applesmc_release_accelerometer();
+-	applesmc_destroy_nodes(temp_group);
+-	applesmc_destroy_nodes(fan_group);
+-	applesmc_destroy_nodes(info_group);
+-	applesmc_destroy_smcreg();
+-	platform_device_unregister(pdev);
+-	platform_driver_unregister(&applesmc_driver);
+-	release_region(APPLESMC_DATA_PORT, APPLESMC_NR_PORTS);
++	acpi_bus_unregister_driver(&applesmc_driver);
+ }
+ 
+ module_init(applesmc_init);
+ module_exit(applesmc_exit);
+ 
+ MODULE_AUTHOR("Nicolas Boichat");
++MODULE_AUTHOR("Paul Pawlowski");
+ MODULE_DESCRIPTION("Apple SMC");
+ MODULE_LICENSE("GPL v2");
+ MODULE_DEVICE_TABLE(dmi, applesmc_whitelist);
+diff --git a/drivers/pci/vgaarb.c b/drivers/pci/vgaarb.c
+index 78748e8d2dba..2b2b558cebe6 100644
+--- a/drivers/pci/vgaarb.c
++++ b/drivers/pci/vgaarb.c
+@@ -143,6 +143,7 @@ void vga_set_default_device(struct pci_dev *pdev)
+ 	pci_dev_put(vga_default);
+ 	vga_default = pci_dev_get(pdev);
+ }
++EXPORT_SYMBOL_GPL(vga_set_default_device);
+ 
+ /**
+  * vga_remove_vgacon - deactivate VGA console
+diff --git a/drivers/platform/x86/apple-gmux.c b/drivers/platform/x86/apple-gmux.c
+index 1417e230edbd..e69785af8e1d 100644
+--- a/drivers/platform/x86/apple-gmux.c
++++ b/drivers/platform/x86/apple-gmux.c
+@@ -21,6 +21,7 @@
+ #include <linux/delay.h>
+ #include <linux/pci.h>
+ #include <linux/vga_switcheroo.h>
++#include <linux/vgaarb.h>
+ #include <linux/debugfs.h>
+ #include <acpi/video.h>
+ #include <asm/io.h>
+@@ -107,6 +108,10 @@ struct apple_gmux_config {
+ 
+ # define MMIO_GMUX_MAX_BRIGHTNESS	0xffff
+ 
++static bool force_igd;
++module_param(force_igd, bool, 0);
++MODULE_PARM_DESC(force_idg, "Switch gpu to igd on module load. Make sure that you have apple-set-os set up and the iGPU is in `lspci -s 00:02.0`. (default: false) (bool)");
++
+ static u8 gmux_pio_read8(struct apple_gmux_data *gmux_data, int port)
+ {
+ 	return inb(gmux_data->iostart + port);
+@@ -945,6 +950,19 @@ static int gmux_probe(struct pnp_dev *pnp, const struct pnp_device_id *id)
+ 	gmux_enable_interrupts(gmux_data);
+ 	gmux_read_switch_state(gmux_data);
+ 
++	if (force_igd) {
++		struct pci_dev *pdev;
++
++		pdev = pci_get_domain_bus_and_slot(0, 0, PCI_DEVFN(2, 0));
++		if (pdev) {
++			pr_info("Switching to IGD");
++			gmux_switchto(VGA_SWITCHEROO_IGD);
++			vga_set_default_device(pdev);
++		} else {
++			pr_err("force_idg is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?");
++		}
++	}
++
+ 	/*
+ 	 * Retina MacBook Pros cannot switch the panel's AUX separately
+ 	 * and need eDP pre-calibration. They are distinguishable from
+diff --git a/drivers/soc/apple/Kconfig b/drivers/soc/apple/Kconfig
+index 6388cbe1e56b..50f092732796 100644
+--- a/drivers/soc/apple/Kconfig
++++ b/drivers/soc/apple/Kconfig
+@@ -4,6 +4,16 @@ if ARCH_APPLE || COMPILE_TEST
+ 
+ menu "Apple SoC drivers"
+ 
++config APPLE_DOCKCHANNEL
++	tristate "Apple DockChannel FIFO"
++	depends on ARCH_APPLE || COMPILE_TEST
++	default ARCH_APPLE
++	help
++	  DockChannel is a simple FIFO used on Apple SoCs for debug and inter-processor
++	  communications.
++
++	  Say 'y' here if you have an Apple SoC.
++
+ config APPLE_MAILBOX
+ 	tristate "Apple SoC mailboxes"
+ 	depends on PM
+@@ -30,6 +40,20 @@ config APPLE_RTKIT
+ 
+ 	  Say 'y' here if you have an Apple SoC.
+ 
++config APPLE_RTKIT_HELPER
++	tristate "Apple Generic RTKit helper co-processor"
++	depends on APPLE_RTKIT
++	depends on ARCH_APPLE || COMPILE_TEST
++	default ARCH_APPLE
++	help
++	  Apple SoCs such as the M1 come with various co-processors running
++	  their proprietary RTKit operating system. This option enables support
++	  for a generic co-processor that does not implement any additional
++	  in-band communications. It can be used for testing purposes, or for
++	  coprocessors such as MTP that communicate over a different interface.
++
++	  Say 'y' here if you have an Apple SoC.
++
+ config APPLE_SART
+ 	tristate "Apple SART DMA address filter"
+ 	depends on ARCH_APPLE || COMPILE_TEST
+diff --git a/drivers/soc/apple/Makefile b/drivers/soc/apple/Makefile
+index 4d9ab8f3037b..5e526a9edcf2 100644
+--- a/drivers/soc/apple/Makefile
++++ b/drivers/soc/apple/Makefile
+@@ -1,10 +1,16 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+ 
++obj-$(CONFIG_APPLE_DOCKCHANNEL) += apple-dockchannel.o
++apple-dockchannel-y = dockchannel.o
++
+ obj-$(CONFIG_APPLE_MAILBOX) += apple-mailbox.o
+ apple-mailbox-y = mailbox.o
+ 
+ obj-$(CONFIG_APPLE_RTKIT) += apple-rtkit.o
+ apple-rtkit-y = rtkit.o rtkit-crashlog.o
+ 
++obj-$(CONFIG_APPLE_RTKIT_HELPER) += apple-rtkit-helper.o
++apple-rtkit-helper-y = rtkit-helper.o
++
+ obj-$(CONFIG_APPLE_SART) += apple-sart.o
+ apple-sart-y = sart.o
+diff --git a/drivers/soc/apple/dockchannel.c b/drivers/soc/apple/dockchannel.c
+new file mode 100644
+index 000000000000..3a0d7964007c
+--- /dev/null
++++ b/drivers/soc/apple/dockchannel.c
+@@ -0,0 +1,406 @@
++// SPDX-License-Identifier: GPL-2.0-only OR MIT
++/*
++ * Apple DockChannel FIFO driver
++ * Copyright The Asahi Linux Contributors
++ */
++
++#include <linux/device.h>
++#include <linux/interrupt.h>
++#include <linux/io.h>
++#include <linux/ioport.h>
++#include <linux/irq.h>
++#include <linux/irqchip/chained_irq.h>
++#include <linux/irqdomain.h>
++#include <linux/platform_device.h>
++#include <linux/soc/apple/dockchannel.h>
++#include <linux/unaligned.h>
++#include <linux/of.h>
++#include <linux/of_platform.h>
++
++#define DOCKCHANNEL_MAX_IRQ	32
++
++#define DOCKCHANNEL_TX_TIMEOUT_MS 1000
++#define DOCKCHANNEL_RX_TIMEOUT_MS 1000
++
++#define IRQ_MASK		0x0
++#define IRQ_FLAG		0x4
++
++#define IRQ_TX			BIT(0)
++#define IRQ_RX			BIT(1)
++
++#define CONFIG_TX_THRESH	0x0
++#define CONFIG_RX_THRESH	0x4
++
++#define DATA_TX8		0x4
++#define DATA_TX16		0x8
++#define DATA_TX24		0xc
++#define DATA_TX32		0x10
++#define DATA_TX_FREE		0x14
++#define DATA_RX8		0x1c
++#define DATA_RX16		0x20
++#define DATA_RX24		0x24
++#define DATA_RX32		0x28
++#define DATA_RX_COUNT		0x2c
++
++struct dockchannel {
++	struct device *dev;
++	int tx_irq;
++	int rx_irq;
++
++	void __iomem *config_base;
++	void __iomem *data_base;
++
++	u32 fifo_size;
++	bool awaiting;
++	struct completion tx_comp;
++	struct completion rx_comp;
++
++	void *cookie;
++	void (*data_available)(void *cookie, size_t avail);
++};
++
++struct dockchannel_common {
++	struct device *dev;
++	struct irq_domain *domain;
++	int irq;
++
++	void __iomem *irq_base;
++};
++
++/* Dockchannel FIFO functions */
++
++static irqreturn_t dockchannel_tx_irq(int irq, void *data)
++{
++	struct dockchannel *dockchannel = data;
++
++	disable_irq_nosync(irq);
++	complete(&dockchannel->tx_comp);
++
++	return IRQ_HANDLED;
++}
++
++static irqreturn_t dockchannel_rx_irq(int irq, void *data)
++{
++	struct dockchannel *dockchannel = data;
++
++	disable_irq_nosync(irq);
++
++	if (dockchannel->awaiting) {
++		return IRQ_WAKE_THREAD;
++	} else {
++		complete(&dockchannel->rx_comp);
++		return IRQ_HANDLED;
++	}
++}
++
++static irqreturn_t dockchannel_rx_irq_thread(int irq, void *data)
++{
++	struct dockchannel *dockchannel = data;
++	size_t avail = readl_relaxed(dockchannel->data_base + DATA_RX_COUNT);
++
++	dockchannel->awaiting = false;
++	dockchannel->data_available(dockchannel->cookie, avail);
++
++	return IRQ_HANDLED;
++}
++
++int dockchannel_send(struct dockchannel *dockchannel, const void *buf, size_t count)
++{
++	size_t left = count;
++	const u8 *p = buf;
++
++	while (left > 0) {
++		size_t avail = readl_relaxed(dockchannel->data_base + DATA_TX_FREE);
++		size_t block = min(left, avail);
++
++		if (avail == 0) {
++			size_t threshold = min((size_t)(dockchannel->fifo_size / 2), left);
++
++			writel_relaxed(threshold, dockchannel->config_base + CONFIG_TX_THRESH);
++			reinit_completion(&dockchannel->tx_comp);
++			enable_irq(dockchannel->tx_irq);
++
++			if (!wait_for_completion_timeout(&dockchannel->tx_comp,
++                                                 msecs_to_jiffies(DOCKCHANNEL_TX_TIMEOUT_MS))) {
++				disable_irq(dockchannel->tx_irq);
++				return -ETIMEDOUT;
++			}
++
++			continue;
++		}
++
++		while (block >= 4) {
++			writel_relaxed(get_unaligned_le32(p), dockchannel->data_base + DATA_TX32);
++			p += 4;
++			left -= 4;
++			block -= 4;
++		}
++		while (block > 0) {
++			writeb_relaxed(*p++, dockchannel->data_base + DATA_TX8);
++			left--;
++			block--;
++		}
++	}
++
++	return count;
++}
++EXPORT_SYMBOL(dockchannel_send);
++
++int dockchannel_recv(struct dockchannel *dockchannel, void *buf, size_t count)
++{
++	size_t left = count;
++	u8 *p = buf;
++
++	while (left > 0) {
++		size_t avail = readl_relaxed(dockchannel->data_base + DATA_RX_COUNT);
++		size_t block = min(left, avail);
++
++		if (avail == 0) {
++			size_t threshold = min((size_t)(dockchannel->fifo_size / 2), left);
++
++			writel_relaxed(threshold, dockchannel->config_base + CONFIG_RX_THRESH);
++			reinit_completion(&dockchannel->rx_comp);
++			enable_irq(dockchannel->rx_irq);
++
++			if (!wait_for_completion_timeout(&dockchannel->rx_comp,
++                                                 msecs_to_jiffies(DOCKCHANNEL_RX_TIMEOUT_MS))) {
++				disable_irq(dockchannel->rx_irq);
++				return -ETIMEDOUT;
++			}
++
++			continue;
++		}
++
++		while (block >= 4) {
++			put_unaligned_le32(readl_relaxed(dockchannel->data_base + DATA_RX32), p);
++			p += 4;
++			left -= 4;
++			block -= 4;
++		}
++		while (block > 0) {
++			*p++ = readl_relaxed(dockchannel->data_base + DATA_RX8) >> 8;
++			left--;
++			block--;
++		}
++	}
++
++	return count;
++}
++EXPORT_SYMBOL(dockchannel_recv);
++
++int dockchannel_await(struct dockchannel *dockchannel,
++			    void (*callback)(void *cookie, size_t avail),
++			    void *cookie, size_t count)
++{
++	size_t threshold = min((size_t)dockchannel->fifo_size, count);
++
++	if (!count) {
++		dockchannel->awaiting = false;
++		disable_irq(dockchannel->rx_irq);
++		return 0;
++	}
++
++	dockchannel->data_available = callback;
++	dockchannel->cookie = cookie;
++	dockchannel->awaiting = true;
++	writel_relaxed(threshold, dockchannel->config_base + CONFIG_RX_THRESH);
++	enable_irq(dockchannel->rx_irq);
++
++	return threshold;
++}
++EXPORT_SYMBOL(dockchannel_await);
++
++struct dockchannel *dockchannel_init(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct dockchannel *dockchannel;
++	int ret;
++
++	dockchannel = devm_kzalloc(dev, sizeof(*dockchannel), GFP_KERNEL);
++	if (!dockchannel)
++		return ERR_PTR(-ENOMEM);
++
++	dockchannel->dev = dev;
++	dockchannel->config_base = devm_platform_ioremap_resource_byname(pdev, "config");
++	if (IS_ERR(dockchannel->config_base))
++		return (__force void *)dockchannel->config_base;
++
++	dockchannel->data_base = devm_platform_ioremap_resource_byname(pdev, "data");
++	if (IS_ERR(dockchannel->data_base))
++		return (__force void *)dockchannel->data_base;
++
++	ret = of_property_read_u32(dev->of_node, "apple,fifo-size", &dockchannel->fifo_size);
++	if (ret)
++		return ERR_PTR(dev_err_probe(dev, ret, "Missing apple,fifo-size property"));
++
++	init_completion(&dockchannel->tx_comp);
++	init_completion(&dockchannel->rx_comp);
++
++	dockchannel->tx_irq = platform_get_irq_byname(pdev, "tx");
++	if (dockchannel->tx_irq <= 0) {
++		return ERR_PTR(dev_err_probe(dev, dockchannel->tx_irq,
++				     "Failed to get TX IRQ"));
++	}
++
++	dockchannel->rx_irq = platform_get_irq_byname(pdev, "rx");
++	if (dockchannel->rx_irq <= 0) {
++		return ERR_PTR(dev_err_probe(dev, dockchannel->rx_irq,
++				     "Failed to get RX IRQ"));
++	}
++
++	ret = devm_request_irq(dev, dockchannel->tx_irq, dockchannel_tx_irq, IRQF_NO_AUTOEN,
++			       "apple-dockchannel-tx", dockchannel);
++	if (ret)
++		return ERR_PTR(dev_err_probe(dev, ret, "Failed to request TX IRQ"));
++
++	ret = devm_request_threaded_irq(dev, dockchannel->rx_irq, dockchannel_rx_irq,
++					dockchannel_rx_irq_thread, IRQF_NO_AUTOEN,
++					"apple-dockchannel-rx", dockchannel);
++	if (ret)
++		return ERR_PTR(dev_err_probe(dev, ret, "Failed to request RX IRQ"));
++
++	return dockchannel;
++}
++EXPORT_SYMBOL(dockchannel_init);
++
++
++/* Dockchannel IRQchip */
++
++static void dockchannel_irq(struct irq_desc *desc)
++{
++	unsigned int irq = irq_desc_get_irq(desc);
++	struct irq_chip *chip = irq_desc_get_chip(desc);
++	struct dockchannel_common *dcc = irq_get_handler_data(irq);
++	unsigned long flags = readl_relaxed(dcc->irq_base + IRQ_FLAG);
++	int bit;
++
++	chained_irq_enter(chip, desc);
++
++	for_each_set_bit(bit, &flags, DOCKCHANNEL_MAX_IRQ)
++		generic_handle_domain_irq(dcc->domain, bit);
++
++	chained_irq_exit(chip, desc);
++}
++
++static void dockchannel_irq_ack(struct irq_data *data)
++{
++	struct dockchannel_common *dcc = irq_data_get_irq_chip_data(data);
++	unsigned int hwirq = data->hwirq;
++
++	writel_relaxed(BIT(hwirq), dcc->irq_base + IRQ_FLAG);
++}
++
++static void dockchannel_irq_mask(struct irq_data *data)
++{
++	struct dockchannel_common *dcc = irq_data_get_irq_chip_data(data);
++	unsigned int hwirq = data->hwirq;
++	u32 val = readl_relaxed(dcc->irq_base + IRQ_MASK);
++
++	writel_relaxed(val & ~BIT(hwirq), dcc->irq_base + IRQ_MASK);
++}
++
++static void dockchannel_irq_unmask(struct irq_data *data)
++{
++	struct dockchannel_common *dcc = irq_data_get_irq_chip_data(data);
++	unsigned int hwirq = data->hwirq;
++	u32 val = readl_relaxed(dcc->irq_base + IRQ_MASK);
++
++	writel_relaxed(val | BIT(hwirq), dcc->irq_base + IRQ_MASK);
++}
++
++static const struct irq_chip dockchannel_irqchip = {
++	.name = "dockchannel-irqc",
++	.irq_ack = dockchannel_irq_ack,
++	.irq_mask = dockchannel_irq_mask,
++	.irq_unmask = dockchannel_irq_unmask,
++};
++
++static int dockchannel_irq_domain_map(struct irq_domain *d, unsigned int virq,
++				      irq_hw_number_t hw)
++{
++	irq_set_chip_data(virq, d->host_data);
++	irq_set_chip_and_handler(virq, &dockchannel_irqchip, handle_level_irq);
++
++	return 0;
++}
++
++static const struct irq_domain_ops dockchannel_irq_domain_ops = {
++	.xlate	= irq_domain_xlate_twocell,
++	.map	= dockchannel_irq_domain_map,
++};
++
++static int dockchannel_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct dockchannel_common *dcc;
++	struct device_node *child;
++
++	dcc = devm_kzalloc(dev, sizeof(*dcc), GFP_KERNEL);
++	if (!dcc)
++		return -ENOMEM;
++
++	dcc->dev = dev;
++	platform_set_drvdata(pdev, dcc);
++
++	dcc->irq_base = devm_platform_ioremap_resource_byname(pdev, "irq");
++	if (IS_ERR(dcc->irq_base))
++		return PTR_ERR(dcc->irq_base);
++
++	writel_relaxed(0, dcc->irq_base + IRQ_MASK);
++	writel_relaxed(~0, dcc->irq_base + IRQ_FLAG);
++
++	dcc->domain = irq_domain_add_linear(dev->of_node, DOCKCHANNEL_MAX_IRQ,
++					    &dockchannel_irq_domain_ops, dcc);
++	if (!dcc->domain)
++		return -ENOMEM;
++
++	dcc->irq = platform_get_irq(pdev, 0);
++	if (dcc->irq <= 0)
++		return dev_err_probe(dev, dcc->irq, "Failed to get IRQ");
++
++	irq_set_handler_data(dcc->irq, dcc);
++	irq_set_chained_handler(dcc->irq, dockchannel_irq);
++
++	for_each_child_of_node(dev->of_node, child)
++		of_platform_device_create(child, NULL, dev);
++
++	return 0;
++}
++
++static void dockchannel_remove(struct platform_device *pdev)
++{
++	struct dockchannel_common *dcc = platform_get_drvdata(pdev);
++	int hwirq;
++
++	device_for_each_child(&pdev->dev, NULL, of_platform_device_destroy);
++
++	irq_set_chained_handler_and_data(dcc->irq, NULL, NULL);
++
++	for (hwirq = 0; hwirq < DOCKCHANNEL_MAX_IRQ; hwirq++)
++		irq_dispose_mapping(irq_find_mapping(dcc->domain, hwirq));
++
++	irq_domain_remove(dcc->domain);
++
++	writel_relaxed(0, dcc->irq_base + IRQ_MASK);
++	writel_relaxed(~0, dcc->irq_base + IRQ_FLAG);
++}
++
++static const struct of_device_id dockchannel_of_match[] = {
++	{ .compatible = "apple,dockchannel" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, dockchannel_of_match);
++
++static struct platform_driver dockchannel_driver = {
++	.driver = {
++		.name = "dockchannel",
++		.of_match_table = dockchannel_of_match,
++	},
++	.probe = dockchannel_probe,
++	.remove = dockchannel_remove,
++};
++module_platform_driver(dockchannel_driver);
++
++MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
++MODULE_LICENSE("Dual MIT/GPL");
++MODULE_DESCRIPTION("Apple DockChannel driver");
+diff --git a/drivers/soc/apple/rtkit-helper.c b/drivers/soc/apple/rtkit-helper.c
+new file mode 100644
+index 000000000000..080d083ed9bd
+--- /dev/null
++++ b/drivers/soc/apple/rtkit-helper.c
+@@ -0,0 +1,151 @@
++// SPDX-License-Identifier: GPL-2.0-only OR MIT
++/*
++ * Apple Generic RTKit helper coprocessor
++ * Copyright The Asahi Linux Contributors
++ */
++
++#include <linux/device.h>
++#include <linux/dma-mapping.h>
++#include <linux/io.h>
++#include <linux/ioport.h>
++#include <linux/of.h>
++#include <linux/of_platform.h>
++#include <linux/platform_device.h>
++#include <linux/soc/apple/rtkit.h>
++
++#define APPLE_ASC_CPU_CONTROL		0x44
++#define APPLE_ASC_CPU_CONTROL_RUN	BIT(4)
++
++struct apple_rtkit_helper {
++	struct device *dev;
++	struct apple_rtkit *rtk;
++
++	void __iomem *asc_base;
++
++	struct resource *sram;
++	void __iomem *sram_base;
++};
++
++static int apple_rtkit_helper_shmem_setup(void *cookie, struct apple_rtkit_shmem *bfr)
++{
++	struct apple_rtkit_helper *helper = cookie;
++	struct resource res = {
++		.start = bfr->iova,
++		.end = bfr->iova + bfr->size - 1,
++		.name = "rtkit_map",
++	};
++
++	if (!bfr->iova) {
++		bfr->buffer = dma_alloc_coherent(helper->dev, bfr->size,
++						    &bfr->iova, GFP_KERNEL);
++		if (!bfr->buffer)
++			return -ENOMEM;
++		return 0;
++	}
++
++	if (!helper->sram) {
++		dev_err(helper->dev,
++			"RTKit buffer request with no SRAM region: %pR", &res);
++		return -EFAULT;
++	}
++
++	res.flags = helper->sram->flags;
++
++	if (res.end < res.start || !resource_contains(helper->sram, &res)) {
++		dev_err(helper->dev,
++			"RTKit buffer request outside SRAM region: %pR", &res);
++		return -EFAULT;
++	}
++
++	bfr->iomem = helper->sram_base + (res.start - helper->sram->start);
++	bfr->is_mapped = true;
++
++	return 0;
++}
++
++static void apple_rtkit_helper_shmem_destroy(void *cookie, struct apple_rtkit_shmem *bfr)
++{
++	// no-op
++}
++
++static const struct apple_rtkit_ops apple_rtkit_helper_ops = {
++	.shmem_setup = apple_rtkit_helper_shmem_setup,
++	.shmem_destroy = apple_rtkit_helper_shmem_destroy,
++};
++
++static int apple_rtkit_helper_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct apple_rtkit_helper *helper;
++	int ret;
++
++	/* 44 bits for addresses in standard RTKit requests */
++	ret = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(44));
++	if (ret)
++		return ret;
++
++	helper = devm_kzalloc(dev, sizeof(*helper), GFP_KERNEL);
++	if (!helper)
++		return -ENOMEM;
++
++	helper->dev = dev;
++	platform_set_drvdata(pdev, helper);
++
++	helper->asc_base = devm_platform_ioremap_resource_byname(pdev, "asc");
++	if (IS_ERR(helper->asc_base))
++		return PTR_ERR(helper->asc_base);
++
++	helper->sram = platform_get_resource_byname(pdev, IORESOURCE_MEM, "sram");
++	if (helper->sram) {
++		helper->sram_base = devm_ioremap_resource(dev, helper->sram);
++		if (IS_ERR(helper->sram_base))
++			return dev_err_probe(dev, PTR_ERR(helper->sram_base),
++					"Failed to map SRAM region");
++	}
++
++	helper->rtk =
++		devm_apple_rtkit_init(dev, helper, NULL, 0, &apple_rtkit_helper_ops);
++	if (IS_ERR(helper->rtk))
++		return dev_err_probe(dev, PTR_ERR(helper->rtk),
++				     "Failed to intialize RTKit");
++
++	writel_relaxed(APPLE_ASC_CPU_CONTROL_RUN,
++		       helper->asc_base + APPLE_ASC_CPU_CONTROL);
++
++	/* Works for both wake and boot */
++	ret = apple_rtkit_wake(helper->rtk);
++	if (ret != 0)
++		return dev_err_probe(dev, ret, "Failed to wake up coprocessor");
++
++	return 0;
++}
++
++static void apple_rtkit_helper_remove(struct platform_device *pdev)
++{
++	struct apple_rtkit_helper *helper = platform_get_drvdata(pdev);
++
++	if (apple_rtkit_is_running(helper->rtk))
++		apple_rtkit_quiesce(helper->rtk);
++
++	writel_relaxed(0, helper->asc_base + APPLE_ASC_CPU_CONTROL);
++}
++
++static const struct of_device_id apple_rtkit_helper_of_match[] = {
++	{ .compatible = "apple,rtk-helper-asc4" },
++	{},
++};
++MODULE_DEVICE_TABLE(of, apple_rtkit_helper_of_match);
++
++static struct platform_driver apple_rtkit_helper_driver = {
++	.driver = {
++		.name = "rtkit-helper",
++		.of_match_table = apple_rtkit_helper_of_match,
++	},
++	.probe = apple_rtkit_helper_probe,
++	.remove = apple_rtkit_helper_remove,
++};
++module_platform_driver(apple_rtkit_helper_driver);
++
++MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
++MODULE_LICENSE("Dual MIT/GPL");
++MODULE_DESCRIPTION("Apple RTKit helper driver");
+diff --git a/drivers/staging/Kconfig b/drivers/staging/Kconfig
+index 075e775d3868..e1cc0d60eeb6 100644
+--- a/drivers/staging/Kconfig
++++ b/drivers/staging/Kconfig
+@@ -50,4 +50,6 @@ source "drivers/staging/vme_user/Kconfig"
+ 
+ source "drivers/staging/gpib/Kconfig"
+ 
++source "drivers/staging/apple-bce/Kconfig"
++
+ endif # STAGING
+diff --git a/drivers/staging/Makefile b/drivers/staging/Makefile
+index e681e403509c..4045c588b3b4 100644
+--- a/drivers/staging/Makefile
++++ b/drivers/staging/Makefile
+@@ -14,3 +14,4 @@ obj-$(CONFIG_GREYBUS)		+= greybus/
+ obj-$(CONFIG_BCM2835_VCHIQ)	+= vc04_services/
+ obj-$(CONFIG_XIL_AXIS_FIFO)	+= axis-fifo/
+ obj-$(CONFIG_GPIB)	 	+= gpib/
++obj-$(CONFIG_APPLE_BCE)		+= apple-bce/
+diff --git a/drivers/staging/apple-bce/Kconfig b/drivers/staging/apple-bce/Kconfig
+new file mode 100644
+index 000000000000..fe92bc441e89
+--- /dev/null
++++ b/drivers/staging/apple-bce/Kconfig
+@@ -0,0 +1,18 @@
++config APPLE_BCE
++	tristate "Apple BCE driver (VHCI and Audio support)"
++	default m
++	depends on X86
++	select SOUND
++	select SND
++	select SND_PCM
++	select SND_JACK
++	help
++	  VHCI and audio support on Apple MacBooks with the T2 Chip.
++	  This driver is divided in three components:
++	    - BCE (Buffer Copy Engine): which establishes a basic communication
++	      channel with the T2 chip. This component is required by the other two:
++	      - VHCI (Virtual Host Controller Interface): Access to keyboard, mouse
++	        and other system devices depend on this virtual USB host controller
++	      - Audio: a driver for the T2 audio interface.
++	 
++	  If "M" is selected, the module will be called apple-bce.'
+diff --git a/drivers/staging/apple-bce/Makefile b/drivers/staging/apple-bce/Makefile
+new file mode 100644
+index 000000000000..8cfbd3f64af6
+--- /dev/null
++++ b/drivers/staging/apple-bce/Makefile
+@@ -0,0 +1,28 @@
++modname := apple-bce
++obj-$(CONFIG_APPLE_BCE) += $(modname).o
++
++apple-bce-objs := apple_bce.o mailbox.o queue.o queue_dma.o vhci/vhci.o vhci/queue.o vhci/transfer.o audio/audio.o audio/protocol.o audio/protocol_bce.o audio/pcm.o
++
++MY_CFLAGS += -DWITHOUT_NVME_PATCH
++#MY_CFLAGS += -g -DDEBUG
++ccflags-y += ${MY_CFLAGS}
++CC += ${MY_CFLAGS}
++
++KVERSION := $(KERNELRELEASE)
++ifeq ($(origin KERNELRELEASE), undefined)
++KVERSION := $(shell uname -r)
++endif
++
++KDIR := /lib/modules/$(KVERSION)/build
++PWD := $(shell pwd)
++
++.PHONY: all
++
++all:
++	$(MAKE) -C $(KDIR) M=$(PWD) modules
++
++clean:
++	$(MAKE) -C $(KDIR) M=$(PWD) clean
++
++install:
++	$(MAKE) -C $(KDIR) M=$(PWD) modules_install
+diff --git a/drivers/staging/apple-bce/apple_bce.c b/drivers/staging/apple-bce/apple_bce.c
+new file mode 100644
+index 000000000000..4fd2415d7028
+--- /dev/null
++++ b/drivers/staging/apple-bce/apple_bce.c
+@@ -0,0 +1,445 @@
++#include "apple_bce.h"
++#include <linux/module.h>
++#include <linux/crc32.h>
++#include "audio/audio.h"
++#include <linux/version.h>
++
++static dev_t bce_chrdev;
++static struct class *bce_class;
++
++struct apple_bce_device *global_bce;
++
++static int bce_create_command_queues(struct apple_bce_device *bce);
++static void bce_free_command_queues(struct apple_bce_device *bce);
++static irqreturn_t bce_handle_mb_irq(int irq, void *dev);
++static irqreturn_t bce_handle_dma_irq(int irq, void *dev);
++static int bce_fw_version_handshake(struct apple_bce_device *bce);
++static int bce_register_command_queue(struct apple_bce_device *bce, struct bce_queue_memcfg *cfg, int is_sq);
++
++static int apple_bce_probe(struct pci_dev *dev, const struct pci_device_id *id)
++{
++    struct apple_bce_device *bce = NULL;
++    int status = 0;
++    int nvec;
++
++    pr_info("apple-bce: capturing our device\n");
++
++    if (pci_enable_device(dev))
++        return -ENODEV;
++    if (pci_request_regions(dev, "apple-bce")) {
++        status = -ENODEV;
++        goto fail;
++    }
++    pci_set_master(dev);
++    nvec = pci_alloc_irq_vectors(dev, 1, 8, PCI_IRQ_MSI);
++    if (nvec < 5) {
++        status = -EINVAL;
++        goto fail;
++    }
++
++    bce = kzalloc(sizeof(struct apple_bce_device), GFP_KERNEL);
++    if (!bce) {
++        status = -ENOMEM;
++        goto fail;
++    }
++
++    bce->pci = dev;
++    pci_set_drvdata(dev, bce);
++
++    bce->devt = bce_chrdev;
++    bce->dev = device_create(bce_class, &dev->dev, bce->devt, NULL, "apple-bce");
++    if (IS_ERR_OR_NULL(bce->dev)) {
++        status = PTR_ERR(bce_class);
++        goto fail;
++    }
++
++    bce->reg_mem_mb = pci_iomap(dev, 4, 0);
++    bce->reg_mem_dma = pci_iomap(dev, 2, 0);
++
++    if (IS_ERR_OR_NULL(bce->reg_mem_mb) || IS_ERR_OR_NULL(bce->reg_mem_dma)) {
++        dev_warn(&dev->dev, "apple-bce: Failed to pci_iomap required regions\n");
++        goto fail;
++    }
++
++    bce_mailbox_init(&bce->mbox, bce->reg_mem_mb);
++    bce_timestamp_init(&bce->timestamp, bce->reg_mem_mb);
++
++    spin_lock_init(&bce->queues_lock);
++    ida_init(&bce->queue_ida);
++
++    if ((status = pci_request_irq(dev, 0, bce_handle_mb_irq, NULL, dev, "bce_mbox")))
++        goto fail;
++    if ((status = pci_request_irq(dev, 4, NULL, bce_handle_dma_irq, dev, "bce_dma")))
++        goto fail_interrupt_0;
++
++    if ((status = dma_set_mask_and_coherent(&dev->dev, DMA_BIT_MASK(37)))) {
++        dev_warn(&dev->dev, "dma: Setting mask failed\n");
++        goto fail_interrupt;
++    }
++
++    /* Gets the function 0's interface. This is needed because Apple only accepts DMA on our function if function 0
++       is a bus master, so we need to work around this. */
++    bce->pci0 = pci_get_slot(dev->bus, PCI_DEVFN(PCI_SLOT(dev->devfn), 0));
++#ifndef WITHOUT_NVME_PATCH
++    if ((status = pci_enable_device_mem(bce->pci0))) {
++        dev_warn(&dev->dev, "apple-bce: failed to enable function 0\n");
++        goto fail_dev0;
++    }
++#endif
++    pci_set_master(bce->pci0);
++
++    bce_timestamp_start(&bce->timestamp, true);
++
++    if ((status = bce_fw_version_handshake(bce)))
++        goto fail_ts;
++    pr_info("apple-bce: handshake done\n");
++
++    if ((status = bce_create_command_queues(bce))) {
++        pr_info("apple-bce: Creating command queues failed\n");
++        goto fail_ts;
++    }
++
++    global_bce = bce;
++
++    bce_vhci_create(bce, &bce->vhci);
++
++    return 0;
++
++fail_ts:
++    bce_timestamp_stop(&bce->timestamp);
++#ifndef WITHOUT_NVME_PATCH
++    pci_disable_device(bce->pci0);
++fail_dev0:
++#endif
++    pci_dev_put(bce->pci0);
++fail_interrupt:
++    pci_free_irq(dev, 4, dev);
++fail_interrupt_0:
++    pci_free_irq(dev, 0, dev);
++fail:
++    if (bce && bce->dev) {
++        device_destroy(bce_class, bce->devt);
++
++        if (!IS_ERR_OR_NULL(bce->reg_mem_mb))
++            pci_iounmap(dev, bce->reg_mem_mb);
++        if (!IS_ERR_OR_NULL(bce->reg_mem_dma))
++            pci_iounmap(dev, bce->reg_mem_dma);
++
++        kfree(bce);
++    }
++
++    pci_free_irq_vectors(dev);
++    pci_release_regions(dev);
++    pci_disable_device(dev);
++
++    if (!status)
++        status = -EINVAL;
++    return status;
++}
++
++static int bce_create_command_queues(struct apple_bce_device *bce)
++{
++    int status;
++    struct bce_queue_memcfg *cfg;
++
++    bce->cmd_cq = bce_alloc_cq(bce, 0, 0x20);
++    bce->cmd_cmdq = bce_alloc_cmdq(bce, 1, 0x20);
++    if (bce->cmd_cq == NULL || bce->cmd_cmdq == NULL) {
++        status = -ENOMEM;
++        goto err;
++    }
++    bce->queues[0] = (struct bce_queue *) bce->cmd_cq;
++    bce->queues[1] = (struct bce_queue *) bce->cmd_cmdq->sq;
++
++    cfg = kzalloc(sizeof(struct bce_queue_memcfg), GFP_KERNEL);
++    if (!cfg) {
++        status = -ENOMEM;
++        goto err;
++    }
++    bce_get_cq_memcfg(bce->cmd_cq, cfg);
++    if ((status = bce_register_command_queue(bce, cfg, false)))
++        goto err;
++    bce_get_sq_memcfg(bce->cmd_cmdq->sq, bce->cmd_cq, cfg);
++    if ((status = bce_register_command_queue(bce, cfg, true)))
++        goto err;
++    kfree(cfg);
++
++    return 0;
++
++err:
++    if (bce->cmd_cq)
++        bce_free_cq(bce, bce->cmd_cq);
++    if (bce->cmd_cmdq)
++        bce_free_cmdq(bce, bce->cmd_cmdq);
++    return status;
++}
++
++static void bce_free_command_queues(struct apple_bce_device *bce)
++{
++    bce_free_cq(bce, bce->cmd_cq);
++    bce_free_cmdq(bce, bce->cmd_cmdq);
++    bce->cmd_cq = NULL;
++    bce->queues[0] = NULL;
++}
++
++static irqreturn_t bce_handle_mb_irq(int irq, void *dev)
++{
++    struct apple_bce_device *bce = pci_get_drvdata(dev);
++    bce_mailbox_handle_interrupt(&bce->mbox);
++    return IRQ_HANDLED;
++}
++
++static irqreturn_t bce_handle_dma_irq(int irq, void *dev)
++{
++    int i;
++    struct apple_bce_device *bce = pci_get_drvdata(dev);
++    spin_lock(&bce->queues_lock);
++    for (i = 0; i < BCE_MAX_QUEUE_COUNT; i++)
++        if (bce->queues[i] && bce->queues[i]->type == BCE_QUEUE_CQ)
++            bce_handle_cq_completions(bce, (struct bce_queue_cq *) bce->queues[i]);
++    spin_unlock(&bce->queues_lock);
++    return IRQ_HANDLED;
++}
++
++static int bce_fw_version_handshake(struct apple_bce_device *bce)
++{
++    u64 result;
++    int status;
++
++    if ((status = bce_mailbox_send(&bce->mbox, BCE_MB_MSG(BCE_MB_SET_FW_PROTOCOL_VERSION, BC_PROTOCOL_VERSION),
++            &result)))
++        return status;
++    if (BCE_MB_TYPE(result) != BCE_MB_SET_FW_PROTOCOL_VERSION ||
++        BCE_MB_VALUE(result) != BC_PROTOCOL_VERSION) {
++        pr_err("apple-bce: FW version handshake failed %x:%llx\n", BCE_MB_TYPE(result), BCE_MB_VALUE(result));
++        return -EINVAL;
++    }
++    return 0;
++}
++
++static int bce_register_command_queue(struct apple_bce_device *bce, struct bce_queue_memcfg *cfg, int is_sq)
++{
++    int status;
++    int cmd_type;
++    u64 result;
++    // OS X uses an bidirectional direction, but that's not really needed
++    dma_addr_t a = dma_map_single(&bce->pci->dev, cfg, sizeof(struct bce_queue_memcfg), DMA_TO_DEVICE);
++    if (dma_mapping_error(&bce->pci->dev, a))
++        return -ENOMEM;
++    cmd_type = is_sq ? BCE_MB_REGISTER_COMMAND_SQ : BCE_MB_REGISTER_COMMAND_CQ;
++    status = bce_mailbox_send(&bce->mbox, BCE_MB_MSG(cmd_type, a), &result);
++    dma_unmap_single(&bce->pci->dev, a, sizeof(struct bce_queue_memcfg), DMA_TO_DEVICE);
++    if (status)
++        return status;
++    if (BCE_MB_TYPE(result) != BCE_MB_REGISTER_COMMAND_QUEUE_REPLY)
++        return -EINVAL;
++    return 0;
++}
++
++static void apple_bce_remove(struct pci_dev *dev)
++{
++    struct apple_bce_device *bce = pci_get_drvdata(dev);
++    bce->is_being_removed = true;
++
++    bce_vhci_destroy(&bce->vhci);
++
++    bce_timestamp_stop(&bce->timestamp);
++#ifndef WITHOUT_NVME_PATCH
++    pci_disable_device(bce->pci0);
++#endif
++    pci_dev_put(bce->pci0);
++    pci_free_irq(dev, 0, dev);
++    pci_free_irq(dev, 4, dev);
++    bce_free_command_queues(bce);
++    pci_iounmap(dev, bce->reg_mem_mb);
++    pci_iounmap(dev, bce->reg_mem_dma);
++    device_destroy(bce_class, bce->devt);
++    pci_free_irq_vectors(dev);
++    pci_release_regions(dev);
++    pci_disable_device(dev);
++    kfree(bce);
++}
++
++static int bce_save_state_and_sleep(struct apple_bce_device *bce)
++{
++    int attempt, status = 0;
++    u64 resp;
++    dma_addr_t dma_addr;
++    void *dma_ptr = NULL;
++    size_t size = max(PAGE_SIZE, 4096UL);
++
++    for (attempt = 0; attempt < 5; ++attempt) {
++        pr_debug("apple-bce: suspend: attempt %i, buffer size %li\n", attempt, size);
++        dma_ptr = dma_alloc_coherent(&bce->pci->dev, size, &dma_addr, GFP_KERNEL);
++        if (!dma_ptr) {
++            pr_err("apple-bce: suspend failed (data alloc failed)\n");
++            break;
++        }
++        BUG_ON((dma_addr % 4096) != 0);
++        status = bce_mailbox_send(&bce->mbox,
++                BCE_MB_MSG(BCE_MB_SAVE_STATE_AND_SLEEP, (dma_addr & ~(4096LLU - 1)) | (size / 4096)), &resp);
++        if (status) {
++            pr_err("apple-bce: suspend failed (mailbox send)\n");
++            break;
++        }
++        if (BCE_MB_TYPE(resp) == BCE_MB_SAVE_RESTORE_STATE_COMPLETE) {
++            bce->saved_data_dma_addr = dma_addr;
++            bce->saved_data_dma_ptr = dma_ptr;
++            bce->saved_data_dma_size = size;
++            return 0;
++        } else if (BCE_MB_TYPE(resp) == BCE_MB_SAVE_STATE_AND_SLEEP_FAILURE) {
++            dma_free_coherent(&bce->pci->dev, size, dma_ptr, dma_addr);
++            /* The 0x10ff magic value was extracted from Apple's driver */
++            size = (BCE_MB_VALUE(resp) + 0x10ff) & ~(4096LLU - 1);
++            pr_debug("apple-bce: suspend: device requested a larger buffer (%li)\n", size);
++            continue;
++        } else {
++            pr_err("apple-bce: suspend failed (invalid device response)\n");
++            status = -EINVAL;
++            break;
++        }
++    }
++    if (dma_ptr)
++        dma_free_coherent(&bce->pci->dev, size, dma_ptr, dma_addr);
++    if (!status)
++        return bce_mailbox_send(&bce->mbox, BCE_MB_MSG(BCE_MB_SLEEP_NO_STATE, 0), &resp);
++    return status;
++}
++
++static int bce_restore_state_and_wake(struct apple_bce_device *bce)
++{
++    int status;
++    u64 resp;
++    if (!bce->saved_data_dma_ptr) {
++        if ((status = bce_mailbox_send(&bce->mbox, BCE_MB_MSG(BCE_MB_RESTORE_NO_STATE, 0), &resp))) {
++            pr_err("apple-bce: resume with no state failed (mailbox send)\n");
++            return status;
++        }
++        if (BCE_MB_TYPE(resp) != BCE_MB_RESTORE_NO_STATE) {
++            pr_err("apple-bce: resume with no state failed (invalid device response)\n");
++            return -EINVAL;
++        }
++        return 0;
++    }
++
++    if ((status = bce_mailbox_send(&bce->mbox, BCE_MB_MSG(BCE_MB_RESTORE_STATE_AND_WAKE,
++            (bce->saved_data_dma_addr & ~(4096LLU - 1)) | (bce->saved_data_dma_size / 4096)), &resp))) {
++        pr_err("apple-bce: resume with state failed (mailbox send)\n");
++        goto finish_with_state;
++    }
++    if (BCE_MB_TYPE(resp) != BCE_MB_SAVE_RESTORE_STATE_COMPLETE) {
++        pr_err("apple-bce: resume with state failed (invalid device response)\n");
++        status = -EINVAL;
++        goto finish_with_state;
++    }
++
++finish_with_state:
++    dma_free_coherent(&bce->pci->dev, bce->saved_data_dma_size, bce->saved_data_dma_ptr, bce->saved_data_dma_addr);
++    bce->saved_data_dma_ptr = NULL;
++    return status;
++}
++
++static int apple_bce_suspend(struct device *dev)
++{
++    struct apple_bce_device *bce = pci_get_drvdata(to_pci_dev(dev));
++    int status;
++
++    bce_timestamp_stop(&bce->timestamp);
++
++    if ((status = bce_save_state_and_sleep(bce)))
++        return status;
++
++    return 0;
++}
++
++static int apple_bce_resume(struct device *dev)
++{
++    struct apple_bce_device *bce = pci_get_drvdata(to_pci_dev(dev));
++    int status;
++
++    pci_set_master(bce->pci);
++    pci_set_master(bce->pci0);
++
++    if ((status = bce_restore_state_and_wake(bce)))
++        return status;
++
++    bce_timestamp_start(&bce->timestamp, false);
++
++    return 0;
++}
++
++static struct pci_device_id apple_bce_ids[  ] = {
++        { PCI_DEVICE(PCI_VENDOR_ID_APPLE, 0x1801) },
++        { 0, },
++};
++
++MODULE_DEVICE_TABLE(pci, apple_bce_ids);
++
++struct dev_pm_ops apple_bce_pci_driver_pm = {
++        .suspend = apple_bce_suspend,
++        .resume = apple_bce_resume
++};
++struct pci_driver apple_bce_pci_driver = {
++        .name = "apple-bce",
++        .id_table = apple_bce_ids,
++        .probe = apple_bce_probe,
++        .remove = apple_bce_remove,
++        .driver = {
++                .pm = &apple_bce_pci_driver_pm
++        }
++};
++
++
++static int __init apple_bce_module_init(void)
++{
++    int result;
++    if ((result = alloc_chrdev_region(&bce_chrdev, 0, 1, "apple-bce")))
++        goto fail_chrdev;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
++    bce_class = class_create(THIS_MODULE, "apple-bce");
++#else
++    bce_class = class_create("apple-bce");
++#endif
++    if (IS_ERR(bce_class)) {
++        result = PTR_ERR(bce_class);
++        goto fail_class;
++    }
++    if ((result = bce_vhci_module_init())) {
++        pr_err("apple-bce: bce-vhci init failed");
++        goto fail_class;
++    }
++
++    result = pci_register_driver(&apple_bce_pci_driver);
++    if (result)
++        goto fail_drv;
++
++    aaudio_module_init();
++
++    return 0;
++
++fail_drv:
++    pci_unregister_driver(&apple_bce_pci_driver);
++fail_class:
++    class_destroy(bce_class);
++fail_chrdev:
++    unregister_chrdev_region(bce_chrdev, 1);
++    if (!result)
++        result = -EINVAL;
++    return result;
++}
++static void __exit apple_bce_module_exit(void)
++{
++    pci_unregister_driver(&apple_bce_pci_driver);
++
++    aaudio_module_exit();
++    bce_vhci_module_exit();
++    class_destroy(bce_class);
++    unregister_chrdev_region(bce_chrdev, 1);
++}
++
++MODULE_LICENSE("GPL");
++MODULE_AUTHOR("MrARM");
++MODULE_DESCRIPTION("Apple BCE Driver");
++MODULE_VERSION("0.01");
++module_init(apple_bce_module_init);
++module_exit(apple_bce_module_exit);
+diff --git a/drivers/staging/apple-bce/apple_bce.h b/drivers/staging/apple-bce/apple_bce.h
+new file mode 100644
+index 000000000000..58dbeff79e43
+--- /dev/null
++++ b/drivers/staging/apple-bce/apple_bce.h
+@@ -0,0 +1,41 @@
++#ifndef APPLE_BCE_H
++#define APPLE_BCE_H
++
++#include <linux/pci.h>
++#include <linux/spinlock.h>
++#include "mailbox.h"
++#include "queue.h"
++#include "vhci/vhci.h"
++
++#define BC_PROTOCOL_VERSION 0x20001
++#define BCE_MAX_QUEUE_COUNT 0x100
++
++#define BCE_QUEUE_USER_MIN 2
++#define BCE_QUEUE_USER_MAX (BCE_MAX_QUEUE_COUNT - 1)
++
++struct apple_bce_device {
++    struct pci_dev *pci, *pci0;
++    dev_t devt;
++    struct device *dev;
++    void __iomem *reg_mem_mb;
++    void __iomem *reg_mem_dma;
++    struct bce_mailbox mbox;
++    struct bce_timestamp timestamp;
++    struct bce_queue *queues[BCE_MAX_QUEUE_COUNT];
++    struct spinlock queues_lock;
++    struct ida queue_ida;
++    struct bce_queue_cq *cmd_cq;
++    struct bce_queue_cmdq *cmd_cmdq;
++    struct bce_queue_sq *int_sq_list[BCE_MAX_QUEUE_COUNT];
++    bool is_being_removed;
++
++    dma_addr_t saved_data_dma_addr;
++    void *saved_data_dma_ptr;
++    size_t saved_data_dma_size;
++
++    struct bce_vhci vhci;
++};
++
++extern struct apple_bce_device *global_bce;
++
++#endif //APPLE_BCE_H
+diff --git a/drivers/staging/apple-bce/audio/audio.c b/drivers/staging/apple-bce/audio/audio.c
+new file mode 100644
+index 000000000000..bd16ddd16c1d
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/audio.c
+@@ -0,0 +1,711 @@
++#include <linux/pci.h>
++#include <linux/spinlock.h>
++#include <linux/module.h>
++#include <linux/random.h>
++#include <sound/core.h>
++#include <sound/initval.h>
++#include <sound/pcm.h>
++#include <sound/jack.h>
++#include "audio.h"
++#include "pcm.h"
++#include <linux/version.h>
++
++static int aaudio_alsa_index = SNDRV_DEFAULT_IDX1;
++static char *aaudio_alsa_id = SNDRV_DEFAULT_STR1;
++
++static dev_t aaudio_chrdev;
++static struct class *aaudio_class;
++
++static int aaudio_init_cmd(struct aaudio_device *a);
++static int aaudio_init_bs(struct aaudio_device *a);
++static void aaudio_init_dev(struct aaudio_device *a, aaudio_device_id_t dev_id);
++static void aaudio_free_dev(struct aaudio_subdevice *sdev);
++
++static int aaudio_probe(struct pci_dev *dev, const struct pci_device_id *id)
++{
++    struct aaudio_device *aaudio = NULL;
++    struct aaudio_subdevice *sdev = NULL;
++    int status = 0;
++    u32 cfg;
++
++    pr_info("aaudio: capturing our device\n");
++
++    if (pci_enable_device(dev))
++        return -ENODEV;
++    if (pci_request_regions(dev, "aaudio")) {
++        status = -ENODEV;
++        goto fail;
++    }
++    pci_set_master(dev);
++
++    aaudio = kzalloc(sizeof(struct aaudio_device), GFP_KERNEL);
++    if (!aaudio) {
++        status = -ENOMEM;
++        goto fail;
++    }
++
++    aaudio->bce = global_bce;
++    if (!aaudio->bce) {
++        dev_warn(&dev->dev, "aaudio: No BCE available\n");
++        status = -EINVAL;
++        goto fail;
++    }
++
++    aaudio->pci = dev;
++    pci_set_drvdata(dev, aaudio);
++
++    aaudio->devt = aaudio_chrdev;
++    aaudio->dev = device_create(aaudio_class, &dev->dev, aaudio->devt, NULL, "aaudio");
++    if (IS_ERR_OR_NULL(aaudio->dev)) {
++        status = PTR_ERR(aaudio_class);
++        goto fail;
++    }
++    device_link_add(aaudio->dev, aaudio->bce->dev, DL_FLAG_PM_RUNTIME | DL_FLAG_AUTOREMOVE_CONSUMER);
++
++    init_completion(&aaudio->remote_alive);
++    INIT_LIST_HEAD(&aaudio->subdevice_list);
++
++    /* Init: set an unknown flag in the bitset */
++    if (pci_read_config_dword(dev, 4, &cfg))
++        dev_warn(&dev->dev, "aaudio: pci_read_config_dword fail\n");
++    if (pci_write_config_dword(dev, 4, cfg | 6u))
++        dev_warn(&dev->dev, "aaudio: pci_write_config_dword fail\n");
++
++    dev_info(aaudio->dev, "aaudio: bs len = %llx\n", pci_resource_len(dev, 0));
++    aaudio->reg_mem_bs_dma = pci_resource_start(dev, 0);
++    aaudio->reg_mem_bs = pci_iomap(dev, 0, 0);
++    aaudio->reg_mem_cfg = pci_iomap(dev, 4, 0);
++
++    aaudio->reg_mem_gpr = (u32 __iomem *) ((u8 __iomem *) aaudio->reg_mem_cfg + 0xC000);
++
++    if (IS_ERR_OR_NULL(aaudio->reg_mem_bs) || IS_ERR_OR_NULL(aaudio->reg_mem_cfg)) {
++        dev_warn(&dev->dev, "aaudio: Failed to pci_iomap required regions\n");
++        goto fail;
++    }
++
++    if (aaudio_bce_init(aaudio)) {
++        dev_warn(&dev->dev, "aaudio: Failed to init BCE command transport\n");
++        goto fail;
++    }
++
++    if (snd_card_new(aaudio->dev, aaudio_alsa_index, aaudio_alsa_id, THIS_MODULE, 0, &aaudio->card)) {
++        dev_err(&dev->dev, "aaudio: Failed to create ALSA card\n");
++        goto fail;
++    }
++
++    strcpy(aaudio->card->shortname, "Apple T2 Audio");
++    strcpy(aaudio->card->longname, "Apple T2 Audio");
++    strcpy(aaudio->card->mixername, "Apple T2 Audio");
++    /* Dynamic alsa ids start at 100 */
++    aaudio->next_alsa_id = 100;
++
++    if (aaudio_init_cmd(aaudio)) {
++        dev_err(&dev->dev, "aaudio: Failed to initialize over BCE\n");
++        goto fail_snd;
++    }
++
++    if (aaudio_init_bs(aaudio)) {
++        dev_err(&dev->dev, "aaudio: Failed to initialize BufferStruct\n");
++        goto fail_snd;
++    }
++
++    if ((status = aaudio_cmd_set_remote_access(aaudio, AAUDIO_REMOTE_ACCESS_ON))) {
++        dev_err(&dev->dev, "Failed to set remote access\n");
++        return status;
++    }
++
++    if (snd_card_register(aaudio->card)) {
++        dev_err(&dev->dev, "aaudio: Failed to register ALSA sound device\n");
++        goto fail_snd;
++    }
++
++    list_for_each_entry(sdev, &aaudio->subdevice_list, list) {
++        struct aaudio_buffer_struct_device *dev = &aaudio->bs->devices[sdev->buf_id];
++
++        if (sdev->out_stream_cnt == 1 && !strcmp(dev->name, "Speaker")) {
++            struct snd_pcm_hardware *hw = sdev->out_streams[0].alsa_hw_desc;
++
++            snprintf(aaudio->card->driver, sizeof(aaudio->card->driver) / sizeof(char), "AppleT2x%d", hw->channels_min);
++        }
++    }
++
++    return 0;
++
++fail_snd:
++    snd_card_free(aaudio->card);
++fail:
++    if (aaudio && aaudio->dev)
++        device_destroy(aaudio_class, aaudio->devt);
++    kfree(aaudio);
++
++    if (!IS_ERR_OR_NULL(aaudio->reg_mem_bs))
++        pci_iounmap(dev, aaudio->reg_mem_bs);
++    if (!IS_ERR_OR_NULL(aaudio->reg_mem_cfg))
++        pci_iounmap(dev, aaudio->reg_mem_cfg);
++
++    pci_release_regions(dev);
++    pci_disable_device(dev);
++
++    if (!status)
++        status = -EINVAL;
++    return status;
++}
++
++
++
++static void aaudio_remove(struct pci_dev *dev)
++{
++    struct aaudio_subdevice *sdev;
++    struct aaudio_device *aaudio = pci_get_drvdata(dev);
++
++    snd_card_free(aaudio->card);
++    while (!list_empty(&aaudio->subdevice_list)) {
++        sdev = list_first_entry(&aaudio->subdevice_list, struct aaudio_subdevice, list);
++        list_del(&sdev->list);
++        aaudio_free_dev(sdev);
++    }
++    pci_iounmap(dev, aaudio->reg_mem_bs);
++    pci_iounmap(dev, aaudio->reg_mem_cfg);
++    device_destroy(aaudio_class, aaudio->devt);
++    pci_free_irq_vectors(dev);
++    pci_release_regions(dev);
++    pci_disable_device(dev);
++    kfree(aaudio);
++}
++
++static int aaudio_suspend(struct device *dev)
++{
++    struct aaudio_device *aaudio = pci_get_drvdata(to_pci_dev(dev));
++
++    if (aaudio_cmd_set_remote_access(aaudio, AAUDIO_REMOTE_ACCESS_OFF))
++        dev_warn(aaudio->dev, "Failed to reset remote access\n");
++
++    pci_disable_device(aaudio->pci);
++    return 0;
++}
++
++static int aaudio_resume(struct device *dev)
++{
++    int status;
++    struct aaudio_device *aaudio = pci_get_drvdata(to_pci_dev(dev));
++
++    if ((status = pci_enable_device(aaudio->pci)))
++        return status;
++    pci_set_master(aaudio->pci);
++
++    if ((status = aaudio_cmd_set_remote_access(aaudio, AAUDIO_REMOTE_ACCESS_ON))) {
++        dev_err(aaudio->dev, "Failed to set remote access\n");
++        return status;
++    }
++
++    return 0;
++}
++
++static int aaudio_init_cmd(struct aaudio_device *a)
++{
++    int status;
++    struct aaudio_send_ctx sctx;
++    struct aaudio_msg buf;
++    u64 dev_cnt, dev_i;
++    aaudio_device_id_t *dev_l;
++
++    if ((status = aaudio_send(a, &sctx, 500,
++                              aaudio_msg_write_alive_notification, 1, 3))) {
++        dev_err(a->dev, "Sending alive notification failed\n");
++        return status;
++    }
++
++    if (wait_for_completion_timeout(&a->remote_alive, msecs_to_jiffies(500)) == 0) {
++        dev_err(a->dev, "Timed out waiting for remote\n");
++        return -ETIMEDOUT;
++    }
++    dev_info(a->dev, "Continuing init\n");
++
++    buf = aaudio_reply_alloc();
++    if ((status = aaudio_cmd_get_device_list(a, &buf, &dev_l, &dev_cnt))) {
++        dev_err(a->dev, "Failed to get device list\n");
++        aaudio_reply_free(&buf);
++        return status;
++    }
++    for (dev_i = 0; dev_i < dev_cnt; ++dev_i)
++        aaudio_init_dev(a, dev_l[dev_i]);
++    aaudio_reply_free(&buf);
++
++    return 0;
++}
++
++static void aaudio_init_stream_info(struct aaudio_subdevice *sdev, struct aaudio_stream *strm);
++static void aaudio_handle_jack_connection_change(struct aaudio_subdevice *sdev);
++
++static void aaudio_init_dev(struct aaudio_device *a, aaudio_device_id_t dev_id)
++{
++    struct aaudio_subdevice *sdev;
++    struct aaudio_msg buf = aaudio_reply_alloc();
++    u64 uid_len, stream_cnt, i;
++    aaudio_object_id_t *stream_list;
++    char *uid;
++
++    sdev = kzalloc(sizeof(struct aaudio_subdevice), GFP_KERNEL);
++
++    if (aaudio_cmd_get_property(a, &buf, dev_id, dev_id, AAUDIO_PROP(AAUDIO_PROP_SCOPE_GLOBAL, AAUDIO_PROP_UID, 0),
++            NULL, 0, (void **) &uid, &uid_len) || uid_len > AAUDIO_DEVICE_MAX_UID_LEN) {
++        dev_err(a->dev, "Failed to get device uid for device %llx\n", dev_id);
++        goto fail;
++    }
++    dev_info(a->dev, "Remote device %llx %.*s\n", dev_id, (int) uid_len, uid);
++
++    sdev->a = a;
++    INIT_LIST_HEAD(&sdev->list);
++    sdev->dev_id = dev_id;
++    sdev->buf_id = AAUDIO_BUFFER_ID_NONE;
++    strncpy(sdev->uid, uid, uid_len);
++    sdev->uid[uid_len + 1] = '\0';
++
++    if (aaudio_cmd_get_primitive_property(a, dev_id, dev_id,
++            AAUDIO_PROP(AAUDIO_PROP_SCOPE_INPUT, AAUDIO_PROP_LATENCY, 0), NULL, 0, &sdev->in_latency, sizeof(u32)))
++        dev_warn(a->dev, "Failed to query device input latency\n");
++    if (aaudio_cmd_get_primitive_property(a, dev_id, dev_id,
++            AAUDIO_PROP(AAUDIO_PROP_SCOPE_OUTPUT, AAUDIO_PROP_LATENCY, 0), NULL, 0, &sdev->out_latency, sizeof(u32)))
++        dev_warn(a->dev, "Failed to query device output latency\n");
++
++    if (aaudio_cmd_get_input_stream_list(a, &buf, dev_id, &stream_list, &stream_cnt)) {
++        dev_err(a->dev, "Failed to get input stream list for device %llx\n", dev_id);
++        goto fail;
++    }
++    if (stream_cnt > AAUDIO_DEIVCE_MAX_INPUT_STREAMS) {
++        dev_warn(a->dev, "Device %s input stream count %llu is larger than the supported count of %u\n",
++                sdev->uid, stream_cnt, AAUDIO_DEIVCE_MAX_INPUT_STREAMS);
++        stream_cnt = AAUDIO_DEIVCE_MAX_INPUT_STREAMS;
++    }
++    sdev->in_stream_cnt = stream_cnt;
++    for (i = 0; i < stream_cnt; i++) {
++        sdev->in_streams[i].id = stream_list[i];
++        sdev->in_streams[i].buffer_cnt = 0;
++        aaudio_init_stream_info(sdev, &sdev->in_streams[i]);
++        sdev->in_streams[i].latency += sdev->in_latency;
++    }
++
++    if (aaudio_cmd_get_output_stream_list(a, &buf, dev_id, &stream_list, &stream_cnt)) {
++        dev_err(a->dev, "Failed to get output stream list for device %llx\n", dev_id);
++        goto fail;
++    }
++    if (stream_cnt > AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS) {
++        dev_warn(a->dev, "Device %s input stream count %llu is larger than the supported count of %u\n",
++                 sdev->uid, stream_cnt, AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS);
++        stream_cnt = AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS;
++    }
++    sdev->out_stream_cnt = stream_cnt;
++    for (i = 0; i < stream_cnt; i++) {
++        sdev->out_streams[i].id = stream_list[i];
++        sdev->out_streams[i].buffer_cnt = 0;
++        aaudio_init_stream_info(sdev, &sdev->out_streams[i]);
++        sdev->out_streams[i].latency += sdev->in_latency;
++    }
++
++    if (sdev->is_pcm)
++        aaudio_create_pcm(sdev);
++    /* Headphone Jack status */
++    if (!strcmp(sdev->uid, "Codec Output")) {
++        if (snd_jack_new(a->card, sdev->uid, SND_JACK_HEADPHONE, &sdev->jack, true, false))
++            dev_warn(a->dev, "Failed to create an attached jack for %s\n", sdev->uid);
++        aaudio_cmd_property_listener(a, sdev->dev_id, sdev->dev_id,
++                AAUDIO_PROP(AAUDIO_PROP_SCOPE_OUTPUT, AAUDIO_PROP_JACK_PLUGGED, 0));
++        aaudio_handle_jack_connection_change(sdev);
++    }
++
++    aaudio_reply_free(&buf);
++
++    list_add_tail(&sdev->list, &a->subdevice_list);
++    return;
++
++fail:
++    aaudio_reply_free(&buf);
++    kfree(sdev);
++}
++
++static void aaudio_init_stream_info(struct aaudio_subdevice *sdev, struct aaudio_stream *strm)
++{
++    if (aaudio_cmd_get_primitive_property(sdev->a, sdev->dev_id, strm->id,
++            AAUDIO_PROP(AAUDIO_PROP_SCOPE_GLOBAL, AAUDIO_PROP_PHYS_FORMAT, 0), NULL, 0,
++            &strm->desc, sizeof(strm->desc)))
++        dev_warn(sdev->a->dev, "Failed to query stream descriptor\n");
++    if (aaudio_cmd_get_primitive_property(sdev->a, sdev->dev_id, strm->id,
++            AAUDIO_PROP(AAUDIO_PROP_SCOPE_GLOBAL, AAUDIO_PROP_LATENCY, 0), NULL, 0, &strm->latency, sizeof(u32)))
++        dev_warn(sdev->a->dev, "Failed to query stream latency\n");
++    if (strm->desc.format_id == AAUDIO_FORMAT_LPCM)
++        sdev->is_pcm = true;
++}
++
++static void aaudio_free_dev(struct aaudio_subdevice *sdev)
++{
++    size_t i;
++    for (i = 0; i < sdev->in_stream_cnt; i++) {
++        if (sdev->in_streams[i].alsa_hw_desc)
++            kfree(sdev->in_streams[i].alsa_hw_desc);
++        if (sdev->in_streams[i].buffers)
++            kfree(sdev->in_streams[i].buffers);
++    }
++    for (i = 0; i < sdev->out_stream_cnt; i++) {
++        if (sdev->out_streams[i].alsa_hw_desc)
++            kfree(sdev->out_streams[i].alsa_hw_desc);
++        if (sdev->out_streams[i].buffers)
++            kfree(sdev->out_streams[i].buffers);
++    }
++    kfree(sdev);
++}
++
++static struct aaudio_subdevice *aaudio_find_dev_by_dev_id(struct aaudio_device *a, aaudio_device_id_t dev_id)
++{
++    struct aaudio_subdevice *sdev;
++    list_for_each_entry(sdev, &a->subdevice_list, list) {
++        if (dev_id == sdev->dev_id)
++            return sdev;
++    }
++    return NULL;
++}
++
++static struct aaudio_subdevice *aaudio_find_dev_by_uid(struct aaudio_device *a, const char *uid)
++{
++    struct aaudio_subdevice *sdev;
++    list_for_each_entry(sdev, &a->subdevice_list, list) {
++        if (!strcmp(uid, sdev->uid))
++            return sdev;
++    }
++    return NULL;
++}
++
++static void aaudio_init_bs_stream(struct aaudio_device *a, struct aaudio_stream *strm,
++        struct aaudio_buffer_struct_stream *bs_strm);
++static void aaudio_init_bs_stream_host(struct aaudio_device *a, struct aaudio_stream *strm,
++        struct aaudio_buffer_struct_stream *bs_strm);
++
++static int aaudio_init_bs(struct aaudio_device *a)
++{
++    int i, j;
++    struct aaudio_buffer_struct_device *dev;
++    struct aaudio_subdevice *sdev;
++    u32 ver, sig, bs_base;
++
++    ver = ioread32(&a->reg_mem_gpr[0]);
++    if (ver < 3) {
++        dev_err(a->dev, "aaudio: Bad GPR version (%u)", ver);
++        return -EINVAL;
++    }
++    sig = ioread32(&a->reg_mem_gpr[1]);
++    if (sig != AAUDIO_SIG) {
++        dev_err(a->dev, "aaudio: Bad GPR sig (%x)", sig);
++        return -EINVAL;
++    }
++    bs_base = ioread32(&a->reg_mem_gpr[2]);
++    a->bs = (struct aaudio_buffer_struct *) ((u8 *) a->reg_mem_bs + bs_base);
++    if (a->bs->signature != AAUDIO_SIG) {
++        dev_err(a->dev, "aaudio: Bad BufferStruct sig (%x)", a->bs->signature);
++        return -EINVAL;
++    }
++    dev_info(a->dev, "aaudio: BufferStruct ver = %i\n", a->bs->version);
++    dev_info(a->dev, "aaudio: Num devices = %i\n", a->bs->num_devices);
++    for (i = 0; i < a->bs->num_devices; i++) {
++        dev = &a->bs->devices[i];
++        dev_info(a->dev, "aaudio: Device %i %s\n", i, dev->name);
++
++        sdev = aaudio_find_dev_by_uid(a, dev->name);
++        if (!sdev) {
++            dev_err(a->dev, "aaudio: Subdevice not found for BufferStruct device %s\n", dev->name);
++            continue;
++        }
++        sdev->buf_id = (u8) i;
++        dev->num_input_streams = 0;
++        for (j = 0; j < dev->num_output_streams; j++) {
++            dev_info(a->dev, "aaudio: Device %i Stream %i: Output; Buffer Count = %i\n", i, j,
++                     dev->output_streams[j].num_buffers);
++            if (j < sdev->out_stream_cnt)
++                aaudio_init_bs_stream(a, &sdev->out_streams[j], &dev->output_streams[j]);
++        }
++    }
++
++    list_for_each_entry(sdev, &a->subdevice_list, list) {
++        if (sdev->buf_id != AAUDIO_BUFFER_ID_NONE)
++            continue;
++        sdev->buf_id = i;
++        dev_info(a->dev, "aaudio: Created device %i %s\n", i, sdev->uid);
++        strcpy(a->bs->devices[i].name, sdev->uid);
++        a->bs->devices[i].num_input_streams = 0;
++        a->bs->devices[i].num_output_streams = 0;
++        a->bs->num_devices = ++i;
++    }
++    list_for_each_entry(sdev, &a->subdevice_list, list) {
++        if (sdev->in_stream_cnt == 1) {
++            dev_info(a->dev, "aaudio: Device %i Host Stream; Input\n", sdev->buf_id);
++            aaudio_init_bs_stream_host(a, &sdev->in_streams[0], &a->bs->devices[sdev->buf_id].input_streams[0]);
++            a->bs->devices[sdev->buf_id].num_input_streams = 1;
++            wmb();
++
++            if (aaudio_cmd_set_input_stream_address_ranges(a, sdev->dev_id)) {
++                dev_err(a->dev, "aaudio: Failed to set input stream address ranges\n");
++            }
++        }
++    }
++
++    return 0;
++}
++
++static void aaudio_init_bs_stream(struct aaudio_device *a, struct aaudio_stream *strm,
++                                  struct aaudio_buffer_struct_stream *bs_strm)
++{
++    size_t i;
++    strm->buffer_cnt = bs_strm->num_buffers;
++    if (bs_strm->num_buffers > AAUDIO_DEIVCE_MAX_BUFFER_COUNT) {
++        dev_warn(a->dev, "BufferStruct buffer count %u exceeds driver limit of %u\n", bs_strm->num_buffers,
++                AAUDIO_DEIVCE_MAX_BUFFER_COUNT);
++        strm->buffer_cnt = AAUDIO_DEIVCE_MAX_BUFFER_COUNT;
++    }
++    if (!strm->buffer_cnt)
++        return;
++    strm->buffers = kmalloc_array(strm->buffer_cnt, sizeof(struct aaudio_dma_buf), GFP_KERNEL);
++    if (!strm->buffers) {
++        dev_err(a->dev, "Buffer list allocation failed\n");
++        return;
++    }
++    for (i = 0; i < strm->buffer_cnt; i++) {
++        strm->buffers[i].dma_addr = a->reg_mem_bs_dma + (dma_addr_t) bs_strm->buffers[i].address;
++        strm->buffers[i].ptr = a->reg_mem_bs + bs_strm->buffers[i].address;
++        strm->buffers[i].size = bs_strm->buffers[i].size;
++    }
++
++    if (strm->buffer_cnt == 1) {
++        strm->alsa_hw_desc = kmalloc(sizeof(struct snd_pcm_hardware), GFP_KERNEL);
++        if (aaudio_create_hw_info(&strm->desc, strm->alsa_hw_desc, strm->buffers[0].size)) {
++            kfree(strm->alsa_hw_desc);
++            strm->alsa_hw_desc = NULL;
++        }
++    }
++}
++
++static void aaudio_init_bs_stream_host(struct aaudio_device *a, struct aaudio_stream *strm,
++        struct aaudio_buffer_struct_stream *bs_strm)
++{
++    size_t size;
++    dma_addr_t dma_addr;
++    void *dma_ptr;
++    size = strm->desc.bytes_per_packet * 16640;
++    dma_ptr = dma_alloc_coherent(&a->pci->dev, size, &dma_addr, GFP_KERNEL);
++    if (!dma_ptr) {
++        dev_err(a->dev, "dma_alloc_coherent failed\n");
++        return;
++    }
++    bs_strm->buffers[0].address = dma_addr;
++    bs_strm->buffers[0].size = size;
++    bs_strm->num_buffers = 1;
++
++    memset(dma_ptr, 0, size);
++
++    strm->buffer_cnt = 1;
++    strm->buffers = kmalloc_array(strm->buffer_cnt, sizeof(struct aaudio_dma_buf), GFP_KERNEL);
++    if (!strm->buffers) {
++        dev_err(a->dev, "Buffer list allocation failed\n");
++        return;
++    }
++    strm->buffers[0].dma_addr = dma_addr;
++    strm->buffers[0].ptr = dma_ptr;
++    strm->buffers[0].size = size;
++
++    strm->alsa_hw_desc = kmalloc(sizeof(struct snd_pcm_hardware), GFP_KERNEL);
++    if (aaudio_create_hw_info(&strm->desc, strm->alsa_hw_desc, strm->buffers[0].size)) {
++        kfree(strm->alsa_hw_desc);
++        strm->alsa_hw_desc = NULL;
++    }
++}
++
++static void aaudio_handle_prop_change(struct aaudio_device *a, struct aaudio_msg *msg);
++
++void aaudio_handle_notification(struct aaudio_device *a, struct aaudio_msg *msg)
++{
++    struct aaudio_send_ctx sctx;
++    struct aaudio_msg_base base;
++    if (aaudio_msg_read_base(msg, &base))
++        return;
++    switch (base.msg) {
++        case AAUDIO_MSG_NOTIFICATION_BOOT:
++            dev_info(a->dev, "Received boot notification from remote\n");
++
++            /* Resend the alive notify */
++            if (aaudio_send(a, &sctx, 500,
++                    aaudio_msg_write_alive_notification, 1, 3)) {
++                pr_err("Sending alive notification failed\n");
++            }
++            break;
++        case AAUDIO_MSG_NOTIFICATION_ALIVE:
++            dev_info(a->dev, "Received alive notification from remote\n");
++            complete_all(&a->remote_alive);
++            break;
++        case AAUDIO_MSG_PROPERTY_CHANGED:
++            aaudio_handle_prop_change(a, msg);
++            break;
++        default:
++            dev_info(a->dev, "Unhandled notification %i", base.msg);
++            break;
++    }
++}
++
++struct aaudio_prop_change_work_struct {
++    struct work_struct ws;
++    struct aaudio_device *a;
++    aaudio_device_id_t dev;
++    aaudio_object_id_t obj;
++    struct aaudio_prop_addr prop;
++};
++
++static void aaudio_handle_jack_connection_change(struct aaudio_subdevice *sdev)
++{
++    u32 plugged;
++    if (!sdev->jack)
++        return;
++    /* NOTE: Apple made the plug status scoped to the input and output streams. This makes no sense for us, so I just
++     * always pick the OUTPUT status. */
++    if (aaudio_cmd_get_primitive_property(sdev->a, sdev->dev_id, sdev->dev_id,
++            AAUDIO_PROP(AAUDIO_PROP_SCOPE_OUTPUT, AAUDIO_PROP_JACK_PLUGGED, 0), NULL, 0, &plugged, sizeof(plugged))) {
++        dev_err(sdev->a->dev, "Failed to get jack enable status\n");
++        return;
++    }
++    dev_dbg(sdev->a->dev, "Jack is now %s\n", plugged ? "plugged" : "unplugged");
++    snd_jack_report(sdev->jack, plugged ? sdev->jack->type : 0);
++}
++
++void aaudio_handle_prop_change_work(struct work_struct *ws)
++{
++    struct aaudio_prop_change_work_struct *work = container_of(ws, struct aaudio_prop_change_work_struct, ws);
++    struct aaudio_subdevice *sdev;
++
++    sdev = aaudio_find_dev_by_dev_id(work->a, work->dev);
++    if (!sdev) {
++        dev_err(work->a->dev, "Property notification change: device not found\n");
++        goto done;
++    }
++    dev_dbg(work->a->dev, "Property changed for device: %s\n", sdev->uid);
++
++    if (work->prop.scope == AAUDIO_PROP_SCOPE_OUTPUT && work->prop.selector == AAUDIO_PROP_JACK_PLUGGED) {
++        aaudio_handle_jack_connection_change(sdev);
++    }
++
++done:
++    kfree(work);
++}
++
++void aaudio_handle_prop_change(struct aaudio_device *a, struct aaudio_msg *msg)
++{
++    /* NOTE: This is a scheduled work because this callback will generally need to query device information and this
++     * is not possible when we are in the reply parsing code's context. */
++    struct aaudio_prop_change_work_struct *work;
++    work = kmalloc(sizeof(struct aaudio_prop_change_work_struct), GFP_KERNEL);
++    work->a = a;
++    INIT_WORK(&work->ws, aaudio_handle_prop_change_work);
++    aaudio_msg_read_property_changed(msg, &work->dev, &work->obj, &work->prop);
++    schedule_work(&work->ws);
++}
++
++#define aaudio_send_cmd_response(a, sctx, msg, fn, ...) \
++    if (aaudio_send_with_tag(a, sctx, ((struct aaudio_msg_header *) msg->data)->tag, 500, fn, ##__VA_ARGS__)) \
++        pr_err("aaudio: Failed to reply to a command\n");
++
++void aaudio_handle_cmd_timestamp(struct aaudio_device *a, struct aaudio_msg *msg)
++{
++    ktime_t time_os = ktime_get_boottime();
++    struct aaudio_send_ctx sctx;
++    struct aaudio_subdevice *sdev;
++    u64 devid, timestamp, update_seed;
++    aaudio_msg_read_update_timestamp(msg, &devid, &timestamp, &update_seed);
++    dev_dbg(a->dev, "Received timestamp update for dev=%llx ts=%llx seed=%llx\n", devid, timestamp, update_seed);
++
++    sdev = aaudio_find_dev_by_dev_id(a, devid);
++    aaudio_handle_timestamp(sdev, time_os, timestamp);
++
++    aaudio_send_cmd_response(a, &sctx, msg,
++            aaudio_msg_write_update_timestamp_response);
++}
++
++void aaudio_handle_command(struct aaudio_device *a, struct aaudio_msg *msg)
++{
++    struct aaudio_msg_base base;
++    if (aaudio_msg_read_base(msg, &base))
++        return;
++    switch (base.msg) {
++        case AAUDIO_MSG_UPDATE_TIMESTAMP:
++            aaudio_handle_cmd_timestamp(a, msg);
++            break;
++        default:
++            dev_info(a->dev, "Unhandled device command %i", base.msg);
++            break;
++    }
++}
++
++static struct pci_device_id aaudio_ids[  ] = {
++        { PCI_DEVICE(PCI_VENDOR_ID_APPLE, 0x1803) },
++        { 0, },
++};
++
++struct dev_pm_ops aaudio_pci_driver_pm = {
++        .suspend = aaudio_suspend,
++        .resume = aaudio_resume
++};
++struct pci_driver aaudio_pci_driver = {
++        .name = "aaudio",
++        .id_table = aaudio_ids,
++        .probe = aaudio_probe,
++        .remove = aaudio_remove,
++        .driver = {
++                .pm = &aaudio_pci_driver_pm
++        }
++};
++
++
++int aaudio_module_init(void)
++{
++    int result;
++    if ((result = alloc_chrdev_region(&aaudio_chrdev, 0, 1, "aaudio")))
++        goto fail_chrdev;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
++    aaudio_class = class_create(THIS_MODULE, "aaudio");
++#else
++    aaudio_class = class_create("aaudio");
++#endif
++    if (IS_ERR(aaudio_class)) {
++        result = PTR_ERR(aaudio_class);
++        goto fail_class;
++    }
++    
++    result = pci_register_driver(&aaudio_pci_driver);
++    if (result)
++        goto fail_drv;
++    return 0;
++
++fail_drv:
++    pci_unregister_driver(&aaudio_pci_driver);
++fail_class:
++    class_destroy(aaudio_class);
++fail_chrdev:
++    unregister_chrdev_region(aaudio_chrdev, 1);
++    if (!result)
++        result = -EINVAL;
++    return result;
++}
++
++void aaudio_module_exit(void)
++{
++    pci_unregister_driver(&aaudio_pci_driver);
++    class_destroy(aaudio_class);
++    unregister_chrdev_region(aaudio_chrdev, 1);
++}
++
++struct aaudio_alsa_pcm_id_mapping aaudio_alsa_id_mappings[] = {
++        {"Speaker", 0},
++        {"Digital Mic", 1},
++        {"Codec Output", 2},
++        {"Codec Input", 3},
++        {"Bridge Loopback", 4},
++        {}
++};
++
++module_param_named(index, aaudio_alsa_index, int, 0444);
++MODULE_PARM_DESC(index, "Index value for Apple Internal Audio soundcard.");
++module_param_named(id, aaudio_alsa_id, charp, 0444);
++MODULE_PARM_DESC(id, "ID string for Apple Internal Audio soundcard.");
+diff --git a/drivers/staging/apple-bce/audio/audio.h b/drivers/staging/apple-bce/audio/audio.h
+new file mode 100644
+index 000000000000..004bc1e22ea4
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/audio.h
+@@ -0,0 +1,125 @@
++#ifndef AAUDIO_H
++#define AAUDIO_H
++
++#include <linux/types.h>
++#include <sound/pcm.h>
++#include "../apple_bce.h"
++#include "protocol_bce.h"
++#include "description.h"
++
++#define AAUDIO_SIG 0x19870423
++
++#define AAUDIO_DEVICE_MAX_UID_LEN 128
++#define AAUDIO_DEIVCE_MAX_INPUT_STREAMS 1
++#define AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS 1
++#define AAUDIO_DEIVCE_MAX_BUFFER_COUNT 1
++
++#define AAUDIO_BUFFER_ID_NONE 0xffu
++
++struct snd_card;
++struct snd_pcm;
++struct snd_pcm_hardware;
++struct snd_jack;
++
++struct __attribute__((packed)) __attribute__((aligned(4))) aaudio_buffer_struct_buffer {
++    size_t address;
++    size_t size;
++    size_t pad[4];
++};
++struct aaudio_buffer_struct_stream {
++    u8 num_buffers;
++    struct aaudio_buffer_struct_buffer buffers[100];
++    char filler[32];
++};
++struct aaudio_buffer_struct_device {
++    char name[128];
++    u8 num_input_streams;
++    u8 num_output_streams;
++    struct aaudio_buffer_struct_stream input_streams[5];
++    struct aaudio_buffer_struct_stream output_streams[5];
++    char filler[128];
++};
++struct aaudio_buffer_struct {
++    u32 version;
++    u32 signature;
++    u32 flags;
++    u8 num_devices;
++    struct aaudio_buffer_struct_device devices[20];
++};
++
++struct aaudio_device;
++struct aaudio_dma_buf {
++    dma_addr_t dma_addr;
++    void *ptr;
++    size_t size;
++};
++struct aaudio_stream {
++    aaudio_object_id_t id;
++    size_t buffer_cnt;
++    struct aaudio_dma_buf *buffers;
++
++    struct aaudio_apple_description desc;
++    struct snd_pcm_hardware *alsa_hw_desc;
++    u32 latency;
++
++    bool waiting_for_first_ts;
++
++    ktime_t remote_timestamp;
++    snd_pcm_sframes_t frame_min;
++    int started;
++};
++struct aaudio_subdevice {
++    struct aaudio_device *a;
++    struct list_head list;
++    aaudio_device_id_t dev_id;
++    u32 in_latency, out_latency;
++    u8 buf_id;
++    int alsa_id;
++    char uid[AAUDIO_DEVICE_MAX_UID_LEN + 1];
++    size_t in_stream_cnt;
++    struct aaudio_stream in_streams[AAUDIO_DEIVCE_MAX_INPUT_STREAMS];
++    size_t out_stream_cnt;
++    struct aaudio_stream out_streams[AAUDIO_DEIVCE_MAX_OUTPUT_STREAMS];
++    bool is_pcm;
++    struct snd_pcm *pcm;
++    struct snd_jack *jack;
++};
++struct aaudio_alsa_pcm_id_mapping {
++    const char *name;
++    int alsa_id;
++};
++
++struct aaudio_device {
++    struct pci_dev *pci;
++    dev_t devt;
++    struct device *dev;
++    void __iomem *reg_mem_bs;
++    dma_addr_t reg_mem_bs_dma;
++    void __iomem *reg_mem_cfg;
++
++    u32 __iomem *reg_mem_gpr;
++
++    struct aaudio_buffer_struct *bs;
++
++    struct apple_bce_device *bce;
++    struct aaudio_bce bcem;
++
++    struct snd_card *card;
++
++    struct list_head subdevice_list;
++    int next_alsa_id;
++
++    struct completion remote_alive;
++};
++
++void aaudio_handle_notification(struct aaudio_device *a, struct aaudio_msg *msg);
++void aaudio_handle_prop_change_work(struct work_struct *ws);
++void aaudio_handle_cmd_timestamp(struct aaudio_device *a, struct aaudio_msg *msg);
++void aaudio_handle_command(struct aaudio_device *a, struct aaudio_msg *msg);
++
++int aaudio_module_init(void);
++void aaudio_module_exit(void);
++
++extern struct aaudio_alsa_pcm_id_mapping aaudio_alsa_id_mappings[];
++
++#endif //AAUDIO_H
+diff --git a/drivers/staging/apple-bce/audio/description.h b/drivers/staging/apple-bce/audio/description.h
+new file mode 100644
+index 000000000000..dfef3ab68f27
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/description.h
+@@ -0,0 +1,42 @@
++#ifndef AAUDIO_DESCRIPTION_H
++#define AAUDIO_DESCRIPTION_H
++
++#include <linux/types.h>
++
++struct aaudio_apple_description {
++    u64 sample_rate_double;
++    u32 format_id;
++    u32 format_flags;
++    u32 bytes_per_packet;
++    u32 frames_per_packet;
++    u32 bytes_per_frame;
++    u32 channels_per_frame;
++    u32 bits_per_channel;
++    u32 reserved;
++};
++
++enum {
++    AAUDIO_FORMAT_LPCM = 0x6c70636d  // 'lpcm'
++};
++
++enum {
++    AAUDIO_FORMAT_FLAG_FLOAT = 1,
++    AAUDIO_FORMAT_FLAG_BIG_ENDIAN = 2,
++    AAUDIO_FORMAT_FLAG_SIGNED = 4,
++    AAUDIO_FORMAT_FLAG_PACKED = 8,
++    AAUDIO_FORMAT_FLAG_ALIGNED_HIGH = 16,
++    AAUDIO_FORMAT_FLAG_NON_INTERLEAVED = 32,
++    AAUDIO_FORMAT_FLAG_NON_MIXABLE = 64
++};
++
++static inline u64 aaudio_double_to_u64(u64 d)
++{
++    u8 sign = (u8) ((d >> 63) & 1);
++    s32 exp = (s32) ((d >> 52) & 0x7ff) - 1023;
++    u64 fr = d & ((1LL << 52) - 1);
++    if (sign || exp < 0)
++        return 0;
++    return (u64) ((1LL << exp) + (fr >> (52 - exp)));
++}
++
++#endif //AAUDIO_DESCRIPTION_H
+diff --git a/drivers/staging/apple-bce/audio/pcm.c b/drivers/staging/apple-bce/audio/pcm.c
+new file mode 100644
+index 000000000000..1026e10a9ac5
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/pcm.c
+@@ -0,0 +1,308 @@
++#include "pcm.h"
++#include "audio.h"
++
++static u64 aaudio_get_alsa_fmtbit(struct aaudio_apple_description *desc)
++{
++    if (desc->format_flags & AAUDIO_FORMAT_FLAG_FLOAT) {
++        if (desc->bits_per_channel == 32) {
++            if (desc->format_flags & AAUDIO_FORMAT_FLAG_BIG_ENDIAN)
++                return SNDRV_PCM_FMTBIT_FLOAT_BE;
++            else
++                return SNDRV_PCM_FMTBIT_FLOAT_LE;
++        } else if (desc->bits_per_channel == 64) {
++            if (desc->format_flags & AAUDIO_FORMAT_FLAG_BIG_ENDIAN)
++                return SNDRV_PCM_FMTBIT_FLOAT64_BE;
++            else
++                return SNDRV_PCM_FMTBIT_FLOAT64_LE;
++        } else {
++            pr_err("aaudio: unsupported bits per channel for float format: %u\n", desc->bits_per_channel);
++            return 0;
++        }
++    }
++#define DEFINE_BPC_OPTION(val, b) \
++    case val: \
++        if (desc->format_flags & AAUDIO_FORMAT_FLAG_BIG_ENDIAN) { \
++            if (desc->format_flags & AAUDIO_FORMAT_FLAG_SIGNED) \
++                return SNDRV_PCM_FMTBIT_S ## b ## BE; \
++            else \
++                return SNDRV_PCM_FMTBIT_U ## b ## BE; \
++        } else { \
++            if (desc->format_flags & AAUDIO_FORMAT_FLAG_SIGNED) \
++                return SNDRV_PCM_FMTBIT_S ## b ## LE; \
++            else \
++                return SNDRV_PCM_FMTBIT_U ## b ## LE; \
++        }
++    if (desc->format_flags & AAUDIO_FORMAT_FLAG_PACKED) {
++        switch (desc->bits_per_channel) {
++            case 8:
++            case 16:
++            case 32:
++                break;
++            DEFINE_BPC_OPTION(24, 24_3)
++            default:
++                pr_err("aaudio: unsupported bits per channel for packed format: %u\n", desc->bits_per_channel);
++                return 0;
++        }
++    }
++    if (desc->format_flags & AAUDIO_FORMAT_FLAG_ALIGNED_HIGH) {
++        switch (desc->bits_per_channel) {
++            DEFINE_BPC_OPTION(24, 32_)
++            default:
++                pr_err("aaudio: unsupported bits per channel for high-aligned format: %u\n", desc->bits_per_channel);
++                return 0;
++        }
++    }
++    switch (desc->bits_per_channel) {
++        case 8:
++            if (desc->format_flags & AAUDIO_FORMAT_FLAG_SIGNED)
++                return SNDRV_PCM_FMTBIT_S8;
++            else
++                return SNDRV_PCM_FMTBIT_U8;
++        DEFINE_BPC_OPTION(16, 16_)
++        DEFINE_BPC_OPTION(24, 24_)
++        DEFINE_BPC_OPTION(32, 32_)
++        default:
++            pr_err("aaudio: unsupported bits per channel: %u\n", desc->bits_per_channel);
++            return 0;
++    }
++}
++int aaudio_create_hw_info(struct aaudio_apple_description *desc, struct snd_pcm_hardware *alsa_hw,
++        size_t buf_size)
++{
++    uint rate;
++    alsa_hw->info = (SNDRV_PCM_INFO_MMAP |
++                     SNDRV_PCM_INFO_BLOCK_TRANSFER |
++                     SNDRV_PCM_INFO_MMAP_VALID |
++                     SNDRV_PCM_INFO_DOUBLE);
++    if (desc->format_flags & AAUDIO_FORMAT_FLAG_NON_MIXABLE)
++        pr_warn("aaudio: unsupported hw flag: NON_MIXABLE\n");
++    if (!(desc->format_flags & AAUDIO_FORMAT_FLAG_NON_INTERLEAVED))
++        alsa_hw->info |= SNDRV_PCM_INFO_INTERLEAVED;
++    alsa_hw->formats = aaudio_get_alsa_fmtbit(desc);
++    if (!alsa_hw->formats)
++        return -EINVAL;
++    rate = (uint) aaudio_double_to_u64(desc->sample_rate_double);
++    alsa_hw->rates = snd_pcm_rate_to_rate_bit(rate);
++    alsa_hw->rate_min = rate;
++    alsa_hw->rate_max = rate;
++    alsa_hw->channels_min = desc->channels_per_frame;
++    alsa_hw->channels_max = desc->channels_per_frame;
++    alsa_hw->buffer_bytes_max = buf_size;
++    alsa_hw->period_bytes_min = desc->bytes_per_packet;
++    alsa_hw->period_bytes_max = desc->bytes_per_packet;
++    alsa_hw->periods_min = (uint) (buf_size / desc->bytes_per_packet);
++    alsa_hw->periods_max = (uint) (buf_size / desc->bytes_per_packet);
++    pr_debug("aaudio_create_hw_info: format = %llu, rate = %u/%u. channels = %u, periods = %u, period size = %lu\n",
++            alsa_hw->formats, alsa_hw->rate_min, alsa_hw->rates, alsa_hw->channels_min, alsa_hw->periods_min,
++            alsa_hw->period_bytes_min);
++    return 0;
++}
++
++static struct aaudio_stream *aaudio_pcm_stream(struct snd_pcm_substream *substream)
++{
++    struct aaudio_subdevice *sdev = snd_pcm_substream_chip(substream);
++    if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
++        return &sdev->out_streams[substream->number];
++    else
++        return &sdev->in_streams[substream->number];
++}
++
++static int aaudio_pcm_open(struct snd_pcm_substream *substream)
++{
++    pr_debug("aaudio_pcm_open\n");
++    substream->runtime->hw = *aaudio_pcm_stream(substream)->alsa_hw_desc;
++
++    return 0;
++}
++
++static int aaudio_pcm_close(struct snd_pcm_substream *substream)
++{
++    pr_debug("aaudio_pcm_close\n");
++    return 0;
++}
++
++static int aaudio_pcm_prepare(struct snd_pcm_substream *substream)
++{
++    return 0;
++}
++
++static int aaudio_pcm_hw_params(struct snd_pcm_substream *substream, struct snd_pcm_hw_params *hw_params)
++{
++    struct aaudio_stream *astream = aaudio_pcm_stream(substream);
++    pr_debug("aaudio_pcm_hw_params\n");
++
++    if (!astream->buffer_cnt || !astream->buffers)
++        return -EINVAL;
++
++    substream->runtime->dma_area = astream->buffers[0].ptr;
++    substream->runtime->dma_addr = astream->buffers[0].dma_addr;
++    substream->runtime->dma_bytes = astream->buffers[0].size;
++    return 0;
++}
++
++static int aaudio_pcm_hw_free(struct snd_pcm_substream *substream)
++{
++    pr_debug("aaudio_pcm_hw_free\n");
++    return 0;
++}
++
++static void aaudio_pcm_start(struct snd_pcm_substream *substream)
++{
++    struct aaudio_subdevice *sdev = snd_pcm_substream_chip(substream);
++    struct aaudio_stream *stream = aaudio_pcm_stream(substream);
++    void *buf;
++    size_t s;
++    ktime_t time_start, time_end;
++    bool back_buffer;
++    time_start = ktime_get();
++
++    back_buffer = (substream->stream == SNDRV_PCM_STREAM_PLAYBACK);
++
++    if (back_buffer) {
++        s = frames_to_bytes(substream->runtime, substream->runtime->control->appl_ptr);
++        buf = kmalloc(s, GFP_KERNEL);
++        memcpy_fromio(buf, substream->runtime->dma_area, s);
++        time_end = ktime_get();
++        pr_debug("aaudio: Backed up the buffer in %lluns [%li]\n", ktime_to_ns(time_end - time_start),
++                substream->runtime->control->appl_ptr);
++    }
++
++    stream->waiting_for_first_ts = true;
++    stream->frame_min = stream->latency;
++
++    aaudio_cmd_start_io(sdev->a, sdev->dev_id);
++    if (back_buffer)
++        memcpy_toio(substream->runtime->dma_area, buf, s);
++
++    time_end = ktime_get();
++    pr_debug("aaudio: Started the audio device in %lluns\n", ktime_to_ns(time_end - time_start));
++}
++
++static int aaudio_pcm_trigger(struct snd_pcm_substream *substream, int cmd)
++{
++    struct aaudio_subdevice *sdev = snd_pcm_substream_chip(substream);
++    struct aaudio_stream *stream = aaudio_pcm_stream(substream);
++    pr_debug("aaudio_pcm_trigger %x\n", cmd);
++
++    /* We only supports triggers on the #0 buffer */
++    if (substream->number != 0)
++        return 0;
++    switch (cmd) {
++        case SNDRV_PCM_TRIGGER_START:
++            aaudio_pcm_start(substream);
++            stream->started = 1;
++            break;
++        case SNDRV_PCM_TRIGGER_STOP:
++            aaudio_cmd_stop_io(sdev->a, sdev->dev_id);
++            stream->started = 0;
++            break;
++        default:
++            return -EINVAL;
++    }
++    return 0;
++}
++
++static snd_pcm_uframes_t aaudio_pcm_pointer(struct snd_pcm_substream *substream)
++{
++    struct aaudio_stream *stream = aaudio_pcm_stream(substream);
++    ktime_t time_from_start;
++    snd_pcm_sframes_t frames;
++    snd_pcm_sframes_t buffer_time_length;
++
++    if (!stream->started || stream->waiting_for_first_ts) {
++        pr_warn("aaudio_pcm_pointer while not started\n");
++        return 0;
++    }
++
++    /* Approximate the pointer based on the last received timestamp */
++    time_from_start = ktime_get_boottime() - stream->remote_timestamp;
++    buffer_time_length = NSEC_PER_SEC * substream->runtime->buffer_size / substream->runtime->rate;
++    frames = (ktime_to_ns(time_from_start) % buffer_time_length) * substream->runtime->buffer_size / buffer_time_length;
++    if (ktime_to_ns(time_from_start) < buffer_time_length) {
++        if (frames < stream->frame_min)
++            frames = stream->frame_min;
++        else
++            stream->frame_min = 0;
++    } else {
++        if (ktime_to_ns(time_from_start) < 2 * buffer_time_length)
++            stream->frame_min = frames;
++        else
++            stream->frame_min = 0; /* Heavy desync */
++    }
++    frames -= stream->latency;
++    if (frames < 0)
++        frames += ((-frames - 1) / substream->runtime->buffer_size + 1) * substream->runtime->buffer_size;
++    return (snd_pcm_uframes_t) frames;
++}
++
++static struct snd_pcm_ops aaudio_pcm_ops = {
++        .open =        aaudio_pcm_open,
++        .close =       aaudio_pcm_close,
++        .ioctl =       snd_pcm_lib_ioctl,
++        .hw_params =   aaudio_pcm_hw_params,
++        .hw_free =     aaudio_pcm_hw_free,
++        .prepare =     aaudio_pcm_prepare,
++        .trigger =     aaudio_pcm_trigger,
++        .pointer =     aaudio_pcm_pointer,
++        .mmap    =     snd_pcm_lib_mmap_iomem
++};
++
++int aaudio_create_pcm(struct aaudio_subdevice *sdev)
++{
++    struct snd_pcm *pcm;
++    struct aaudio_alsa_pcm_id_mapping *id_mapping;
++    int err;
++
++    if (!sdev->is_pcm || (sdev->in_stream_cnt == 0 && sdev->out_stream_cnt == 0)) {
++        return -EINVAL;
++    }
++
++    for (id_mapping = aaudio_alsa_id_mappings; id_mapping->name; id_mapping++) {
++        if (!strcmp(sdev->uid, id_mapping->name)) {
++            sdev->alsa_id = id_mapping->alsa_id;
++            break;
++        }
++    }
++    if (!id_mapping->name)
++        sdev->alsa_id = sdev->a->next_alsa_id++;
++    err = snd_pcm_new(sdev->a->card, sdev->uid, sdev->alsa_id,
++            (int) sdev->out_stream_cnt, (int) sdev->in_stream_cnt, &pcm);
++    if (err < 0)
++        return err;
++    pcm->private_data = sdev;
++    pcm->nonatomic = 1;
++    sdev->pcm = pcm;
++    strcpy(pcm->name, sdev->uid);
++    snd_pcm_set_ops(pcm, SNDRV_PCM_STREAM_PLAYBACK, &aaudio_pcm_ops);
++    snd_pcm_set_ops(pcm, SNDRV_PCM_STREAM_CAPTURE, &aaudio_pcm_ops);
++    return 0;
++}
++
++static void aaudio_handle_stream_timestamp(struct snd_pcm_substream *substream, ktime_t timestamp)
++{
++    unsigned long flags;
++    struct aaudio_stream *stream;
++
++    stream = aaudio_pcm_stream(substream);
++    snd_pcm_stream_lock_irqsave(substream, flags);
++    stream->remote_timestamp = timestamp;
++    if (stream->waiting_for_first_ts) {
++        stream->waiting_for_first_ts = false;
++        snd_pcm_stream_unlock_irqrestore(substream, flags);
++        return;
++    }
++    snd_pcm_stream_unlock_irqrestore(substream, flags);
++    snd_pcm_period_elapsed(substream);
++}
++
++void aaudio_handle_timestamp(struct aaudio_subdevice *sdev, ktime_t os_timestamp, u64 dev_timestamp)
++{
++    struct snd_pcm_substream *substream;
++
++    substream = sdev->pcm->streams[SNDRV_PCM_STREAM_PLAYBACK].substream;
++    if (substream)
++        aaudio_handle_stream_timestamp(substream, dev_timestamp);
++    substream = sdev->pcm->streams[SNDRV_PCM_STREAM_CAPTURE].substream;
++    if (substream)
++        aaudio_handle_stream_timestamp(substream, os_timestamp);
++}
+diff --git a/drivers/staging/apple-bce/audio/pcm.h b/drivers/staging/apple-bce/audio/pcm.h
+new file mode 100644
+index 000000000000..ea5f35fbe408
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/pcm.h
+@@ -0,0 +1,16 @@
++#ifndef AAUDIO_PCM_H
++#define AAUDIO_PCM_H
++
++#include <linux/types.h>
++#include <linux/ktime.h>
++
++struct aaudio_subdevice;
++struct aaudio_apple_description;
++struct snd_pcm_hardware;
++
++int aaudio_create_hw_info(struct aaudio_apple_description *desc, struct snd_pcm_hardware *alsa_hw, size_t buf_size);
++int aaudio_create_pcm(struct aaudio_subdevice *sdev);
++
++void aaudio_handle_timestamp(struct aaudio_subdevice *sdev, ktime_t os_timestamp, u64 dev_timestamp);
++
++#endif //AAUDIO_PCM_H
+diff --git a/drivers/staging/apple-bce/audio/protocol.c b/drivers/staging/apple-bce/audio/protocol.c
+new file mode 100644
+index 000000000000..2314813aeead
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/protocol.c
+@@ -0,0 +1,347 @@
++#include "protocol.h"
++#include "protocol_bce.h"
++#include "audio.h"
++
++int aaudio_msg_read_base(struct aaudio_msg *msg, struct aaudio_msg_base *base)
++{
++    if (msg->size < sizeof(struct aaudio_msg_header) + sizeof(struct aaudio_msg_base) * 2)
++        return -EINVAL;
++    *base = *((struct aaudio_msg_base *) ((struct aaudio_msg_header *) msg->data + 1));
++    return 0;
++}
++
++#define READ_START(type) \
++    size_t offset = sizeof(struct aaudio_msg_header) + sizeof(struct aaudio_msg_base); (void)offset; \
++    if (((struct aaudio_msg_base *) ((struct aaudio_msg_header *) msg->data + 1))->msg != type) \
++        return -EINVAL;
++#define READ_DEVID_VAR(devid) *devid = ((struct aaudio_msg_header *) msg->data)->device_id
++#define READ_VAL(type) ({ offset += sizeof(type); *((type *) ((u8 *) msg->data + offset - sizeof(type))); })
++#define READ_VAR(type, var) *var = READ_VAL(type)
++
++int aaudio_msg_read_start_io_response(struct aaudio_msg *msg)
++{
++    READ_START(AAUDIO_MSG_START_IO_RESPONSE);
++    return 0;
++}
++
++int aaudio_msg_read_stop_io_response(struct aaudio_msg *msg)
++{
++    READ_START(AAUDIO_MSG_STOP_IO_RESPONSE);
++    return 0;
++}
++
++int aaudio_msg_read_update_timestamp(struct aaudio_msg *msg, aaudio_device_id_t *devid,
++        u64 *timestamp, u64 *update_seed)
++{
++    READ_START(AAUDIO_MSG_UPDATE_TIMESTAMP);
++    READ_DEVID_VAR(devid);
++    READ_VAR(u64, timestamp);
++    READ_VAR(u64, update_seed);
++    return 0;
++}
++
++int aaudio_msg_read_get_property_response(struct aaudio_msg *msg, aaudio_object_id_t *obj,
++        struct aaudio_prop_addr *prop, void **data, u64 *data_size)
++{
++    READ_START(AAUDIO_MSG_GET_PROPERTY_RESPONSE);
++    READ_VAR(aaudio_object_id_t, obj);
++    READ_VAR(u32, &prop->element);
++    READ_VAR(u32, &prop->scope);
++    READ_VAR(u32, &prop->selector);
++    READ_VAR(u64, data_size);
++    *data = ((u8 *) msg->data + offset);
++    /* offset += data_size; */
++    return 0;
++}
++
++int aaudio_msg_read_set_property_response(struct aaudio_msg *msg, aaudio_object_id_t *obj)
++{
++    READ_START(AAUDIO_MSG_SET_PROPERTY_RESPONSE);
++    READ_VAR(aaudio_object_id_t, obj);
++    return 0;
++}
++
++int aaudio_msg_read_property_listener_response(struct aaudio_msg *msg, aaudio_object_id_t *obj,
++        struct aaudio_prop_addr *prop)
++{
++    READ_START(AAUDIO_MSG_PROPERTY_LISTENER_RESPONSE);
++    READ_VAR(aaudio_object_id_t, obj);
++    READ_VAR(u32, &prop->element);
++    READ_VAR(u32, &prop->scope);
++    READ_VAR(u32, &prop->selector);
++    return 0;
++}
++
++int aaudio_msg_read_property_changed(struct aaudio_msg *msg, aaudio_device_id_t *devid, aaudio_object_id_t *obj,
++        struct aaudio_prop_addr *prop)
++{
++    READ_START(AAUDIO_MSG_PROPERTY_CHANGED);
++    READ_DEVID_VAR(devid);
++    READ_VAR(aaudio_object_id_t, obj);
++    READ_VAR(u32, &prop->element);
++    READ_VAR(u32, &prop->scope);
++    READ_VAR(u32, &prop->selector);
++    return 0;
++}
++
++int aaudio_msg_read_set_input_stream_address_ranges_response(struct aaudio_msg *msg)
++{
++    READ_START(AAUDIO_MSG_SET_INPUT_STREAM_ADDRESS_RANGES_RESPONSE);
++    return 0;
++}
++
++int aaudio_msg_read_get_input_stream_list_response(struct aaudio_msg *msg, aaudio_object_id_t **str_l, u64 *str_cnt)
++{
++    READ_START(AAUDIO_MSG_GET_INPUT_STREAM_LIST_RESPONSE);
++    READ_VAR(u64, str_cnt);
++    *str_l = (aaudio_device_id_t *) ((u8 *) msg->data + offset);
++    /* offset += str_cnt * sizeof(aaudio_object_id_t); */
++    return 0;
++}
++
++int aaudio_msg_read_get_output_stream_list_response(struct aaudio_msg *msg, aaudio_object_id_t **str_l, u64 *str_cnt)
++{
++    READ_START(AAUDIO_MSG_GET_OUTPUT_STREAM_LIST_RESPONSE);
++    READ_VAR(u64, str_cnt);
++    *str_l = (aaudio_device_id_t *) ((u8 *) msg->data + offset);
++    /* offset += str_cnt * sizeof(aaudio_object_id_t); */
++    return 0;
++}
++
++int aaudio_msg_read_set_remote_access_response(struct aaudio_msg *msg)
++{
++    READ_START(AAUDIO_MSG_SET_REMOTE_ACCESS_RESPONSE);
++    return 0;
++}
++
++int aaudio_msg_read_get_device_list_response(struct aaudio_msg *msg, aaudio_device_id_t **dev_l, u64 *dev_cnt)
++{
++    READ_START(AAUDIO_MSG_GET_DEVICE_LIST_RESPONSE);
++    READ_VAR(u64, dev_cnt);
++    *dev_l = (aaudio_device_id_t *) ((u8 *) msg->data + offset);
++    /* offset += dev_cnt * sizeof(aaudio_device_id_t); */
++    return 0;
++}
++
++#define WRITE_START_OF_TYPE(typev, devid) \
++    size_t offset = sizeof(struct aaudio_msg_header); (void) offset; \
++    ((struct aaudio_msg_header *) msg->data)->type = (typev); \
++    ((struct aaudio_msg_header *) msg->data)->device_id = (devid);
++#define WRITE_START_COMMAND(devid) WRITE_START_OF_TYPE(AAUDIO_MSG_TYPE_COMMAND, devid)
++#define WRITE_START_RESPONSE() WRITE_START_OF_TYPE(AAUDIO_MSG_TYPE_RESPONSE, 0)
++#define WRITE_START_NOTIFICATION() WRITE_START_OF_TYPE(AAUDIO_MSG_TYPE_NOTIFICATION, 0)
++#define WRITE_VAL(type, value) { *((type *) ((u8 *) msg->data + offset)) = value; offset += sizeof(value); }
++#define WRITE_BIN(value, size) { memcpy((u8 *) msg->data + offset, value, size); offset += size; }
++#define WRITE_BASE(type) WRITE_VAL(u32, type) WRITE_VAL(u32, 0)
++#define WRITE_END() { msg->size = offset; }
++
++void aaudio_msg_write_start_io(struct aaudio_msg *msg, aaudio_device_id_t dev)
++{
++    WRITE_START_COMMAND(dev);
++    WRITE_BASE(AAUDIO_MSG_START_IO);
++    WRITE_END();
++}
++
++void aaudio_msg_write_stop_io(struct aaudio_msg *msg, aaudio_device_id_t dev)
++{
++    WRITE_START_COMMAND(dev);
++    WRITE_BASE(AAUDIO_MSG_STOP_IO);
++    WRITE_END();
++}
++
++void aaudio_msg_write_get_property(struct aaudio_msg *msg, aaudio_device_id_t dev, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size)
++{
++    WRITE_START_COMMAND(dev);
++    WRITE_BASE(AAUDIO_MSG_GET_PROPERTY);
++    WRITE_VAL(aaudio_object_id_t, obj);
++    WRITE_VAL(u32, prop.element);
++    WRITE_VAL(u32, prop.scope);
++    WRITE_VAL(u32, prop.selector);
++    WRITE_VAL(u64, qualifier_size);
++    WRITE_BIN(qualifier, qualifier_size);
++    WRITE_END();
++}
++
++void aaudio_msg_write_set_property(struct aaudio_msg *msg, aaudio_device_id_t dev, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *data, u64 data_size, void *qualifier, u64 qualifier_size)
++{
++    WRITE_START_COMMAND(dev);
++    WRITE_BASE(AAUDIO_MSG_SET_PROPERTY);
++    WRITE_VAL(aaudio_object_id_t, obj);
++    WRITE_VAL(u32, prop.element);
++    WRITE_VAL(u32, prop.scope);
++    WRITE_VAL(u32, prop.selector);
++    WRITE_VAL(u64, data_size);
++    WRITE_BIN(data, data_size);
++    WRITE_VAL(u64, qualifier_size);
++    WRITE_BIN(qualifier, qualifier_size);
++    WRITE_END();
++}
++
++void aaudio_msg_write_property_listener(struct aaudio_msg *msg, aaudio_device_id_t dev, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop)
++{
++    WRITE_START_COMMAND(dev);
++    WRITE_BASE(AAUDIO_MSG_PROPERTY_LISTENER);
++    WRITE_VAL(aaudio_object_id_t, obj);
++    WRITE_VAL(u32, prop.element);
++    WRITE_VAL(u32, prop.scope);
++    WRITE_VAL(u32, prop.selector);
++    WRITE_END();
++}
++
++void aaudio_msg_write_set_input_stream_address_ranges(struct aaudio_msg *msg, aaudio_device_id_t devid)
++{
++    WRITE_START_COMMAND(devid);
++    WRITE_BASE(AAUDIO_MSG_SET_INPUT_STREAM_ADDRESS_RANGES);
++    WRITE_END();
++}
++
++void aaudio_msg_write_get_input_stream_list(struct aaudio_msg *msg, aaudio_device_id_t devid)
++{
++    WRITE_START_COMMAND(devid);
++    WRITE_BASE(AAUDIO_MSG_GET_INPUT_STREAM_LIST);
++    WRITE_END();
++}
++
++void aaudio_msg_write_get_output_stream_list(struct aaudio_msg *msg, aaudio_device_id_t devid)
++{
++    WRITE_START_COMMAND(devid);
++    WRITE_BASE(AAUDIO_MSG_GET_OUTPUT_STREAM_LIST);
++    WRITE_END();
++}
++
++void aaudio_msg_write_set_remote_access(struct aaudio_msg *msg, u64 mode)
++{
++    WRITE_START_COMMAND(0);
++    WRITE_BASE(AAUDIO_MSG_SET_REMOTE_ACCESS);
++    WRITE_VAL(u64, mode);
++    WRITE_END();
++}
++
++void aaudio_msg_write_alive_notification(struct aaudio_msg *msg, u32 proto_ver, u32 msg_ver)
++{
++    WRITE_START_NOTIFICATION();
++    WRITE_BASE(AAUDIO_MSG_NOTIFICATION_ALIVE);
++    WRITE_VAL(u32, proto_ver);
++    WRITE_VAL(u32, msg_ver);
++    WRITE_END();
++}
++
++void aaudio_msg_write_update_timestamp_response(struct aaudio_msg *msg)
++{
++    WRITE_START_RESPONSE();
++    WRITE_BASE(AAUDIO_MSG_UPDATE_TIMESTAMP_RESPONSE);
++    WRITE_END();
++}
++
++void aaudio_msg_write_get_device_list(struct aaudio_msg *msg)
++{
++    WRITE_START_COMMAND(0);
++    WRITE_BASE(AAUDIO_MSG_GET_DEVICE_LIST);
++    WRITE_END();
++}
++
++#define CMD_SHARED_VARS_NO_REPLY \
++    int status = 0; \
++    struct aaudio_send_ctx sctx;
++#define CMD_SHARED_VARS \
++    CMD_SHARED_VARS_NO_REPLY \
++    struct aaudio_msg reply = aaudio_reply_alloc(); \
++    struct aaudio_msg *buf = &reply;
++#define CMD_SEND_REQUEST(fn, ...) \
++    if ((status = aaudio_send_cmd_sync(a, &sctx, buf, 500, fn, ##__VA_ARGS__))) \
++        return status;
++#define CMD_DEF_SHARED_AND_SEND(fn, ...) \
++    CMD_SHARED_VARS \
++    CMD_SEND_REQUEST(fn, ##__VA_ARGS__);
++#define CMD_DEF_SHARED_NO_REPLY_AND_SEND(fn, ...) \
++    CMD_SHARED_VARS_NO_REPLY \
++    CMD_SEND_REQUEST(fn, ##__VA_ARGS__);
++#define CMD_HNDL_REPLY_NO_FREE(fn, ...) \
++    status = fn(buf, ##__VA_ARGS__); \
++    return status;
++#define CMD_HNDL_REPLY_AND_FREE(fn, ...) \
++    status = fn(buf, ##__VA_ARGS__); \
++    aaudio_reply_free(&reply); \
++    return status;
++
++int aaudio_cmd_start_io(struct aaudio_device *a, aaudio_device_id_t devid)
++{
++    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_start_io, devid);
++    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_start_io_response);
++}
++int aaudio_cmd_stop_io(struct aaudio_device *a, aaudio_device_id_t devid)
++{
++    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_stop_io, devid);
++    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_stop_io_response);
++}
++int aaudio_cmd_get_property(struct aaudio_device *a, struct aaudio_msg *buf,
++        aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size, void **data, u64 *data_size)
++{
++    CMD_DEF_SHARED_NO_REPLY_AND_SEND(aaudio_msg_write_get_property, devid, obj, prop, qualifier, qualifier_size);
++    CMD_HNDL_REPLY_NO_FREE(aaudio_msg_read_get_property_response, &obj, &prop, data, data_size);
++}
++int aaudio_cmd_get_primitive_property(struct aaudio_device *a,
++        aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size, void *data, u64 data_size)
++{
++    int status;
++    struct aaudio_msg reply = aaudio_reply_alloc();
++    void *r_data;
++    u64 r_data_size;
++    if ((status = aaudio_cmd_get_property(a, &reply, devid, obj, prop, qualifier, qualifier_size,
++            &r_data, &r_data_size)))
++        goto finish;
++    if (r_data_size != data_size) {
++        status = -EINVAL;
++        goto finish;
++    }
++    memcpy(data, r_data, data_size);
++finish:
++    aaudio_reply_free(&reply);
++    return status;
++}
++int aaudio_cmd_set_property(struct aaudio_device *a, aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size, void *data, u64 data_size)
++{
++    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_set_property, devid, obj, prop, data, data_size,
++            qualifier, qualifier_size);
++    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_set_property_response, &obj);
++}
++int aaudio_cmd_property_listener(struct aaudio_device *a, aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop)
++{
++    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_property_listener, devid, obj, prop);
++    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_property_listener_response, &obj, &prop);
++}
++int aaudio_cmd_set_input_stream_address_ranges(struct aaudio_device *a, aaudio_device_id_t devid)
++{
++    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_set_input_stream_address_ranges, devid);
++    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_set_input_stream_address_ranges_response);
++}
++int aaudio_cmd_get_input_stream_list(struct aaudio_device *a, struct aaudio_msg *buf, aaudio_device_id_t devid,
++        aaudio_object_id_t **str_l, u64 *str_cnt)
++{
++    CMD_DEF_SHARED_NO_REPLY_AND_SEND(aaudio_msg_write_get_input_stream_list, devid);
++    CMD_HNDL_REPLY_NO_FREE(aaudio_msg_read_get_input_stream_list_response, str_l, str_cnt);
++}
++int aaudio_cmd_get_output_stream_list(struct aaudio_device *a, struct aaudio_msg *buf, aaudio_device_id_t devid,
++        aaudio_object_id_t **str_l, u64 *str_cnt)
++{
++    CMD_DEF_SHARED_NO_REPLY_AND_SEND(aaudio_msg_write_get_output_stream_list, devid);
++    CMD_HNDL_REPLY_NO_FREE(aaudio_msg_read_get_output_stream_list_response, str_l, str_cnt);
++}
++int aaudio_cmd_set_remote_access(struct aaudio_device *a, u64 mode)
++{
++    CMD_DEF_SHARED_AND_SEND(aaudio_msg_write_set_remote_access, mode);
++    CMD_HNDL_REPLY_AND_FREE(aaudio_msg_read_set_remote_access_response);
++}
++int aaudio_cmd_get_device_list(struct aaudio_device *a, struct aaudio_msg *buf,
++        aaudio_device_id_t **dev_l, u64 *dev_cnt)
++{
++    CMD_DEF_SHARED_NO_REPLY_AND_SEND(aaudio_msg_write_get_device_list);
++    CMD_HNDL_REPLY_NO_FREE(aaudio_msg_read_get_device_list_response, dev_l, dev_cnt);
++}
+\ No newline at end of file
+diff --git a/drivers/staging/apple-bce/audio/protocol.h b/drivers/staging/apple-bce/audio/protocol.h
+new file mode 100644
+index 000000000000..3427486f3f57
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/protocol.h
+@@ -0,0 +1,147 @@
++#ifndef AAUDIO_PROTOCOL_H
++#define AAUDIO_PROTOCOL_H
++
++#include <linux/types.h>
++
++struct aaudio_device;
++
++typedef u64 aaudio_device_id_t;
++typedef u64 aaudio_object_id_t;
++
++struct aaudio_msg {
++    void *data;
++    size_t size;
++};
++
++struct __attribute__((packed)) aaudio_msg_header {
++    char tag[4];
++    u8 type;
++    aaudio_device_id_t device_id; // Idk, use zero for commands?
++};
++struct __attribute__((packed)) aaudio_msg_base {
++    u32 msg;
++    u32 status;
++};
++
++struct aaudio_prop_addr {
++    u32 scope;
++    u32 selector;
++    u32 element;
++};
++#define AAUDIO_PROP(scope, sel, el) (struct aaudio_prop_addr) { scope, sel, el }
++
++enum {
++    AAUDIO_MSG_TYPE_COMMAND = 1,
++    AAUDIO_MSG_TYPE_RESPONSE = 2,
++    AAUDIO_MSG_TYPE_NOTIFICATION = 3
++};
++
++enum {
++    AAUDIO_MSG_START_IO = 0,
++    AAUDIO_MSG_START_IO_RESPONSE = 1,
++    AAUDIO_MSG_STOP_IO = 2,
++    AAUDIO_MSG_STOP_IO_RESPONSE = 3,
++    AAUDIO_MSG_UPDATE_TIMESTAMP = 4,
++    AAUDIO_MSG_GET_PROPERTY = 7,
++    AAUDIO_MSG_GET_PROPERTY_RESPONSE = 8,
++    AAUDIO_MSG_SET_PROPERTY = 9,
++    AAUDIO_MSG_SET_PROPERTY_RESPONSE = 10,
++    AAUDIO_MSG_PROPERTY_LISTENER = 11,
++    AAUDIO_MSG_PROPERTY_LISTENER_RESPONSE = 12,
++    AAUDIO_MSG_PROPERTY_CHANGED = 13,
++    AAUDIO_MSG_SET_INPUT_STREAM_ADDRESS_RANGES = 18,
++    AAUDIO_MSG_SET_INPUT_STREAM_ADDRESS_RANGES_RESPONSE = 19,
++    AAUDIO_MSG_GET_INPUT_STREAM_LIST = 24,
++    AAUDIO_MSG_GET_INPUT_STREAM_LIST_RESPONSE = 25,
++    AAUDIO_MSG_GET_OUTPUT_STREAM_LIST = 26,
++    AAUDIO_MSG_GET_OUTPUT_STREAM_LIST_RESPONSE = 27,
++    AAUDIO_MSG_SET_REMOTE_ACCESS = 32,
++    AAUDIO_MSG_SET_REMOTE_ACCESS_RESPONSE = 33,
++    AAUDIO_MSG_UPDATE_TIMESTAMP_RESPONSE = 34,
++
++    AAUDIO_MSG_NOTIFICATION_ALIVE = 100,
++    AAUDIO_MSG_GET_DEVICE_LIST = 101,
++    AAUDIO_MSG_GET_DEVICE_LIST_RESPONSE = 102,
++    AAUDIO_MSG_NOTIFICATION_BOOT = 104
++};
++
++enum {
++    AAUDIO_REMOTE_ACCESS_OFF = 0,
++    AAUDIO_REMOTE_ACCESS_ON = 2
++};
++
++enum {
++    AAUDIO_PROP_SCOPE_GLOBAL = 0x676c6f62, // 'glob'
++    AAUDIO_PROP_SCOPE_INPUT  = 0x696e7074, // 'inpt'
++    AAUDIO_PROP_SCOPE_OUTPUT = 0x6f757470  // 'outp'
++};
++
++enum {
++    AAUDIO_PROP_UID          = 0x75696420, // 'uid '
++    AAUDIO_PROP_BOOL_VALUE   = 0x6263766c, // 'bcvl'
++    AAUDIO_PROP_JACK_PLUGGED = 0x6a61636b, // 'jack'
++    AAUDIO_PROP_SEL_VOLUME   = 0x64656176, // 'deav'
++    AAUDIO_PROP_LATENCY      = 0x6c746e63, // 'ltnc'
++    AAUDIO_PROP_PHYS_FORMAT  = 0x70667420  // 'pft '
++};
++
++int aaudio_msg_read_base(struct aaudio_msg *msg, struct aaudio_msg_base *base);
++
++int aaudio_msg_read_start_io_response(struct aaudio_msg *msg);
++int aaudio_msg_read_stop_io_response(struct aaudio_msg *msg);
++int aaudio_msg_read_update_timestamp(struct aaudio_msg *msg, aaudio_device_id_t *devid,
++        u64 *timestamp, u64 *update_seed);
++int aaudio_msg_read_get_property_response(struct aaudio_msg *msg, aaudio_object_id_t *obj,
++        struct aaudio_prop_addr *prop, void **data, u64 *data_size);
++int aaudio_msg_read_set_property_response(struct aaudio_msg *msg, aaudio_object_id_t *obj);
++int aaudio_msg_read_property_listener_response(struct aaudio_msg *msg,aaudio_object_id_t *obj,
++        struct aaudio_prop_addr *prop);
++int aaudio_msg_read_property_changed(struct aaudio_msg *msg, aaudio_device_id_t *devid, aaudio_object_id_t *obj,
++        struct aaudio_prop_addr *prop);
++int aaudio_msg_read_set_input_stream_address_ranges_response(struct aaudio_msg *msg);
++int aaudio_msg_read_get_input_stream_list_response(struct aaudio_msg *msg, aaudio_object_id_t **str_l, u64 *str_cnt);
++int aaudio_msg_read_get_output_stream_list_response(struct aaudio_msg *msg, aaudio_object_id_t **str_l, u64 *str_cnt);
++int aaudio_msg_read_set_remote_access_response(struct aaudio_msg *msg);
++int aaudio_msg_read_get_device_list_response(struct aaudio_msg *msg, aaudio_device_id_t **dev_l, u64 *dev_cnt);
++
++void aaudio_msg_write_start_io(struct aaudio_msg *msg, aaudio_device_id_t dev);
++void aaudio_msg_write_stop_io(struct aaudio_msg *msg, aaudio_device_id_t dev);
++void aaudio_msg_write_get_property(struct aaudio_msg *msg, aaudio_device_id_t dev, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size);
++void aaudio_msg_write_set_property(struct aaudio_msg *msg, aaudio_device_id_t dev, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *data, u64 data_size, void *qualifier, u64 qualifier_size);
++void aaudio_msg_write_property_listener(struct aaudio_msg *msg, aaudio_device_id_t dev, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop);
++void aaudio_msg_write_set_input_stream_address_ranges(struct aaudio_msg *msg, aaudio_device_id_t devid);
++void aaudio_msg_write_get_input_stream_list(struct aaudio_msg *msg, aaudio_device_id_t devid);
++void aaudio_msg_write_get_output_stream_list(struct aaudio_msg *msg, aaudio_device_id_t devid);
++void aaudio_msg_write_set_remote_access(struct aaudio_msg *msg, u64 mode);
++void aaudio_msg_write_alive_notification(struct aaudio_msg *msg, u32 proto_ver, u32 msg_ver);
++void aaudio_msg_write_update_timestamp_response(struct aaudio_msg *msg);
++void aaudio_msg_write_get_device_list(struct aaudio_msg *msg);
++
++
++int aaudio_cmd_start_io(struct aaudio_device *a, aaudio_device_id_t devid);
++int aaudio_cmd_stop_io(struct aaudio_device *a, aaudio_device_id_t devid);
++int aaudio_cmd_get_property(struct aaudio_device *a, struct aaudio_msg *buf,
++        aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size, void **data, u64 *data_size);
++int aaudio_cmd_get_primitive_property(struct aaudio_device *a,
++        aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size, void *data, u64 data_size);
++int aaudio_cmd_set_property(struct aaudio_device *a, aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop, void *qualifier, u64 qualifier_size, void *data, u64 data_size);
++int aaudio_cmd_property_listener(struct aaudio_device *a, aaudio_device_id_t devid, aaudio_object_id_t obj,
++        struct aaudio_prop_addr prop);
++int aaudio_cmd_set_input_stream_address_ranges(struct aaudio_device *a, aaudio_device_id_t devid);
++int aaudio_cmd_get_input_stream_list(struct aaudio_device *a, struct aaudio_msg *buf, aaudio_device_id_t devid,
++        aaudio_object_id_t **str_l, u64 *str_cnt);
++int aaudio_cmd_get_output_stream_list(struct aaudio_device *a, struct aaudio_msg *buf, aaudio_device_id_t devid,
++        aaudio_object_id_t **str_l, u64 *str_cnt);
++int aaudio_cmd_set_remote_access(struct aaudio_device *a, u64 mode);
++int aaudio_cmd_get_device_list(struct aaudio_device *a, struct aaudio_msg *buf,
++        aaudio_device_id_t **dev_l, u64 *dev_cnt);
++
++
++
++#endif //AAUDIO_PROTOCOL_H
+diff --git a/drivers/staging/apple-bce/audio/protocol_bce.c b/drivers/staging/apple-bce/audio/protocol_bce.c
+new file mode 100644
+index 000000000000..28f2dfd44d67
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/protocol_bce.c
+@@ -0,0 +1,226 @@
++#include "protocol_bce.h"
++
++#include "audio.h"
++
++static void aaudio_bce_out_queue_completion(struct bce_queue_sq *sq);
++static void aaudio_bce_in_queue_completion(struct bce_queue_sq *sq);
++static int aaudio_bce_queue_init(struct aaudio_device *dev, struct aaudio_bce_queue *q, const char *name, int direction,
++                                 bce_sq_completion cfn);
++void aaudio_bce_in_queue_submit_pending(struct aaudio_bce_queue *q, size_t count);
++
++int aaudio_bce_init(struct aaudio_device *dev)
++{
++    int status;
++    struct aaudio_bce *bce = &dev->bcem;
++    bce->cq = bce_create_cq(dev->bce, 0x80);
++    spin_lock_init(&bce->spinlock);
++    if (!bce->cq)
++        return -EINVAL;
++    if ((status = aaudio_bce_queue_init(dev, &bce->qout, "com.apple.BridgeAudio.IntelToARM", DMA_TO_DEVICE,
++            aaudio_bce_out_queue_completion))) {
++        return status;
++    }
++    if ((status = aaudio_bce_queue_init(dev, &bce->qin, "com.apple.BridgeAudio.ARMToIntel", DMA_FROM_DEVICE,
++            aaudio_bce_in_queue_completion))) {
++        return status;
++    }
++    aaudio_bce_in_queue_submit_pending(&bce->qin, bce->qin.el_count);
++    return 0;
++}
++
++int aaudio_bce_queue_init(struct aaudio_device *dev, struct aaudio_bce_queue *q, const char *name, int direction,
++        bce_sq_completion cfn)
++{
++    q->cq = dev->bcem.cq;
++    q->el_size = AAUDIO_BCE_QUEUE_ELEMENT_SIZE;
++    q->el_count = AAUDIO_BCE_QUEUE_ELEMENT_COUNT;
++    /* NOTE: The Apple impl uses 0x80 as the queue size, however we use 21 (in fact 20) to simplify the impl */
++    q->sq = bce_create_sq(dev->bce, q->cq, name, (u32) (q->el_count + 1), direction, cfn, dev);
++    if (!q->sq)
++        return -EINVAL;
++
++    q->data = dma_alloc_coherent(&dev->bce->pci->dev, q->el_size * q->el_count, &q->dma_addr, GFP_KERNEL);
++    if (!q->data) {
++        bce_destroy_sq(dev->bce, q->sq);
++        return -EINVAL;
++    }
++    return 0;
++}
++
++static void aaudio_send_create_tag(struct aaudio_bce *b, int *tagn, char tag[4])
++{
++    char tag_zero[5];
++    b->tag_num = (b->tag_num + 1) % AAUDIO_BCE_QUEUE_TAG_COUNT;
++    *tagn = b->tag_num;
++    snprintf(tag_zero, 5, "S%03d", b->tag_num);
++    *((u32 *) tag) = *((u32 *) tag_zero);
++}
++
++int __aaudio_send_prepare(struct aaudio_bce *b, struct aaudio_send_ctx *ctx, char *tag)
++{
++    int status;
++    size_t index;
++    void *dptr;
++    struct aaudio_msg_header *header;
++    if ((status = bce_reserve_submission(b->qout.sq, &ctx->timeout)))
++        return status;
++    spin_lock_irqsave(&b->spinlock, ctx->irq_flags);
++    index = b->qout.data_tail;
++    dptr = (u8 *) b->qout.data + index * b->qout.el_size;
++    ctx->msg.data = dptr;
++    header = dptr;
++    if (tag)
++        *((u32 *) header->tag) = *((u32 *) tag);
++    else
++        aaudio_send_create_tag(b, &ctx->tag_n, header->tag);
++    return 0;
++}
++
++void __aaudio_send(struct aaudio_bce *b, struct aaudio_send_ctx *ctx)
++{
++    struct bce_qe_submission *s = bce_next_submission(b->qout.sq);
++#ifdef DEBUG
++    pr_debug("aaudio: Sending command data\n");
++    print_hex_dump(KERN_DEBUG, "aaudio:OUT ", DUMP_PREFIX_NONE, 32, 1, ctx->msg.data, ctx->msg.size, true);
++#endif
++    bce_set_submission_single(s, b->qout.dma_addr + (dma_addr_t) (ctx->msg.data - b->qout.data), ctx->msg.size);
++    bce_submit_to_device(b->qout.sq);
++    b->qout.data_tail = (b->qout.data_tail + 1) % b->qout.el_count;
++    spin_unlock_irqrestore(&b->spinlock, ctx->irq_flags);
++}
++
++int __aaudio_send_cmd_sync(struct aaudio_bce *b, struct aaudio_send_ctx *ctx, struct aaudio_msg *reply)
++{
++    struct aaudio_bce_queue_entry ent;
++    DECLARE_COMPLETION_ONSTACK(cmpl);
++    ent.msg = reply;
++    ent.cmpl = &cmpl;
++    b->pending_entries[ctx->tag_n] = &ent;
++    __aaudio_send(b, ctx); /* unlocks the spinlock */
++    ctx->timeout = wait_for_completion_timeout(&cmpl, ctx->timeout);
++    if (ctx->timeout == 0) {
++        /* Remove the pending queue entry; this will be normally handled by the completion route but
++         * during a timeout it won't */
++        spin_lock_irqsave(&b->spinlock, ctx->irq_flags);
++        if (b->pending_entries[ctx->tag_n] == &ent)
++            b->pending_entries[ctx->tag_n] = NULL;
++        spin_unlock_irqrestore(&b->spinlock, ctx->irq_flags);
++        return -ETIMEDOUT;
++    }
++    return 0;
++}
++
++static void aaudio_handle_reply(struct aaudio_bce *b, struct aaudio_msg *reply)
++{
++    const char *tag;
++    int tagn;
++    unsigned long irq_flags;
++    char tag_zero[5];
++    struct aaudio_bce_queue_entry *entry;
++
++    tag = ((struct aaudio_msg_header *) reply->data)->tag;
++    if (tag[0] != 'S') {
++        pr_err("aaudio_handle_reply: Unexpected tag: %.4s\n", tag);
++        return;
++    }
++    *((u32 *) tag_zero) = *((u32 *) tag);
++    tag_zero[4] = 0;
++    if (kstrtoint(&tag_zero[1], 10, &tagn)) {
++        pr_err("aaudio_handle_reply: Tag parse failed: %.4s\n", tag);
++        return;
++    }
++
++    spin_lock_irqsave(&b->spinlock, irq_flags);
++    entry = b->pending_entries[tagn];
++    if (entry) {
++        if (reply->size < entry->msg->size)
++            entry->msg->size = reply->size;
++        memcpy(entry->msg->data, reply->data, entry->msg->size);
++        complete(entry->cmpl);
++
++        b->pending_entries[tagn] = NULL;
++    } else {
++        pr_err("aaudio_handle_reply: No queued item found for tag: %.4s\n", tag);
++    }
++    spin_unlock_irqrestore(&b->spinlock, irq_flags);
++}
++
++static void aaudio_bce_out_queue_completion(struct bce_queue_sq *sq)
++{
++    while (bce_next_completion(sq)) {
++        //pr_info("aaudio: Send confirmed\n");
++        bce_notify_submission_complete(sq);
++    }
++}
++
++static void aaudio_bce_in_queue_handle_msg(struct aaudio_device *a, struct aaudio_msg *msg);
++
++static void aaudio_bce_in_queue_completion(struct bce_queue_sq *sq)
++{
++    struct aaudio_msg msg;
++    struct aaudio_device *dev = sq->userdata;
++    struct aaudio_bce_queue *q = &dev->bcem.qin;
++    struct bce_sq_completion_data *c;
++    size_t cnt = 0;
++
++    mb();
++    while ((c = bce_next_completion(sq))) {
++        msg.data = (u8 *) q->data + q->data_head * q->el_size;
++        msg.size = c->data_size;
++#ifdef DEBUG
++        pr_debug("aaudio: Received command data %llx\n", c->data_size);
++        print_hex_dump(KERN_DEBUG, "aaudio:IN ", DUMP_PREFIX_NONE, 32, 1, msg.data, min(msg.size, 128UL), true);
++#endif
++        aaudio_bce_in_queue_handle_msg(dev, &msg);
++
++        q->data_head = (q->data_head + 1) % q->el_count;
++
++        bce_notify_submission_complete(sq);
++        ++cnt;
++    }
++    aaudio_bce_in_queue_submit_pending(q, cnt);
++}
++
++static void aaudio_bce_in_queue_handle_msg(struct aaudio_device *a, struct aaudio_msg *msg)
++{
++    struct aaudio_msg_header *header = (struct aaudio_msg_header *) msg->data;
++    if (msg->size < sizeof(struct aaudio_msg_header)) {
++        pr_err("aaudio: Msg size smaller than header (%lx)", msg->size);
++        return;
++    }
++    if (header->type == AAUDIO_MSG_TYPE_RESPONSE) {
++        aaudio_handle_reply(&a->bcem, msg);
++    } else if (header->type == AAUDIO_MSG_TYPE_COMMAND) {
++        aaudio_handle_command(a, msg);
++    } else if (header->type == AAUDIO_MSG_TYPE_NOTIFICATION) {
++        aaudio_handle_notification(a, msg);
++    }
++}
++
++void aaudio_bce_in_queue_submit_pending(struct aaudio_bce_queue *q, size_t count)
++{
++    struct bce_qe_submission *s;
++    while (count--) {
++        if (bce_reserve_submission(q->sq, NULL)) {
++            pr_err("aaudio: Failed to reserve an event queue submission\n");
++            break;
++        }
++        s = bce_next_submission(q->sq);
++        bce_set_submission_single(s, q->dma_addr + (dma_addr_t) (q->data_tail * q->el_size), q->el_size);
++        q->data_tail = (q->data_tail + 1) % q->el_count;
++    }
++    bce_submit_to_device(q->sq);
++}
++
++struct aaudio_msg aaudio_reply_alloc(void)
++{
++    struct aaudio_msg ret;
++    ret.size = AAUDIO_BCE_QUEUE_ELEMENT_SIZE;
++    ret.data = kmalloc(ret.size, GFP_KERNEL);
++    return ret;
++}
++
++void aaudio_reply_free(struct aaudio_msg *reply)
++{
++    kfree(reply->data);
++}
+diff --git a/drivers/staging/apple-bce/audio/protocol_bce.h b/drivers/staging/apple-bce/audio/protocol_bce.h
+new file mode 100644
+index 000000000000..14d26c05ddf9
+--- /dev/null
++++ b/drivers/staging/apple-bce/audio/protocol_bce.h
+@@ -0,0 +1,72 @@
++#ifndef AAUDIO_PROTOCOL_BCE_H
++#define AAUDIO_PROTOCOL_BCE_H
++
++#include "protocol.h"
++#include "../queue.h"
++
++#define AAUDIO_BCE_QUEUE_ELEMENT_SIZE 0x1000
++#define AAUDIO_BCE_QUEUE_ELEMENT_COUNT 20
++
++#define AAUDIO_BCE_QUEUE_TAG_COUNT 1000
++
++struct aaudio_device;
++
++struct aaudio_bce_queue_entry {
++    struct aaudio_msg *msg;
++    struct completion *cmpl;
++};
++struct aaudio_bce_queue {
++    struct bce_queue_cq *cq;
++    struct bce_queue_sq *sq;
++    void *data;
++    dma_addr_t dma_addr;
++    size_t data_head, data_tail;
++    size_t el_size, el_count;
++};
++struct aaudio_bce {
++    struct bce_queue_cq *cq;
++    struct aaudio_bce_queue qin;
++    struct aaudio_bce_queue qout;
++    int tag_num;
++    struct aaudio_bce_queue_entry *pending_entries[AAUDIO_BCE_QUEUE_TAG_COUNT];
++    struct spinlock spinlock;
++};
++
++struct aaudio_send_ctx {
++    int status;
++    int tag_n;
++    unsigned long irq_flags;
++    struct aaudio_msg msg;
++    unsigned long timeout;
++};
++
++int aaudio_bce_init(struct aaudio_device *dev);
++int __aaudio_send_prepare(struct aaudio_bce *b, struct aaudio_send_ctx *ctx, char *tag);
++void __aaudio_send(struct aaudio_bce *b, struct aaudio_send_ctx *ctx);
++int __aaudio_send_cmd_sync(struct aaudio_bce *b, struct aaudio_send_ctx *ctx, struct aaudio_msg *reply);
++
++#define aaudio_send_with_tag(a, ctx, tag, tout, fn, ...) ({ \
++    (ctx)->timeout = msecs_to_jiffies(tout); \
++    (ctx)->status = __aaudio_send_prepare(&(a)->bcem, (ctx), (tag)); \
++    if (!(ctx)->status) { \
++        fn(&(ctx)->msg, ##__VA_ARGS__); \
++        __aaudio_send(&(a)->bcem, (ctx)); \
++    } \
++    (ctx)->status; \
++})
++#define aaudio_send(a, ctx, tout, fn, ...) aaudio_send_with_tag(a, ctx, NULL, tout, fn, ##__VA_ARGS__)
++
++#define aaudio_send_cmd_sync(a, ctx, reply, tout, fn, ...) ({ \
++    (ctx)->timeout = msecs_to_jiffies(tout); \
++    (ctx)->status = __aaudio_send_prepare(&(a)->bcem, (ctx), NULL); \
++    if (!(ctx)->status) { \
++        fn(&(ctx)->msg, ##__VA_ARGS__); \
++        (ctx)->status = __aaudio_send_cmd_sync(&(a)->bcem, (ctx), (reply)); \
++    } \
++    (ctx)->status; \
++})
++
++struct aaudio_msg aaudio_reply_alloc(void);
++void aaudio_reply_free(struct aaudio_msg *reply);
++
++#endif //AAUDIO_PROTOCOL_BCE_H
+diff --git a/drivers/staging/apple-bce/mailbox.c b/drivers/staging/apple-bce/mailbox.c
+new file mode 100644
+index 000000000000..07ce11928988
+--- /dev/null
++++ b/drivers/staging/apple-bce/mailbox.c
+@@ -0,0 +1,155 @@
++#include "mailbox.h"
++#include <linux/atomic.h>
++#include "apple_bce.h"
++#include <linux/version.h>
++
++#define REG_MBOX_OUT_BASE 0x820
++#define REG_MBOX_REPLY_COUNTER 0x108
++#define REG_MBOX_REPLY_BASE 0x810
++#define REG_TIMESTAMP_BASE 0xC000
++
++#define BCE_MBOX_TIMEOUT_MS 200
++
++void bce_mailbox_init(struct bce_mailbox *mb, void __iomem *reg_mb)
++{
++    mb->reg_mb = reg_mb;
++    init_completion(&mb->mb_completion);
++}
++
++int bce_mailbox_send(struct bce_mailbox *mb, u64 msg, u64* recv)
++{
++    u32 __iomem *regb;
++
++    if (atomic_cmpxchg(&mb->mb_status, 0, 1) != 0) {
++        return -EEXIST; // We don't support two messages at once
++    }
++    reinit_completion(&mb->mb_completion);
++
++    pr_debug("bce_mailbox_send: %llx\n", msg);
++    regb = (u32*) ((u8*) mb->reg_mb + REG_MBOX_OUT_BASE);
++    iowrite32((u32) msg, regb);
++    iowrite32((u32) (msg >> 32), regb + 1);
++    iowrite32(0, regb + 2);
++    iowrite32(0, regb + 3);
++
++    wait_for_completion_timeout(&mb->mb_completion, msecs_to_jiffies(BCE_MBOX_TIMEOUT_MS));
++    if (atomic_read(&mb->mb_status) != 2) { // Didn't get the reply
++        atomic_set(&mb->mb_status, 0);
++        return -ETIMEDOUT;
++    }
++
++    *recv = mb->mb_result;
++    pr_debug("bce_mailbox_send: reply %llx\n", *recv);
++
++    atomic_set(&mb->mb_status, 0);
++    return 0;
++}
++
++static int bce_mailbox_retrive_response(struct bce_mailbox *mb)
++{
++    u32 __iomem *regb;
++    u32 lo, hi;
++    int count, counter;
++    u32 res = ioread32((u8*) mb->reg_mb + REG_MBOX_REPLY_COUNTER);
++    count = (res >> 20) & 0xf;
++    counter = count;
++    pr_debug("bce_mailbox_retrive_response count=%i\n", count);
++    while (counter--) {
++        regb = (u32*) ((u8*) mb->reg_mb + REG_MBOX_REPLY_BASE);
++        lo = ioread32(regb);
++        hi = ioread32(regb + 1);
++        ioread32(regb + 2);
++        ioread32(regb + 3);
++        pr_debug("bce_mailbox_retrive_response %llx\n", ((u64) hi << 32) | lo);
++        mb->mb_result = ((u64) hi << 32) | lo;
++    }
++    return count > 0 ? 0 : -ENODATA;
++}
++
++int bce_mailbox_handle_interrupt(struct bce_mailbox *mb)
++{
++    int status = bce_mailbox_retrive_response(mb);
++    if (!status) {
++        atomic_set(&mb->mb_status, 2);
++        complete(&mb->mb_completion);
++    }
++    return status;
++}
++
++static void bc_send_timestamp(struct timer_list *tl);
++
++void bce_timestamp_init(struct bce_timestamp *ts, void __iomem *reg)
++{
++    u32 __iomem *regb;
++
++    spin_lock_init(&ts->stop_sl);
++    ts->stopped = false;
++
++    ts->reg = reg;
++
++    regb = (u32*) ((u8*) ts->reg + REG_TIMESTAMP_BASE);
++
++    ioread32(regb);
++    mb();
++
++    timer_setup(&ts->timer, bc_send_timestamp, 0);
++}
++
++void bce_timestamp_start(struct bce_timestamp *ts, bool is_initial)
++{
++    unsigned long flags;
++    u32 __iomem *regb = (u32*) ((u8*) ts->reg + REG_TIMESTAMP_BASE);
++
++    if (is_initial) {
++        iowrite32((u32) -4, regb + 2);
++        iowrite32((u32) -1, regb);
++    } else {
++        iowrite32((u32) -3, regb + 2);
++        iowrite32((u32) -1, regb);
++    }
++
++    spin_lock_irqsave(&ts->stop_sl, flags);
++    ts->stopped = false;
++    spin_unlock_irqrestore(&ts->stop_sl, flags);
++    mod_timer(&ts->timer, jiffies + msecs_to_jiffies(150));
++}
++
++void bce_timestamp_stop(struct bce_timestamp *ts)
++{
++    unsigned long flags;
++    u32 __iomem *regb = (u32*) ((u8*) ts->reg + REG_TIMESTAMP_BASE);
++
++    spin_lock_irqsave(&ts->stop_sl, flags);
++    ts->stopped = true;
++    spin_unlock_irqrestore(&ts->stop_sl, flags);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
++    del_timer_sync(&ts->timer);
++#else
++    timer_delete_sync(&ts->timer);
++#endif
++    iowrite32((u32) -2, regb + 2);
++    iowrite32((u32) -1, regb);
++}
++
++static void bc_send_timestamp(struct timer_list *tl)
++{
++    struct bce_timestamp *ts;
++    unsigned long flags;
++    u32 __iomem *regb;
++    ktime_t bt;
++
++    ts = container_of(tl, struct bce_timestamp, timer);
++    regb = (u32*) ((u8*) ts->reg + REG_TIMESTAMP_BASE);
++    local_irq_save(flags);
++    ioread32(regb + 2);
++    mb();
++    bt = ktime_get_boottime();
++    iowrite32((u32) bt, regb + 2);
++    iowrite32((u32) (bt >> 32), regb);
++
++    spin_lock(&ts->stop_sl);
++    if (!ts->stopped)
++        mod_timer(&ts->timer, jiffies + msecs_to_jiffies(150));
++    spin_unlock(&ts->stop_sl);
++    local_irq_restore(flags);
++}
+diff --git a/drivers/staging/apple-bce/mailbox.h b/drivers/staging/apple-bce/mailbox.h
+new file mode 100644
+index 000000000000..f3323f95ba51
+--- /dev/null
++++ b/drivers/staging/apple-bce/mailbox.h
+@@ -0,0 +1,53 @@
++#ifndef BCE_MAILBOX_H
++#define BCE_MAILBOX_H
++
++#include <linux/completion.h>
++#include <linux/pci.h>
++#include <linux/timer.h>
++
++struct bce_mailbox {
++    void __iomem *reg_mb;
++
++    atomic_t mb_status; // possible statuses: 0 (no msg), 1 (has active msg), 2 (got reply)
++    struct completion mb_completion;
++    uint64_t mb_result;
++};
++
++enum bce_message_type {
++    BCE_MB_REGISTER_COMMAND_SQ = 0x7,            // to-device
++    BCE_MB_REGISTER_COMMAND_CQ = 0x8,            // to-device
++    BCE_MB_REGISTER_COMMAND_QUEUE_REPLY = 0xB,   // to-host
++    BCE_MB_SET_FW_PROTOCOL_VERSION = 0xC,        // both
++    BCE_MB_SLEEP_NO_STATE = 0x14,                // to-device
++    BCE_MB_RESTORE_NO_STATE = 0x15,              // to-device
++    BCE_MB_SAVE_STATE_AND_SLEEP = 0x17,          // to-device
++    BCE_MB_RESTORE_STATE_AND_WAKE = 0x18,        // to-device
++    BCE_MB_SAVE_STATE_AND_SLEEP_FAILURE = 0x19,  // from-device
++    BCE_MB_SAVE_RESTORE_STATE_COMPLETE = 0x1A,   // from-device
++};
++
++#define BCE_MB_MSG(type, value) (((u64) (type) << 58) | ((value) & 0x3FFFFFFFFFFFFFFLL))
++#define BCE_MB_TYPE(v) ((u32) (v >> 58))
++#define BCE_MB_VALUE(v) (v & 0x3FFFFFFFFFFFFFFLL)
++
++void bce_mailbox_init(struct bce_mailbox *mb, void __iomem *reg_mb);
++
++int bce_mailbox_send(struct bce_mailbox *mb, u64 msg, u64* recv);
++
++int bce_mailbox_handle_interrupt(struct bce_mailbox *mb);
++
++
++struct bce_timestamp {
++    void __iomem *reg;
++    struct timer_list timer;
++    struct spinlock stop_sl;
++    bool stopped;
++};
++
++void bce_timestamp_init(struct bce_timestamp *ts, void __iomem *reg);
++
++void bce_timestamp_start(struct bce_timestamp *ts, bool is_initial);
++
++void bce_timestamp_stop(struct bce_timestamp *ts);
++
++#endif //BCEDRIVER_MAILBOX_H
+diff --git a/drivers/staging/apple-bce/queue.c b/drivers/staging/apple-bce/queue.c
+new file mode 100644
+index 000000000000..bc9cd3bc6f0c
+--- /dev/null
++++ b/drivers/staging/apple-bce/queue.c
+@@ -0,0 +1,390 @@
++#include "queue.h"
++#include "apple_bce.h"
++
++#define REG_DOORBELL_BASE 0x44000
++
++struct bce_queue_cq *bce_alloc_cq(struct apple_bce_device *dev, int qid, u32 el_count)
++{
++    struct bce_queue_cq *q;
++    q = kzalloc(sizeof(struct bce_queue_cq), GFP_KERNEL);
++    q->qid = qid;
++    q->type = BCE_QUEUE_CQ;
++    q->el_count = el_count;
++    q->data = dma_alloc_coherent(&dev->pci->dev, el_count * sizeof(struct bce_qe_completion),
++            &q->dma_handle, GFP_KERNEL);
++    if (!q->data) {
++        pr_err("DMA queue memory alloc failed\n");
++        kfree(q);
++        return NULL;
++    }
++    return q;
++}
++
++void bce_get_cq_memcfg(struct bce_queue_cq *cq, struct bce_queue_memcfg *cfg)
++{
++    cfg->qid = (u16) cq->qid;
++    cfg->el_count = (u16) cq->el_count;
++    cfg->vector_or_cq = 0;
++    cfg->_pad = 0;
++    cfg->addr = cq->dma_handle;
++    cfg->length = cq->el_count * sizeof(struct bce_qe_completion);
++}
++
++void bce_free_cq(struct apple_bce_device *dev, struct bce_queue_cq *cq)
++{
++    dma_free_coherent(&dev->pci->dev, cq->el_count * sizeof(struct bce_qe_completion), cq->data, cq->dma_handle);
++    kfree(cq);
++}
++
++static void bce_handle_cq_completion(struct apple_bce_device *dev, struct bce_qe_completion *e, size_t *ce)
++{
++    struct bce_queue *target;
++    struct bce_queue_sq *target_sq;
++    struct bce_sq_completion_data *cmpl;
++    if (e->qid >= BCE_MAX_QUEUE_COUNT) {
++        pr_err("Device sent a response for qid (%u) >= BCE_MAX_QUEUE_COUNT\n", e->qid);
++        return;
++    }
++    target = dev->queues[e->qid];
++    if (!target || target->type != BCE_QUEUE_SQ) {
++        pr_err("Device sent a response for qid (%u), which does not exist\n", e->qid);
++        return;
++    }
++    target_sq = (struct bce_queue_sq *) target;
++    if (target_sq->completion_tail != e->completion_index) {
++        pr_err("Completion index mismatch; this is likely going to make this driver unusable\n");
++        return;
++    }
++    if (!target_sq->has_pending_completions) {
++        target_sq->has_pending_completions = true;
++        dev->int_sq_list[(*ce)++] = target_sq;
++    }
++    cmpl = &target_sq->completion_data[e->completion_index];
++    cmpl->status = e->status;
++    cmpl->data_size = e->data_size;
++    cmpl->result = e->result;
++    wmb();
++    target_sq->completion_tail = (target_sq->completion_tail + 1) % target_sq->el_count;
++}
++
++void bce_handle_cq_completions(struct apple_bce_device *dev, struct bce_queue_cq *cq)
++{
++    size_t ce = 0;
++    struct bce_qe_completion *e;
++    struct bce_queue_sq *sq;
++    e = bce_cq_element(cq, cq->index);
++    if (!(e->flags & BCE_COMPLETION_FLAG_PENDING))
++        return;
++    mb();
++    while (true) {
++        e = bce_cq_element(cq, cq->index);
++        if (!(e->flags & BCE_COMPLETION_FLAG_PENDING))
++            break;
++        // pr_info("apple-bce: compl: %i: %i %llx %llx", e->qid, e->status, e->data_size, e->result);
++        bce_handle_cq_completion(dev, e, &ce);
++        e->flags = 0;
++        cq->index = (cq->index + 1) % cq->el_count;
++    }
++    mb();
++    iowrite32(cq->index, (u32 *) ((u8 *) dev->reg_mem_dma +  REG_DOORBELL_BASE) + cq->qid);
++    while (ce) {
++        --ce;
++        sq = dev->int_sq_list[ce];
++        sq->completion(sq);
++        sq->has_pending_completions = false;
++    }
++}
++
++
++struct bce_queue_sq *bce_alloc_sq(struct apple_bce_device *dev, int qid, u32 el_size, u32 el_count,
++        bce_sq_completion compl, void *userdata)
++{
++    struct bce_queue_sq *q;
++    q = kzalloc(sizeof(struct bce_queue_sq), GFP_KERNEL);
++    q->qid = qid;
++    q->type = BCE_QUEUE_SQ;
++    q->el_size = el_size;
++    q->el_count = el_count;
++    q->data = dma_alloc_coherent(&dev->pci->dev, el_count * el_size,
++                                 &q->dma_handle, GFP_KERNEL);
++    q->completion = compl;
++    q->userdata = userdata;
++    q->completion_data = kzalloc(sizeof(struct bce_sq_completion_data) * el_count, GFP_KERNEL);
++    q->reg_mem_dma = dev->reg_mem_dma;
++    atomic_set(&q->available_commands, el_count - 1);
++    init_completion(&q->available_command_completion);
++    atomic_set(&q->available_command_completion_waiting_count, 0);
++    if (!q->data) {
++        pr_err("DMA queue memory alloc failed\n");
++        kfree(q);
++        return NULL;
++    }
++    return q;
++}
++
++void bce_get_sq_memcfg(struct bce_queue_sq *sq, struct bce_queue_cq *cq, struct bce_queue_memcfg *cfg)
++{
++    cfg->qid = (u16) sq->qid;
++    cfg->el_count = (u16) sq->el_count;
++    cfg->vector_or_cq = (u16) cq->qid;
++    cfg->_pad = 0;
++    cfg->addr = sq->dma_handle;
++    cfg->length = sq->el_count * sq->el_size;
++}
++
++void bce_free_sq(struct apple_bce_device *dev, struct bce_queue_sq *sq)
++{
++    dma_free_coherent(&dev->pci->dev, sq->el_count * sq->el_size, sq->data, sq->dma_handle);
++    kfree(sq);
++}
++
++int bce_reserve_submission(struct bce_queue_sq *sq, unsigned long *timeout)
++{
++    while (atomic_dec_if_positive(&sq->available_commands) < 0) {
++        if (!timeout || !*timeout)
++            return -EAGAIN;
++        atomic_inc(&sq->available_command_completion_waiting_count);
++        *timeout = wait_for_completion_timeout(&sq->available_command_completion, *timeout);
++        if (!*timeout) {
++            if (atomic_dec_if_positive(&sq->available_command_completion_waiting_count) < 0)
++                try_wait_for_completion(&sq->available_command_completion); /* consume the pending completion */
++        }
++    }
++    return 0;
++}
++
++void bce_cancel_submission_reservation(struct bce_queue_sq *sq)
++{
++    atomic_inc(&sq->available_commands);
++}
++
++void *bce_next_submission(struct bce_queue_sq *sq)
++{
++    void *ret = bce_sq_element(sq, sq->tail);
++    sq->tail = (sq->tail + 1) % sq->el_count;
++    return ret;
++}
++
++void bce_submit_to_device(struct bce_queue_sq *sq)
++{
++    mb();
++    iowrite32(sq->tail, (u32 *) ((u8 *) sq->reg_mem_dma +  REG_DOORBELL_BASE) + sq->qid);
++}
++
++void bce_notify_submission_complete(struct bce_queue_sq *sq)
++{
++    sq->head = (sq->head + 1) % sq->el_count;
++    atomic_inc(&sq->available_commands);
++    if (atomic_dec_if_positive(&sq->available_command_completion_waiting_count) >= 0) {
++        complete(&sq->available_command_completion);
++    }
++}
++
++void bce_set_submission_single(struct bce_qe_submission *element, dma_addr_t addr, size_t size)
++{
++    element->addr = addr;
++    element->length = size;
++    element->segl_addr = element->segl_length = 0;
++}
++
++static void bce_cmdq_completion(struct bce_queue_sq *q);
++
++struct bce_queue_cmdq *bce_alloc_cmdq(struct apple_bce_device *dev, int qid, u32 el_count)
++{
++    struct bce_queue_cmdq *q;
++    q = kzalloc(sizeof(struct bce_queue_cmdq), GFP_KERNEL);
++    q->sq = bce_alloc_sq(dev, qid, BCE_CMD_SIZE, el_count, bce_cmdq_completion, q);
++    if (!q->sq) {
++        kfree(q);
++        return NULL;
++    }
++    spin_lock_init(&q->lck);
++    q->tres = kzalloc(sizeof(struct bce_queue_cmdq_result_el*) * el_count, GFP_KERNEL);
++    if (!q->tres) {
++        kfree(q);
++        return NULL;
++    }
++    return q;
++}
++
++void bce_free_cmdq(struct apple_bce_device *dev, struct bce_queue_cmdq *cmdq)
++{
++    bce_free_sq(dev, cmdq->sq);
++    kfree(cmdq->tres);
++    kfree(cmdq);
++}
++
++void bce_cmdq_completion(struct bce_queue_sq *q)
++{
++    struct bce_queue_cmdq_result_el *el;
++    struct bce_queue_cmdq *cmdq = q->userdata;
++    struct bce_sq_completion_data *result;
++
++    spin_lock(&cmdq->lck);
++    while ((result = bce_next_completion(q))) {
++        el = cmdq->tres[cmdq->sq->head];
++        if (el) {
++            el->result = result->result;
++            el->status = result->status;
++            mb();
++            complete(&el->cmpl);
++        } else {
++            pr_err("apple-bce: Unexpected command queue completion\n");
++        }
++        cmdq->tres[cmdq->sq->head] = NULL;
++        bce_notify_submission_complete(q);
++    }
++    spin_unlock(&cmdq->lck);
++}
++
++static __always_inline void *bce_cmd_start(struct bce_queue_cmdq *cmdq, struct bce_queue_cmdq_result_el *res)
++{
++    void *ret;
++    unsigned long timeout;
++    init_completion(&res->cmpl);
++    mb();
++
++    timeout = msecs_to_jiffies(1000L * 60 * 5); /* wait for up to ~5 minutes */
++    if (bce_reserve_submission(cmdq->sq, &timeout))
++        return NULL;
++
++    spin_lock(&cmdq->lck);
++    cmdq->tres[cmdq->sq->tail] = res;
++    ret = bce_next_submission(cmdq->sq);
++    return ret;
++}
++
++static __always_inline void bce_cmd_finish(struct bce_queue_cmdq *cmdq, struct bce_queue_cmdq_result_el *res)
++{
++    bce_submit_to_device(cmdq->sq);
++    spin_unlock(&cmdq->lck);
++
++    wait_for_completion(&res->cmpl);
++    mb();
++}
++
++u32 bce_cmd_register_queue(struct bce_queue_cmdq *cmdq, struct bce_queue_memcfg *cfg, const char *name, bool isdirout)
++{
++    struct bce_queue_cmdq_result_el res;
++    struct bce_cmdq_register_memory_queue_cmd *cmd = bce_cmd_start(cmdq, &res);
++    if (!cmd)
++        return (u32) -1;
++    cmd->cmd = BCE_CMD_REGISTER_MEMORY_QUEUE;
++    cmd->flags = (u16) ((name ? 2 : 0) | (isdirout ? 1 : 0));
++    cmd->qid = cfg->qid;
++    cmd->el_count = cfg->el_count;
++    cmd->vector_or_cq = cfg->vector_or_cq;
++    memset(cmd->name, 0, sizeof(cmd->name));
++    if (name) {
++        cmd->name_len = (u16) min(strlen(name), (size_t) sizeof(cmd->name));
++        memcpy(cmd->name, name, cmd->name_len);
++    } else {
++        cmd->name_len = 0;
++    }
++    cmd->addr = cfg->addr;
++    cmd->length = cfg->length;
++
++    bce_cmd_finish(cmdq, &res);
++    return res.status;
++}
++
++u32 bce_cmd_unregister_memory_queue(struct bce_queue_cmdq *cmdq, u16 qid)
++{
++    struct bce_queue_cmdq_result_el res;
++    struct bce_cmdq_simple_memory_queue_cmd *cmd = bce_cmd_start(cmdq, &res);
++    if (!cmd)
++        return (u32) -1;
++    cmd->cmd = BCE_CMD_UNREGISTER_MEMORY_QUEUE;
++    cmd->flags = 0;
++    cmd->qid = qid;
++    bce_cmd_finish(cmdq, &res);
++    return res.status;
++}
++
++u32 bce_cmd_flush_memory_queue(struct bce_queue_cmdq *cmdq, u16 qid)
++{
++    struct bce_queue_cmdq_result_el res;
++    struct bce_cmdq_simple_memory_queue_cmd *cmd = bce_cmd_start(cmdq, &res);
++    if (!cmd)
++        return (u32) -1;
++    cmd->cmd = BCE_CMD_FLUSH_MEMORY_QUEUE;
++    cmd->flags = 0;
++    cmd->qid = qid;
++    bce_cmd_finish(cmdq, &res);
++    return res.status;
++}
++
++
++struct bce_queue_cq *bce_create_cq(struct apple_bce_device *dev, u32 el_count)
++{
++    struct bce_queue_cq *cq;
++    struct bce_queue_memcfg cfg;
++    int qid = ida_simple_get(&dev->queue_ida, BCE_QUEUE_USER_MIN, BCE_QUEUE_USER_MAX, GFP_KERNEL);
++    if (qid < 0)
++        return NULL;
++    cq = bce_alloc_cq(dev, qid, el_count);
++    if (!cq)
++        return NULL;
++    bce_get_cq_memcfg(cq, &cfg);
++    if (bce_cmd_register_queue(dev->cmd_cmdq, &cfg, NULL, false) != 0) {
++        pr_err("apple-bce: CQ registration failed (%i)", qid);
++        bce_free_cq(dev, cq);
++        ida_simple_remove(&dev->queue_ida, (uint) qid);
++        return NULL;
++    }
++    dev->queues[qid] = (struct bce_queue *) cq;
++    return cq;
++}
++
++struct bce_queue_sq *bce_create_sq(struct apple_bce_device *dev, struct bce_queue_cq *cq, const char *name, u32 el_count,
++        int direction, bce_sq_completion compl, void *userdata)
++{
++    struct bce_queue_sq *sq;
++    struct bce_queue_memcfg cfg;
++    int qid;
++    if (cq == NULL)
++        return NULL; /* cq can not be null */
++    if (name == NULL)
++        return NULL; /* name can not be null */
++    if (direction != DMA_TO_DEVICE && direction != DMA_FROM_DEVICE)
++        return NULL; /* unsupported direction */
++    qid = ida_simple_get(&dev->queue_ida, BCE_QUEUE_USER_MIN, BCE_QUEUE_USER_MAX, GFP_KERNEL);
++    if (qid < 0)
++        return NULL;
++    sq = bce_alloc_sq(dev, qid, sizeof(struct bce_qe_submission), el_count, compl, userdata);
++    if (!sq)
++        return NULL;
++    bce_get_sq_memcfg(sq, cq, &cfg);
++    if (bce_cmd_register_queue(dev->cmd_cmdq, &cfg, name, direction != DMA_FROM_DEVICE) != 0) {
++        pr_err("apple-bce: SQ registration failed (%i)", qid);
++        bce_free_sq(dev, sq);
++        ida_simple_remove(&dev->queue_ida, (uint) qid);
++        return NULL;
++    }
++    spin_lock(&dev->queues_lock);
++    dev->queues[qid] = (struct bce_queue *) sq;
++    spin_unlock(&dev->queues_lock);
++    return sq;
++}
++
++void bce_destroy_cq(struct apple_bce_device *dev, struct bce_queue_cq *cq)
++{
++    if (!dev->is_being_removed && bce_cmd_unregister_memory_queue(dev->cmd_cmdq, (u16) cq->qid))
++        pr_err("apple-bce: CQ unregister failed");
++    spin_lock(&dev->queues_lock);
++    dev->queues[cq->qid] = NULL;
++    spin_unlock(&dev->queues_lock);
++    ida_simple_remove(&dev->queue_ida, (uint) cq->qid);
++    bce_free_cq(dev, cq);
++}
++
++void bce_destroy_sq(struct apple_bce_device *dev, struct bce_queue_sq *sq)
++{
++    if (!dev->is_being_removed && bce_cmd_unregister_memory_queue(dev->cmd_cmdq, (u16) sq->qid))
++        pr_err("apple-bce: CQ unregister failed");
++    spin_lock(&dev->queues_lock);
++    dev->queues[sq->qid] = NULL;
++    spin_unlock(&dev->queues_lock);
++    ida_simple_remove(&dev->queue_ida, (uint) sq->qid);
++    bce_free_sq(dev, sq);
++}
+\ No newline at end of file
+diff --git a/drivers/staging/apple-bce/queue.h b/drivers/staging/apple-bce/queue.h
+new file mode 100644
+index 000000000000..8368ac5dfca8
+--- /dev/null
++++ b/drivers/staging/apple-bce/queue.h
+@@ -0,0 +1,177 @@
++#ifndef BCE_QUEUE_H
++#define BCE_QUEUE_H
++
++#include <linux/completion.h>
++#include <linux/pci.h>
++
++#define BCE_CMD_SIZE 0x40
++
++struct apple_bce_device;
++
++enum bce_queue_type {
++    BCE_QUEUE_CQ, BCE_QUEUE_SQ
++};
++struct bce_queue {
++    int qid;
++    int type;
++};
++struct bce_queue_cq {
++    int qid;
++    int type;
++    u32 el_count;
++    dma_addr_t dma_handle;
++    void *data;
++
++    u32 index;
++};
++struct bce_queue_sq;
++typedef void (*bce_sq_completion)(struct bce_queue_sq *q);
++struct bce_sq_completion_data {
++    u32 status;
++    u64 data_size;
++    u64 result;
++};
++struct bce_queue_sq {
++    int qid;
++    int type;
++    u32 el_size;
++    u32 el_count;
++    dma_addr_t dma_handle;
++    void *data;
++    void *userdata;
++    void __iomem *reg_mem_dma;
++
++    atomic_t available_commands;
++    struct completion available_command_completion;
++    atomic_t available_command_completion_waiting_count;
++    u32 head, tail;
++
++    u32 completion_cidx, completion_tail;
++    struct bce_sq_completion_data *completion_data;
++    bool has_pending_completions;
++    bce_sq_completion completion;
++};
++
++struct bce_queue_cmdq_result_el {
++    struct completion cmpl;
++    u32 status;
++    u64 result;
++};
++struct bce_queue_cmdq {
++    struct bce_queue_sq *sq;
++    struct spinlock lck;
++    struct bce_queue_cmdq_result_el **tres;
++};
++
++struct bce_queue_memcfg {
++    u16 qid;
++    u16 el_count;
++    u16 vector_or_cq;
++    u16 _pad;
++    u64 addr;
++    u64 length;
++};
++
++enum bce_qe_completion_status {
++    BCE_COMPLETION_SUCCESS = 0,
++    BCE_COMPLETION_ERROR = 1,
++    BCE_COMPLETION_ABORTED = 2,
++    BCE_COMPLETION_NO_SPACE = 3,
++    BCE_COMPLETION_OVERRUN = 4
++};
++enum bce_qe_completion_flags {
++    BCE_COMPLETION_FLAG_PENDING = 0x8000
++};
++struct bce_qe_completion {
++    u64 result;
++    u64 data_size;
++    u16 qid;
++    u16 completion_index;
++    u16 status; // bce_qe_completion_status
++    u16 flags;  // bce_qe_completion_flags
++};
++
++struct bce_qe_submission {
++    u64 length;
++    u64 addr;
++
++    u64 segl_addr;
++    u64 segl_length;
++};
++
++enum bce_cmdq_command {
++    BCE_CMD_REGISTER_MEMORY_QUEUE = 0x20,
++    BCE_CMD_UNREGISTER_MEMORY_QUEUE = 0x30,
++    BCE_CMD_FLUSH_MEMORY_QUEUE = 0x40,
++    BCE_CMD_SET_MEMORY_QUEUE_PROPERTY = 0x50
++};
++struct bce_cmdq_simple_memory_queue_cmd {
++    u16 cmd; // bce_cmdq_command
++    u16 flags;
++    u16 qid;
++};
++struct bce_cmdq_register_memory_queue_cmd {
++    u16 cmd; // bce_cmdq_command
++    u16 flags;
++    u16 qid;
++    u16 _pad;
++    u16 el_count;
++    u16 vector_or_cq;
++    u16 _pad2;
++    u16 name_len;
++    char name[0x20];
++    u64 addr;
++    u64 length;
++};
++
++static __always_inline void *bce_sq_element(struct bce_queue_sq *q, int i) {
++    return (void *) ((u8 *) q->data + q->el_size * i);
++}
++static __always_inline void *bce_cq_element(struct bce_queue_cq *q, int i) {
++    return (void *) ((struct bce_qe_completion *) q->data + i);
++}
++
++static __always_inline struct bce_sq_completion_data *bce_next_completion(struct bce_queue_sq *sq) {
++    struct bce_sq_completion_data *res;
++    rmb();
++    if (sq->completion_cidx == sq->completion_tail)
++        return NULL;
++    res = &sq->completion_data[sq->completion_cidx];
++    sq->completion_cidx = (sq->completion_cidx + 1) % sq->el_count;
++    return res;
++}
++
++struct bce_queue_cq *bce_alloc_cq(struct apple_bce_device *dev, int qid, u32 el_count);
++void bce_get_cq_memcfg(struct bce_queue_cq *cq, struct bce_queue_memcfg *cfg);
++void bce_free_cq(struct apple_bce_device *dev, struct bce_queue_cq *cq);
++void bce_handle_cq_completions(struct apple_bce_device *dev, struct bce_queue_cq *cq);
++
++struct bce_queue_sq *bce_alloc_sq(struct apple_bce_device *dev, int qid, u32 el_size, u32 el_count,
++        bce_sq_completion compl, void *userdata);
++void bce_get_sq_memcfg(struct bce_queue_sq *sq, struct bce_queue_cq *cq, struct bce_queue_memcfg *cfg);
++void bce_free_sq(struct apple_bce_device *dev, struct bce_queue_sq *sq);
++int bce_reserve_submission(struct bce_queue_sq *sq, unsigned long *timeout);
++void bce_cancel_submission_reservation(struct bce_queue_sq *sq);
++void *bce_next_submission(struct bce_queue_sq *sq);
++void bce_submit_to_device(struct bce_queue_sq *sq);
++void bce_notify_submission_complete(struct bce_queue_sq *sq);
++
++void bce_set_submission_single(struct bce_qe_submission *element, dma_addr_t addr, size_t size);
++
++struct bce_queue_cmdq *bce_alloc_cmdq(struct apple_bce_device *dev, int qid, u32 el_count);
++void bce_free_cmdq(struct apple_bce_device *dev, struct bce_queue_cmdq *cmdq);
++
++u32 bce_cmd_register_queue(struct bce_queue_cmdq *cmdq, struct bce_queue_memcfg *cfg, const char *name, bool isdirout);
++u32 bce_cmd_unregister_memory_queue(struct bce_queue_cmdq *cmdq, u16 qid);
++u32 bce_cmd_flush_memory_queue(struct bce_queue_cmdq *cmdq, u16 qid);
++
++
++/* User API - Creates and registers the queue */
++
++struct bce_queue_cq *bce_create_cq(struct apple_bce_device *dev, u32 el_count);
++struct bce_queue_sq *bce_create_sq(struct apple_bce_device *dev, struct bce_queue_cq *cq, const char *name, u32 el_count,
++        int direction, bce_sq_completion compl, void *userdata);
++void bce_destroy_cq(struct apple_bce_device *dev, struct bce_queue_cq *cq);
++void bce_destroy_sq(struct apple_bce_device *dev, struct bce_queue_sq *sq);
++
++#endif //BCEDRIVER_MAILBOX_H
+diff --git a/drivers/staging/apple-bce/queue_dma.c b/drivers/staging/apple-bce/queue_dma.c
+new file mode 100644
+index 000000000000..b236613285c0
+--- /dev/null
++++ b/drivers/staging/apple-bce/queue_dma.c
+@@ -0,0 +1,220 @@
++#include "queue_dma.h"
++#include <linux/vmalloc.h>
++#include <linux/mm.h>
++#include "queue.h"
++
++static int bce_alloc_scatterlist_from_vm(struct sg_table *tbl, void *data, size_t len);
++static struct bce_segment_list_element_hostinfo *bce_map_segment_list(
++        struct device *dev, struct scatterlist *pages, int pagen);
++static void bce_unmap_segement_list(struct device *dev, struct bce_segment_list_element_hostinfo *list);
++
++int bce_map_dma_buffer(struct device *dev, struct bce_dma_buffer *buf, struct sg_table scatterlist,
++        enum dma_data_direction dir)
++{
++    int cnt;
++
++    buf->direction = dir;
++    buf->scatterlist = scatterlist;
++    buf->seglist_hostinfo = NULL;
++
++    cnt = dma_map_sg(dev, buf->scatterlist.sgl, buf->scatterlist.nents, dir);
++    if (cnt != buf->scatterlist.nents) {
++        pr_err("apple-bce: DMA scatter list mapping returned an unexpected count: %i\n", cnt);
++        dma_unmap_sg(dev, buf->scatterlist.sgl, buf->scatterlist.nents, dir);
++        return -EIO;
++    }
++    if (cnt == 1)
++        return 0;
++
++    buf->seglist_hostinfo = bce_map_segment_list(dev, buf->scatterlist.sgl, buf->scatterlist.nents);
++    if (!buf->seglist_hostinfo) {
++        pr_err("apple-bce: Creating segment list failed\n");
++        dma_unmap_sg(dev, buf->scatterlist.sgl, buf->scatterlist.nents, dir);
++        return -EIO;
++    }
++    return 0;
++}
++
++int bce_map_dma_buffer_vm(struct device *dev, struct bce_dma_buffer *buf, void *data, size_t len,
++                          enum dma_data_direction dir)
++{
++    int status;
++    struct sg_table scatterlist;
++    if ((status = bce_alloc_scatterlist_from_vm(&scatterlist, data, len)))
++        return status;
++    if ((status = bce_map_dma_buffer(dev, buf, scatterlist, dir))) {
++        sg_free_table(&scatterlist);
++        return status;
++    }
++    return 0;
++}
++
++int bce_map_dma_buffer_km(struct device *dev, struct bce_dma_buffer *buf, void *data, size_t len,
++                          enum dma_data_direction dir)
++{
++    /* Kernel memory is continuous which is great for us. */
++    int status;
++    struct sg_table scatterlist;
++    if ((status = sg_alloc_table(&scatterlist, 1, GFP_KERNEL))) {
++        sg_free_table(&scatterlist);
++        return status;
++    }
++    sg_set_buf(scatterlist.sgl, data, (uint) len);
++    if ((status = bce_map_dma_buffer(dev, buf, scatterlist, dir))) {
++        sg_free_table(&scatterlist);
++        return status;
++    }
++    return 0;
++}
++
++void bce_unmap_dma_buffer(struct device *dev, struct bce_dma_buffer *buf)
++{
++    dma_unmap_sg(dev, buf->scatterlist.sgl, buf->scatterlist.nents, buf->direction);
++    bce_unmap_segement_list(dev, buf->seglist_hostinfo);
++}
++
++
++static int bce_alloc_scatterlist_from_vm(struct sg_table *tbl, void *data, size_t len)
++{
++    int status, i;
++    struct page **pages;
++    size_t off, start_page, end_page, page_count;
++    off        = (size_t) data % PAGE_SIZE;
++    start_page = (size_t) data  / PAGE_SIZE;
++    end_page   = ((size_t) data + len - 1) / PAGE_SIZE;
++    page_count = end_page - start_page + 1;
++
++    if (page_count > PAGE_SIZE / sizeof(struct page *))
++        pages = vmalloc(page_count * sizeof(struct page *));
++    else
++        pages = kmalloc(page_count * sizeof(struct page *), GFP_KERNEL);
++
++    for (i = 0; i < page_count; i++)
++        pages[i] = vmalloc_to_page((void *) ((start_page + i) * PAGE_SIZE));
++
++    if ((status = sg_alloc_table_from_pages(tbl, pages, page_count, (unsigned int) off, len, GFP_KERNEL))) {
++        sg_free_table(tbl);
++    }
++
++    if (page_count > PAGE_SIZE / sizeof(struct page *))
++        vfree(pages);
++    else
++        kfree(pages);
++    return status;
++}
++
++#define BCE_ELEMENTS_PER_PAGE ((PAGE_SIZE - sizeof(struct bce_segment_list_header)) \
++                               / sizeof(struct bce_segment_list_element))
++#define BCE_ELEMENTS_PER_ADDITIONAL_PAGE (PAGE_SIZE / sizeof(struct bce_segment_list_element))
++
++static struct bce_segment_list_element_hostinfo *bce_map_segment_list(
++        struct device *dev, struct scatterlist *pages, int pagen)
++{
++    size_t ptr, pptr = 0;
++    struct bce_segment_list_header theader; /* a temp header, to store the initial seg */
++    struct bce_segment_list_header *header;
++    struct bce_segment_list_element *el, *el_end;
++    struct bce_segment_list_element_hostinfo *out, *pout, *out_root;
++    struct scatterlist *sg;
++    int i;
++    header = &theader;
++    out = out_root = NULL;
++    el = el_end = NULL;
++    for_each_sg(pages, sg, pagen, i) {
++        if (el >= el_end) {
++            /* allocate a new page, this will be also done for the first element */
++            ptr = __get_free_page(GFP_KERNEL);
++            if (pptr && ptr == pptr + PAGE_SIZE) {
++                out->page_count++;
++                header->element_count += BCE_ELEMENTS_PER_ADDITIONAL_PAGE;
++                el_end += BCE_ELEMENTS_PER_ADDITIONAL_PAGE;
++            } else {
++                header = (void *) ptr;
++                header->element_count = BCE_ELEMENTS_PER_PAGE;
++                header->data_size = 0;
++                header->next_segl_addr = 0;
++                header->next_segl_length = 0;
++                el = (void *) (header + 1);
++                el_end = el + BCE_ELEMENTS_PER_PAGE;
++
++                if (out) {
++                    out->next = kmalloc(sizeof(struct bce_segment_list_element_hostinfo), GFP_KERNEL);
++                    out = out->next;
++                } else {
++                    out_root = out = kmalloc(sizeof(struct bce_segment_list_element_hostinfo), GFP_KERNEL);
++                }
++                out->page_start = (void *) ptr;
++                out->page_count = 1;
++                out->dma_start = DMA_MAPPING_ERROR;
++                out->next = NULL;
++            }
++            pptr = ptr;
++        }
++        el->addr = sg->dma_address;
++        el->length = sg->length;
++        header->data_size += el->length;
++    }
++
++    /* DMA map */
++    out = out_root;
++    pout = NULL;
++    while (out) {
++        out->dma_start = dma_map_single(dev, out->page_start, out->page_count * PAGE_SIZE, DMA_TO_DEVICE);
++        if (dma_mapping_error(dev, out->dma_start))
++            goto error;
++        if (pout) {
++            header = pout->page_start;
++            header->next_segl_addr = out->dma_start;
++            header->next_segl_length = out->page_count * PAGE_SIZE;
++        }
++        pout = out;
++        out = out->next;
++    }
++    return out_root;
++
++    error:
++    bce_unmap_segement_list(dev, out_root);
++    return NULL;
++}
++
++static void bce_unmap_segement_list(struct device *dev, struct bce_segment_list_element_hostinfo *list)
++{
++    struct bce_segment_list_element_hostinfo *next;
++    while (list) {
++        if (list->dma_start != DMA_MAPPING_ERROR)
++            dma_unmap_single(dev, list->dma_start, list->page_count * PAGE_SIZE, DMA_TO_DEVICE);
++        next = list->next;
++        kfree(list);
++        list = next;
++    }
++}
++
++int bce_set_submission_buf(struct bce_qe_submission *element, struct bce_dma_buffer *buf, size_t offset, size_t length)
++{
++    struct bce_segment_list_element_hostinfo *seg;
++    struct bce_segment_list_header *seg_header;
++
++    seg = buf->seglist_hostinfo;
++    if (!seg) {
++        element->addr = buf->scatterlist.sgl->dma_address + offset;
++        element->length = length;
++        element->segl_addr = 0;
++        element->segl_length = 0;
++        return 0;
++    }
++
++    while (seg) {
++        seg_header = seg->page_start;
++        if (offset <= seg_header->data_size)
++            break;
++        offset -= seg_header->data_size;
++        seg = seg->next;
++    }
++    if (!seg)
++        return -EINVAL;
++    element->addr = offset;
++    element->length = buf->scatterlist.sgl->dma_length;
++    element->segl_addr = seg->dma_start;
++    element->segl_length = seg->page_count * PAGE_SIZE;
++    return 0;
++}
+\ No newline at end of file
+diff --git a/drivers/staging/apple-bce/queue_dma.h b/drivers/staging/apple-bce/queue_dma.h
+new file mode 100644
+index 000000000000..f8a57e50e7a3
+--- /dev/null
++++ b/drivers/staging/apple-bce/queue_dma.h
+@@ -0,0 +1,50 @@
++#ifndef BCE_QUEUE_DMA_H
++#define BCE_QUEUE_DMA_H
++
++#include <linux/pci.h>
++
++struct bce_qe_submission;
++
++struct bce_segment_list_header {
++    u64 element_count;
++    u64 data_size;
++
++    u64 next_segl_addr;
++    u64 next_segl_length;
++};
++struct bce_segment_list_element {
++    u64 addr;
++    u64 length;
++};
++
++struct bce_segment_list_element_hostinfo {
++    struct bce_segment_list_element_hostinfo *next;
++    void *page_start;
++    size_t page_count;
++    dma_addr_t dma_start;
++};
++
++
++struct bce_dma_buffer {
++    enum dma_data_direction direction;
++    struct sg_table scatterlist;
++    struct bce_segment_list_element_hostinfo *seglist_hostinfo;
++};
++
++/* NOTE: Takes ownership of the sg_table if it succeeds. Ownership is not transferred on failure. */
++int bce_map_dma_buffer(struct device *dev, struct bce_dma_buffer *buf, struct sg_table scatterlist,
++        enum dma_data_direction dir);
++
++/* Creates a buffer from virtual memory (vmalloc) */
++int bce_map_dma_buffer_vm(struct device *dev, struct bce_dma_buffer *buf, void *data, size_t len,
++        enum dma_data_direction dir);
++
++/* Creates a buffer from kernel memory (kmalloc) */
++int bce_map_dma_buffer_km(struct device *dev, struct bce_dma_buffer *buf, void *data, size_t len,
++                          enum dma_data_direction dir);
++
++void bce_unmap_dma_buffer(struct device *dev, struct bce_dma_buffer *buf);
++
++int bce_set_submission_buf(struct bce_qe_submission *element, struct bce_dma_buffer *buf, size_t offset, size_t length);
++
++#endif //BCE_QUEUE_DMA_H
+diff --git a/drivers/staging/apple-bce/vhci/command.h b/drivers/staging/apple-bce/vhci/command.h
+new file mode 100644
+index 000000000000..26619e0bccfa
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/command.h
+@@ -0,0 +1,204 @@
++#ifndef BCE_VHCI_COMMAND_H
++#define BCE_VHCI_COMMAND_H
++
++#include "queue.h"
++#include <linux/jiffies.h>
++#include <linux/usb.h>
++
++#define BCE_VHCI_CMD_TIMEOUT_SHORT msecs_to_jiffies(2000)
++#define BCE_VHCI_CMD_TIMEOUT_LONG msecs_to_jiffies(30000)
++
++#define BCE_VHCI_BULK_MAX_ACTIVE_URBS_POW2 2
++#define BCE_VHCI_BULK_MAX_ACTIVE_URBS (1 << BCE_VHCI_BULK_MAX_ACTIVE_URBS_POW2)
++
++typedef u8 bce_vhci_port_t;
++typedef u8 bce_vhci_device_t;
++
++enum bce_vhci_command {
++    BCE_VHCI_CMD_CONTROLLER_ENABLE = 1,
++    BCE_VHCI_CMD_CONTROLLER_DISABLE = 2,
++    BCE_VHCI_CMD_CONTROLLER_START = 3,
++    BCE_VHCI_CMD_CONTROLLER_PAUSE = 4,
++
++    BCE_VHCI_CMD_PORT_POWER_ON = 0x10,
++    BCE_VHCI_CMD_PORT_POWER_OFF = 0x11,
++    BCE_VHCI_CMD_PORT_RESUME = 0x12,
++    BCE_VHCI_CMD_PORT_SUSPEND = 0x13,
++    BCE_VHCI_CMD_PORT_RESET = 0x14,
++    BCE_VHCI_CMD_PORT_DISABLE = 0x15,
++    BCE_VHCI_CMD_PORT_STATUS = 0x16,
++
++    BCE_VHCI_CMD_DEVICE_CREATE = 0x30,
++    BCE_VHCI_CMD_DEVICE_DESTROY = 0x31,
++
++    BCE_VHCI_CMD_ENDPOINT_CREATE = 0x40,
++    BCE_VHCI_CMD_ENDPOINT_DESTROY = 0x41,
++    BCE_VHCI_CMD_ENDPOINT_SET_STATE = 0x42,
++    BCE_VHCI_CMD_ENDPOINT_RESET = 0x44,
++
++    /* Device to host only */
++    BCE_VHCI_CMD_ENDPOINT_REQUEST_STATE = 0x43,
++    BCE_VHCI_CMD_TRANSFER_REQUEST = 0x1000,
++    BCE_VHCI_CMD_CONTROL_TRANSFER_STATUS = 0x1005
++};
++
++enum bce_vhci_endpoint_state {
++    BCE_VHCI_ENDPOINT_ACTIVE = 0,
++    BCE_VHCI_ENDPOINT_PAUSED = 1,
++    BCE_VHCI_ENDPOINT_STALLED = 2
++};
++
++static inline int bce_vhci_cmd_controller_enable(struct bce_vhci_command_queue *q, u8 busNum, u16 *portMask)
++{
++    int status;
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_CONTROLLER_ENABLE;
++    cmd.param1 = 0x7100u | busNum;
++    status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++    if (!status)
++        *portMask = (u16) res.param2;
++    return status;
++}
++static inline int bce_vhci_cmd_controller_disable(struct bce_vhci_command_queue *q)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_CONTROLLER_DISABLE;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++}
++static inline int bce_vhci_cmd_controller_start(struct bce_vhci_command_queue *q)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_CONTROLLER_START;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++}
++static inline int bce_vhci_cmd_controller_pause(struct bce_vhci_command_queue *q)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_CONTROLLER_PAUSE;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++}
++
++static inline int bce_vhci_cmd_port_power_on(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_POWER_ON;
++    cmd.param1 = port;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++static inline int bce_vhci_cmd_port_power_off(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_POWER_OFF;
++    cmd.param1 = port;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++static inline int bce_vhci_cmd_port_resume(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_RESUME;
++    cmd.param1 = port;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++}
++static inline int bce_vhci_cmd_port_suspend(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_SUSPEND;
++    cmd.param1 = port;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++}
++static inline int bce_vhci_cmd_port_reset(struct bce_vhci_command_queue *q, bce_vhci_port_t port, u32 timeout)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_RESET;
++    cmd.param1 = port;
++    cmd.param2 = timeout;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++static inline int bce_vhci_cmd_port_disable(struct bce_vhci_command_queue *q, bce_vhci_port_t port)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_DISABLE;
++    cmd.param1 = port;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++static inline int bce_vhci_cmd_port_status(struct bce_vhci_command_queue *q, bce_vhci_port_t port,
++        u32 clearFlags, u32 *resStatus)
++{
++    int status;
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_PORT_STATUS;
++    cmd.param1 = port;
++    cmd.param2 = clearFlags & 0x560000;
++    status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++    if (status >= 0)
++        *resStatus = (u32) res.param2;
++    return status;
++}
++
++static inline int bce_vhci_cmd_device_create(struct bce_vhci_command_queue *q, bce_vhci_port_t port,
++        bce_vhci_device_t *dev)
++{
++    int status;
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_DEVICE_CREATE;
++    cmd.param1 = port;
++    status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++    if (!status)
++        *dev = (bce_vhci_device_t) res.param2;
++    return status;
++}
++static inline int bce_vhci_cmd_device_destroy(struct bce_vhci_command_queue *q, bce_vhci_device_t dev)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_DEVICE_DESTROY;
++    cmd.param1 = dev;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_LONG);
++}
++
++static inline int bce_vhci_cmd_endpoint_create(struct bce_vhci_command_queue *q, bce_vhci_device_t dev,
++        struct usb_endpoint_descriptor *desc)
++{
++    struct bce_vhci_message cmd, res;
++    int endpoint_type = usb_endpoint_type(desc);
++    int maxp = usb_endpoint_maxp(desc);
++    int maxp_burst = usb_endpoint_maxp_mult(desc) * maxp;
++    u8 max_active_requests_pow2 = 0;
++    cmd.cmd = BCE_VHCI_CMD_ENDPOINT_CREATE;
++    cmd.param1 = dev | ((desc->bEndpointAddress & 0x8Fu) << 8);
++    if (endpoint_type == USB_ENDPOINT_XFER_BULK)
++        max_active_requests_pow2 = BCE_VHCI_BULK_MAX_ACTIVE_URBS_POW2;
++    cmd.param2 = endpoint_type | ((max_active_requests_pow2 & 0xf) << 4) | (maxp << 16) | ((u64) maxp_burst << 32);
++    if (endpoint_type == USB_ENDPOINT_XFER_INT)
++        cmd.param2 |= (desc->bInterval - 1) << 8;
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++static inline int bce_vhci_cmd_endpoint_destroy(struct bce_vhci_command_queue *q, bce_vhci_device_t dev, u8 endpoint)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_ENDPOINT_DESTROY;
++    cmd.param1 = dev | (endpoint << 8);
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++static inline int bce_vhci_cmd_endpoint_set_state(struct bce_vhci_command_queue *q, bce_vhci_device_t dev, u8 endpoint,
++        enum bce_vhci_endpoint_state newState, enum bce_vhci_endpoint_state *retState)
++{
++    int status;
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_ENDPOINT_SET_STATE;
++    cmd.param1 = dev | (endpoint << 8);
++    cmd.param2 = (u64) newState;
++    status = bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++    if (status != BCE_VHCI_INTERNAL_ERROR && status != BCE_VHCI_NO_POWER)
++        *retState = (enum bce_vhci_endpoint_state) res.param2;
++    return status;
++}
++static inline int bce_vhci_cmd_endpoint_reset(struct bce_vhci_command_queue *q, bce_vhci_device_t dev, u8 endpoint)
++{
++    struct bce_vhci_message cmd, res;
++    cmd.cmd = BCE_VHCI_CMD_ENDPOINT_RESET;
++    cmd.param1 = dev | (endpoint << 8);
++    return bce_vhci_command_queue_execute(q, &cmd, &res, BCE_VHCI_CMD_TIMEOUT_SHORT);
++}
++
++
++#endif //BCE_VHCI_COMMAND_H
+diff --git a/drivers/staging/apple-bce/vhci/queue.c b/drivers/staging/apple-bce/vhci/queue.c
+new file mode 100644
+index 000000000000..7b0b5027157b
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/queue.c
+@@ -0,0 +1,268 @@
++#include "queue.h"
++#include "vhci.h"
++#include "../apple_bce.h"
++
++
++static void bce_vhci_message_queue_completion(struct bce_queue_sq *sq);
++
++int bce_vhci_message_queue_create(struct bce_vhci *vhci, struct bce_vhci_message_queue *ret, const char *name)
++{
++    int status;
++    ret->cq = bce_create_cq(vhci->dev, VHCI_EVENT_QUEUE_EL_COUNT);
++    if (!ret->cq)
++        return -EINVAL;
++    ret->sq = bce_create_sq(vhci->dev, ret->cq, name, VHCI_EVENT_QUEUE_EL_COUNT, DMA_TO_DEVICE,
++                            bce_vhci_message_queue_completion, ret);
++    if (!ret->sq) {
++        status = -EINVAL;
++        goto fail_cq;
++    }
++    ret->data = dma_alloc_coherent(&vhci->dev->pci->dev, sizeof(struct bce_vhci_message) * VHCI_EVENT_QUEUE_EL_COUNT,
++                                   &ret->dma_addr, GFP_KERNEL);
++    if (!ret->data) {
++        status = -EINVAL;
++        goto fail_sq;
++    }
++    return 0;
++
++fail_sq:
++    bce_destroy_sq(vhci->dev, ret->sq);
++    ret->sq = NULL;
++fail_cq:
++    bce_destroy_cq(vhci->dev, ret->cq);
++    ret->cq = NULL;
++    return status;
++}
++
++void bce_vhci_message_queue_destroy(struct bce_vhci *vhci, struct bce_vhci_message_queue *q)
++{
++    if (!q->cq)
++        return;
++    dma_free_coherent(&vhci->dev->pci->dev, sizeof(struct bce_vhci_message) * VHCI_EVENT_QUEUE_EL_COUNT,
++                      q->data, q->dma_addr);
++    bce_destroy_sq(vhci->dev, q->sq);
++    bce_destroy_cq(vhci->dev, q->cq);
++}
++
++void bce_vhci_message_queue_write(struct bce_vhci_message_queue *q, struct bce_vhci_message *req)
++{
++    int sidx;
++    struct bce_qe_submission *s;
++    sidx = q->sq->tail;
++    s = bce_next_submission(q->sq);
++    pr_debug("bce-vhci: Send message: %x s=%x p1=%x p2=%llx\n", req->cmd, req->status, req->param1, req->param2);
++    q->data[sidx] = *req;
++    bce_set_submission_single(s, q->dma_addr + sizeof(struct bce_vhci_message) * sidx,
++            sizeof(struct bce_vhci_message));
++    bce_submit_to_device(q->sq);
++}
++
++static void bce_vhci_message_queue_completion(struct bce_queue_sq *sq)
++{
++    while (bce_next_completion(sq))
++        bce_notify_submission_complete(sq);
++}
++
++
++
++static void bce_vhci_event_queue_completion(struct bce_queue_sq *sq);
++
++int __bce_vhci_event_queue_create(struct bce_vhci *vhci, struct bce_vhci_event_queue *ret, const char *name,
++                                  bce_sq_completion compl)
++{
++    ret->vhci = vhci;
++
++    ret->sq = bce_create_sq(vhci->dev, vhci->ev_cq, name, VHCI_EVENT_QUEUE_EL_COUNT, DMA_FROM_DEVICE, compl, ret);
++    if (!ret->sq)
++        return -EINVAL;
++    ret->data = dma_alloc_coherent(&vhci->dev->pci->dev, sizeof(struct bce_vhci_message) * VHCI_EVENT_QUEUE_EL_COUNT,
++                                   &ret->dma_addr, GFP_KERNEL);
++    if (!ret->data) {
++        bce_destroy_sq(vhci->dev, ret->sq);
++        ret->sq = NULL;
++        return -EINVAL;
++    }
++
++    init_completion(&ret->queue_empty_completion);
++    bce_vhci_event_queue_submit_pending(ret, VHCI_EVENT_PENDING_COUNT);
++    return 0;
++}
++
++int bce_vhci_event_queue_create(struct bce_vhci *vhci, struct bce_vhci_event_queue *ret, const char *name,
++        bce_vhci_event_queue_callback cb)
++{
++    ret->cb = cb;
++    return __bce_vhci_event_queue_create(vhci, ret, name, bce_vhci_event_queue_completion);
++}
++
++void bce_vhci_event_queue_destroy(struct bce_vhci *vhci, struct bce_vhci_event_queue *q)
++{
++    if (!q->sq)
++        return;
++    dma_free_coherent(&vhci->dev->pci->dev, sizeof(struct bce_vhci_message) * VHCI_EVENT_QUEUE_EL_COUNT,
++                      q->data, q->dma_addr);
++    bce_destroy_sq(vhci->dev, q->sq);
++}
++
++static void bce_vhci_event_queue_completion(struct bce_queue_sq *sq)
++{
++    struct bce_sq_completion_data *cd;
++    struct bce_vhci_event_queue *ev = sq->userdata;
++    struct bce_vhci_message *msg;
++    size_t cnt = 0;
++
++    while ((cd = bce_next_completion(sq))) {
++        if (cd->status == BCE_COMPLETION_ABORTED) { /* We flushed the queue */
++            bce_notify_submission_complete(sq);
++            continue;
++        }
++        msg = &ev->data[sq->head];
++        pr_debug("bce-vhci: Got event: %x s=%x p1=%x p2=%llx\n", msg->cmd, msg->status, msg->param1, msg->param2);
++        ev->cb(ev, msg);
++
++        bce_notify_submission_complete(sq);
++        ++cnt;
++    }
++    bce_vhci_event_queue_submit_pending(ev, cnt);
++    if (atomic_read(&sq->available_commands) == sq->el_count - 1)
++        complete(&ev->queue_empty_completion);
++}
++
++void bce_vhci_event_queue_submit_pending(struct bce_vhci_event_queue *q, size_t count)
++{
++    int idx;
++    struct bce_qe_submission *s;
++    while (count--) {
++        if (bce_reserve_submission(q->sq, NULL)) {
++            pr_err("bce-vhci: Failed to reserve an event queue submission\n");
++            break;
++        }
++        idx = q->sq->tail;
++        s = bce_next_submission(q->sq);
++        bce_set_submission_single(s,
++                                  q->dma_addr + idx * sizeof(struct bce_vhci_message), sizeof(struct bce_vhci_message));
++    }
++    bce_submit_to_device(q->sq);
++}
++
++void bce_vhci_event_queue_pause(struct bce_vhci_event_queue *q)
++{
++    unsigned long timeout;
++    reinit_completion(&q->queue_empty_completion);
++    if (bce_cmd_flush_memory_queue(q->vhci->dev->cmd_cmdq, q->sq->qid))
++        pr_warn("bce-vhci: failed to flush event queue\n");
++    timeout = msecs_to_jiffies(5000);
++    while (atomic_read(&q->sq->available_commands) != q->sq->el_count - 1) {
++        timeout = wait_for_completion_timeout(&q->queue_empty_completion, timeout);
++        if (timeout == 0) {
++            pr_err("bce-vhci: waiting for queue to be flushed timed out\n");
++            break;
++        }
++    }
++}
++
++void bce_vhci_event_queue_resume(struct bce_vhci_event_queue *q)
++{
++    if (atomic_read(&q->sq->available_commands) != q->sq->el_count - 1) {
++        pr_err("bce-vhci: resume of a queue with pending submissions\n");
++        return;
++    }
++    bce_vhci_event_queue_submit_pending(q, VHCI_EVENT_PENDING_COUNT);
++}
++
++void bce_vhci_command_queue_create(struct bce_vhci_command_queue *ret, struct bce_vhci_message_queue *mq)
++{
++    ret->mq = mq;
++    ret->completion.result = NULL;
++    init_completion(&ret->completion.completion);
++    spin_lock_init(&ret->completion_lock);
++    mutex_init(&ret->mutex);
++}
++
++void bce_vhci_command_queue_destroy(struct bce_vhci_command_queue *cq)
++{
++    spin_lock(&cq->completion_lock);
++    if (cq->completion.result) {
++        memset(cq->completion.result, 0, sizeof(struct bce_vhci_message));
++        cq->completion.result->status = BCE_VHCI_ABORT;
++        complete(&cq->completion.completion);
++        cq->completion.result = NULL;
++    }
++    spin_unlock(&cq->completion_lock);
++    mutex_lock(&cq->mutex);
++    mutex_unlock(&cq->mutex);
++    mutex_destroy(&cq->mutex);
++}
++
++void bce_vhci_command_queue_deliver_completion(struct bce_vhci_command_queue *cq, struct bce_vhci_message *msg)
++{
++    struct bce_vhci_command_queue_completion *c = &cq->completion;
++
++    spin_lock(&cq->completion_lock);
++    if (c->result) {
++        *c->result = *msg;
++        complete(&c->completion);
++        c->result = NULL;
++    }
++    spin_unlock(&cq->completion_lock);
++}
++
++static int __bce_vhci_command_queue_execute(struct bce_vhci_command_queue *cq, struct bce_vhci_message *req,
++        struct bce_vhci_message *res, unsigned long timeout)
++{
++    int status;
++    struct bce_vhci_command_queue_completion *c;
++    struct bce_vhci_message creq;
++    c = &cq->completion;
++
++    if ((status = bce_reserve_submission(cq->mq->sq, &timeout)))
++        return status;
++
++    spin_lock(&cq->completion_lock);
++    c->result = res;
++    reinit_completion(&c->completion);
++    spin_unlock(&cq->completion_lock);
++
++    bce_vhci_message_queue_write(cq->mq, req);
++
++    if (!wait_for_completion_timeout(&c->completion, timeout)) {
++        /* we ran out of time, send cancellation */
++        pr_debug("bce-vhci: command timed out req=%x\n", req->cmd);
++        if ((status = bce_reserve_submission(cq->mq->sq, &timeout)))
++            return status;
++
++        creq = *req;
++        creq.cmd |= 0x4000;
++        bce_vhci_message_queue_write(cq->mq, &creq);
++
++        if (!wait_for_completion_timeout(&c->completion, 1000)) {
++            pr_err("bce-vhci: Possible desync, cmd cancel timed out\n");
++
++            spin_lock(&cq->completion_lock);
++            c->result = NULL;
++            spin_unlock(&cq->completion_lock);
++            return -ETIMEDOUT;
++        }
++        if ((res->cmd & ~0x8000) == creq.cmd)
++            return -ETIMEDOUT;
++        /* reply for the previous command most likely arrived */
++    }
++
++    if ((res->cmd & ~0x8000) != req->cmd) {
++        pr_err("bce-vhci: Possible desync, cmd reply mismatch req=%x, res=%x\n", req->cmd, res->cmd);
++        return -EIO;
++    }
++    if (res->status == BCE_VHCI_SUCCESS)
++        return 0;
++    return res->status;
++}
++
++int bce_vhci_command_queue_execute(struct bce_vhci_command_queue *cq, struct bce_vhci_message *req,
++                                   struct bce_vhci_message *res, unsigned long timeout)
++{
++    int status;
++    mutex_lock(&cq->mutex);
++    status = __bce_vhci_command_queue_execute(cq, req, res, timeout);
++    mutex_unlock(&cq->mutex);
++    return status;
++}
+diff --git a/drivers/staging/apple-bce/vhci/queue.h b/drivers/staging/apple-bce/vhci/queue.h
+new file mode 100644
+index 000000000000..adb705b6ba1d
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/queue.h
+@@ -0,0 +1,76 @@
++#ifndef BCE_VHCI_QUEUE_H
++#define BCE_VHCI_QUEUE_H
++
++#include <linux/completion.h>
++#include "../queue.h"
++
++#define VHCI_EVENT_QUEUE_EL_COUNT 256
++#define VHCI_EVENT_PENDING_COUNT 32
++
++struct bce_vhci;
++struct bce_vhci_event_queue;
++
++enum bce_vhci_message_status {
++    BCE_VHCI_SUCCESS = 1,
++    BCE_VHCI_ERROR = 2,
++    BCE_VHCI_USB_PIPE_STALL = 3,
++    BCE_VHCI_ABORT = 4,
++    BCE_VHCI_BAD_ARGUMENT = 5,
++    BCE_VHCI_OVERRUN = 6,
++    BCE_VHCI_INTERNAL_ERROR = 7,
++    BCE_VHCI_NO_POWER = 8,
++    BCE_VHCI_UNSUPPORTED = 9
++};
++struct bce_vhci_message {
++    u16 cmd;
++    u16 status; // bce_vhci_message_status
++    u32 param1;
++    u64 param2;
++};
++
++struct bce_vhci_message_queue {
++    struct bce_queue_cq *cq;
++    struct bce_queue_sq *sq;
++    struct bce_vhci_message *data;
++    dma_addr_t dma_addr;
++};
++typedef void (*bce_vhci_event_queue_callback)(struct bce_vhci_event_queue *q, struct bce_vhci_message *msg);
++struct bce_vhci_event_queue {
++    struct bce_vhci *vhci;
++    struct bce_queue_sq *sq;
++    struct bce_vhci_message *data;
++    dma_addr_t dma_addr;
++    bce_vhci_event_queue_callback cb;
++    struct completion queue_empty_completion;
++};
++struct bce_vhci_command_queue_completion {
++    struct bce_vhci_message *result;
++    struct completion completion;
++};
++struct bce_vhci_command_queue {
++    struct bce_vhci_message_queue *mq;
++    struct bce_vhci_command_queue_completion completion;
++    struct spinlock completion_lock;
++    struct mutex mutex;
++};
++
++int bce_vhci_message_queue_create(struct bce_vhci *vhci, struct bce_vhci_message_queue *ret, const char *name);
++void bce_vhci_message_queue_destroy(struct bce_vhci *vhci, struct bce_vhci_message_queue *q);
++void bce_vhci_message_queue_write(struct bce_vhci_message_queue *q, struct bce_vhci_message *req);
++
++int __bce_vhci_event_queue_create(struct bce_vhci *vhci, struct bce_vhci_event_queue *ret, const char *name,
++        bce_sq_completion compl);
++int bce_vhci_event_queue_create(struct bce_vhci *vhci, struct bce_vhci_event_queue *ret, const char *name,
++        bce_vhci_event_queue_callback cb);
++void bce_vhci_event_queue_destroy(struct bce_vhci *vhci, struct bce_vhci_event_queue *q);
++void bce_vhci_event_queue_submit_pending(struct bce_vhci_event_queue *q, size_t count);
++void bce_vhci_event_queue_pause(struct bce_vhci_event_queue *q);
++void bce_vhci_event_queue_resume(struct bce_vhci_event_queue *q);
++
++void bce_vhci_command_queue_create(struct bce_vhci_command_queue *ret, struct bce_vhci_message_queue *mq);
++void bce_vhci_command_queue_destroy(struct bce_vhci_command_queue *cq);
++int bce_vhci_command_queue_execute(struct bce_vhci_command_queue *cq, struct bce_vhci_message *req,
++        struct bce_vhci_message *res, unsigned long timeout);
++void bce_vhci_command_queue_deliver_completion(struct bce_vhci_command_queue *cq, struct bce_vhci_message *msg);
++
++#endif //BCE_VHCI_QUEUE_H
+diff --git a/drivers/staging/apple-bce/vhci/transfer.c b/drivers/staging/apple-bce/vhci/transfer.c
+new file mode 100644
+index 000000000000..d77220707492
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/transfer.c
+@@ -0,0 +1,673 @@
++#include "transfer.h"
++#include "../queue.h"
++#include "vhci.h"
++#include "../apple_bce.h"
++#include <linux/usb/hcd.h>
++
++static void bce_vhci_transfer_queue_completion(struct bce_queue_sq *sq);
++static void bce_vhci_transfer_queue_giveback(struct bce_vhci_transfer_queue *q);
++static void bce_vhci_transfer_queue_remove_pending(struct bce_vhci_transfer_queue *q);
++
++static int bce_vhci_urb_init(struct bce_vhci_urb *vurb);
++static int bce_vhci_urb_update(struct bce_vhci_urb *urb, struct bce_vhci_message *msg);
++static int bce_vhci_urb_transfer_completion(struct bce_vhci_urb *urb, struct bce_sq_completion_data *c);
++
++static void bce_vhci_transfer_queue_reset_w(struct work_struct *work);
++
++void bce_vhci_create_transfer_queue(struct bce_vhci *vhci, struct bce_vhci_transfer_queue *q,
++        struct usb_host_endpoint *endp, bce_vhci_device_t dev_addr, enum dma_data_direction dir)
++{
++    char name[0x21];
++    INIT_LIST_HEAD(&q->evq);
++    INIT_LIST_HEAD(&q->giveback_urb_list);
++    spin_lock_init(&q->urb_lock);
++    mutex_init(&q->pause_lock);
++    q->vhci = vhci;
++    q->endp = endp;
++    q->dev_addr = dev_addr;
++    q->endp_addr = (u8) (endp->desc.bEndpointAddress & 0x8F);
++    q->state = BCE_VHCI_ENDPOINT_ACTIVE;
++    q->active = true;
++    q->stalled = false;
++    q->max_active_requests = 1;
++    if (usb_endpoint_type(&endp->desc) == USB_ENDPOINT_XFER_BULK)
++        q->max_active_requests = BCE_VHCI_BULK_MAX_ACTIVE_URBS;
++    q->remaining_active_requests = q->max_active_requests;
++    q->cq = bce_create_cq(vhci->dev, 0x100);
++    INIT_WORK(&q->w_reset, bce_vhci_transfer_queue_reset_w);
++    q->sq_in = NULL;
++    if (dir == DMA_FROM_DEVICE || dir == DMA_BIDIRECTIONAL) {
++        snprintf(name, sizeof(name), "VHC1-%i-%02x", dev_addr, 0x80 | usb_endpoint_num(&endp->desc));
++        q->sq_in = bce_create_sq(vhci->dev, q->cq, name, 0x100, DMA_FROM_DEVICE,
++                                 bce_vhci_transfer_queue_completion, q);
++    }
++    q->sq_out = NULL;
++    if (dir == DMA_TO_DEVICE || dir == DMA_BIDIRECTIONAL) {
++        snprintf(name, sizeof(name), "VHC1-%i-%02x", dev_addr, usb_endpoint_num(&endp->desc));
++        q->sq_out = bce_create_sq(vhci->dev, q->cq, name, 0x100, DMA_TO_DEVICE,
++                                  bce_vhci_transfer_queue_completion, q);
++    }
++}
++
++void bce_vhci_destroy_transfer_queue(struct bce_vhci *vhci, struct bce_vhci_transfer_queue *q)
++{
++    bce_vhci_transfer_queue_giveback(q);
++    bce_vhci_transfer_queue_remove_pending(q);
++    if (q->sq_in)
++        bce_destroy_sq(vhci->dev, q->sq_in);
++    if (q->sq_out)
++        bce_destroy_sq(vhci->dev, q->sq_out);
++    bce_destroy_cq(vhci->dev, q->cq);
++}
++
++static inline bool bce_vhci_transfer_queue_can_init_urb(struct bce_vhci_transfer_queue *q)
++{
++    return q->remaining_active_requests > 0;
++}
++
++static void bce_vhci_transfer_queue_defer_event(struct bce_vhci_transfer_queue *q, struct bce_vhci_message *msg)
++{
++    struct bce_vhci_list_message *lm;
++    lm = kmalloc(sizeof(struct bce_vhci_list_message), GFP_KERNEL);
++    INIT_LIST_HEAD(&lm->list);
++    lm->msg = *msg;
++    list_add_tail(&lm->list, &q->evq);
++}
++
++static void bce_vhci_transfer_queue_giveback(struct bce_vhci_transfer_queue *q)
++{
++    unsigned long flags;
++    struct urb *urb;
++    spin_lock_irqsave(&q->urb_lock, flags);
++    while (!list_empty(&q->giveback_urb_list)) {
++        urb = list_first_entry(&q->giveback_urb_list, struct urb, urb_list);
++        list_del(&urb->urb_list);
++
++        spin_unlock_irqrestore(&q->urb_lock, flags);
++        usb_hcd_giveback_urb(q->vhci->hcd, urb, urb->status);
++        spin_lock_irqsave(&q->urb_lock, flags);
++    }
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++}
++
++static void bce_vhci_transfer_queue_init_pending_urbs(struct bce_vhci_transfer_queue *q);
++
++static void bce_vhci_transfer_queue_deliver_pending(struct bce_vhci_transfer_queue *q)
++{
++    struct urb *urb;
++    struct bce_vhci_list_message *lm;
++
++    while (!list_empty(&q->endp->urb_list) && !list_empty(&q->evq)) {
++        urb = list_first_entry(&q->endp->urb_list, struct urb, urb_list);
++
++        lm = list_first_entry(&q->evq, struct bce_vhci_list_message, list);
++        if (bce_vhci_urb_update(urb->hcpriv, &lm->msg) == -EAGAIN)
++            break;
++        list_del(&lm->list);
++        kfree(lm);
++    }
++
++    /* some of the URBs could have been completed, so initialize more URBs if possible */
++    bce_vhci_transfer_queue_init_pending_urbs(q);
++}
++
++static void bce_vhci_transfer_queue_remove_pending(struct bce_vhci_transfer_queue *q)
++{
++    unsigned long flags;
++    struct bce_vhci_list_message *lm;
++    spin_lock_irqsave(&q->urb_lock, flags);
++    while (!list_empty(&q->evq)) {
++        lm = list_first_entry(&q->evq, struct bce_vhci_list_message, list);
++        list_del(&lm->list);
++        kfree(lm);
++    }
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++}
++
++void bce_vhci_transfer_queue_event(struct bce_vhci_transfer_queue *q, struct bce_vhci_message *msg)
++{
++    unsigned long flags;
++    struct bce_vhci_urb *turb;
++    struct urb *urb;
++    spin_lock_irqsave(&q->urb_lock, flags);
++    bce_vhci_transfer_queue_deliver_pending(q);
++
++    if (msg->cmd == BCE_VHCI_CMD_TRANSFER_REQUEST &&
++        (!list_empty(&q->evq) || list_empty(&q->endp->urb_list))) {
++        bce_vhci_transfer_queue_defer_event(q, msg);
++        goto complete;
++    }
++    if (list_empty(&q->endp->urb_list)) {
++        pr_err("bce-vhci: [%02x] Unexpected transfer queue event\n", q->endp_addr);
++        goto complete;
++    }
++    urb = list_first_entry(&q->endp->urb_list, struct urb, urb_list);
++    turb = urb->hcpriv;
++    if (bce_vhci_urb_update(turb, msg) == -EAGAIN) {
++        bce_vhci_transfer_queue_defer_event(q, msg);
++    } else {
++        bce_vhci_transfer_queue_init_pending_urbs(q);
++    }
++
++complete:
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    bce_vhci_transfer_queue_giveback(q);
++}
++
++static void bce_vhci_transfer_queue_completion(struct bce_queue_sq *sq)
++{
++    unsigned long flags;
++    struct bce_sq_completion_data *c;
++    struct urb *urb;
++    struct bce_vhci_transfer_queue *q = sq->userdata;
++    spin_lock_irqsave(&q->urb_lock, flags);
++    while ((c = bce_next_completion(sq))) {
++        if (c->status == BCE_COMPLETION_ABORTED) { /* We flushed the queue */
++            pr_debug("bce-vhci: [%02x] Got an abort completion\n", q->endp_addr);
++            bce_notify_submission_complete(sq);
++            continue;
++        }
++        if (list_empty(&q->endp->urb_list)) {
++            pr_err("bce-vhci: [%02x] Got a completion while no requests are pending\n", q->endp_addr);
++            continue;
++        }
++        pr_debug("bce-vhci: [%02x] Got a transfer queue completion\n", q->endp_addr);
++        urb = list_first_entry(&q->endp->urb_list, struct urb, urb_list);
++        bce_vhci_urb_transfer_completion(urb->hcpriv, c);
++        bce_notify_submission_complete(sq);
++    }
++    bce_vhci_transfer_queue_deliver_pending(q);
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    bce_vhci_transfer_queue_giveback(q);
++}
++
++int bce_vhci_transfer_queue_do_pause(struct bce_vhci_transfer_queue *q)
++{
++    unsigned long flags;
++    int status;
++    u8 endp_addr = (u8) (q->endp->desc.bEndpointAddress & 0x8F);
++    spin_lock_irqsave(&q->urb_lock, flags);
++    q->active = false;
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    if (q->sq_out) {
++        pr_err("bce-vhci: Not implemented: wait for pending output requests\n");
++    }
++    bce_vhci_transfer_queue_remove_pending(q);
++    if ((status = bce_vhci_cmd_endpoint_set_state(
++            &q->vhci->cq, q->dev_addr, endp_addr, BCE_VHCI_ENDPOINT_PAUSED, &q->state)))
++        return status;
++    if (q->state != BCE_VHCI_ENDPOINT_PAUSED)
++        return -EINVAL;
++    if (q->sq_in)
++        bce_cmd_flush_memory_queue(q->vhci->dev->cmd_cmdq, (u16) q->sq_in->qid);
++    if (q->sq_out)
++        bce_cmd_flush_memory_queue(q->vhci->dev->cmd_cmdq, (u16) q->sq_out->qid);
++    return 0;
++}
++
++static void bce_vhci_urb_resume(struct bce_vhci_urb *urb);
++
++int bce_vhci_transfer_queue_do_resume(struct bce_vhci_transfer_queue *q)
++{
++    unsigned long flags;
++    int status;
++    struct urb *urb, *urbt;
++    struct bce_vhci_urb *vurb;
++    u8 endp_addr = (u8) (q->endp->desc.bEndpointAddress & 0x8F);
++    if ((status = bce_vhci_cmd_endpoint_set_state(
++            &q->vhci->cq, q->dev_addr, endp_addr, BCE_VHCI_ENDPOINT_ACTIVE, &q->state)))
++        return status;
++    if (q->state != BCE_VHCI_ENDPOINT_ACTIVE)
++        return -EINVAL;
++    spin_lock_irqsave(&q->urb_lock, flags);
++    q->active = true;
++    list_for_each_entry_safe(urb, urbt, &q->endp->urb_list, urb_list) {
++        vurb = urb->hcpriv;
++        if (vurb->state == BCE_VHCI_URB_INIT_PENDING) {
++            if (!bce_vhci_transfer_queue_can_init_urb(q))
++                break;
++            bce_vhci_urb_init(vurb);
++        } else {
++            bce_vhci_urb_resume(vurb);
++        }
++    }
++    bce_vhci_transfer_queue_deliver_pending(q);
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    return 0;
++}
++
++int bce_vhci_transfer_queue_pause(struct bce_vhci_transfer_queue *q, enum bce_vhci_pause_source src)
++{
++    int ret = 0;
++    mutex_lock(&q->pause_lock);
++    if ((q->paused_by & src) != src) {
++        if (!q->paused_by)
++            ret = bce_vhci_transfer_queue_do_pause(q);
++        if (!ret)
++            q->paused_by |= src;
++    }
++    mutex_unlock(&q->pause_lock);
++    return ret;
++}
++
++int bce_vhci_transfer_queue_resume(struct bce_vhci_transfer_queue *q, enum bce_vhci_pause_source src)
++{
++    int ret = 0;
++    mutex_lock(&q->pause_lock);
++    if (q->paused_by & src) {
++        if (!(q->paused_by & ~src))
++            ret = bce_vhci_transfer_queue_do_resume(q);
++        if (!ret)
++            q->paused_by &= ~src;
++    }
++    mutex_unlock(&q->pause_lock);
++    return ret;
++}
++
++static void bce_vhci_transfer_queue_reset_w(struct work_struct *work)
++{
++    unsigned long flags;
++    struct bce_vhci_transfer_queue *q = container_of(work, struct bce_vhci_transfer_queue, w_reset);
++
++    mutex_lock(&q->pause_lock);
++    spin_lock_irqsave(&q->urb_lock, flags);
++    if (!q->stalled) {
++        spin_unlock_irqrestore(&q->urb_lock, flags);
++        mutex_unlock(&q->pause_lock);
++        return;
++    }
++    q->active = false;
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    q->paused_by |= BCE_VHCI_PAUSE_INTERNAL_WQ;
++    bce_vhci_transfer_queue_remove_pending(q);
++    if (q->sq_in)
++        bce_cmd_flush_memory_queue(q->vhci->dev->cmd_cmdq, (u16) q->sq_in->qid);
++    if (q->sq_out)
++        bce_cmd_flush_memory_queue(q->vhci->dev->cmd_cmdq, (u16) q->sq_out->qid);
++    bce_vhci_cmd_endpoint_reset(&q->vhci->cq, q->dev_addr, (u8) (q->endp->desc.bEndpointAddress & 0x8F));
++    spin_lock_irqsave(&q->urb_lock, flags);
++    q->stalled = false;
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    mutex_unlock(&q->pause_lock);
++    bce_vhci_transfer_queue_resume(q, BCE_VHCI_PAUSE_INTERNAL_WQ);
++}
++
++void bce_vhci_transfer_queue_request_reset(struct bce_vhci_transfer_queue *q)
++{
++    queue_work(q->vhci->tq_state_wq, &q->w_reset);
++}
++
++static void bce_vhci_transfer_queue_init_pending_urbs(struct bce_vhci_transfer_queue *q)
++{
++    struct urb *urb, *urbt;
++    struct bce_vhci_urb *vurb;
++    list_for_each_entry_safe(urb, urbt, &q->endp->urb_list, urb_list) {
++        vurb = urb->hcpriv;
++        if (!bce_vhci_transfer_queue_can_init_urb(q))
++            break;
++        if (vurb->state == BCE_VHCI_URB_INIT_PENDING)
++            bce_vhci_urb_init(vurb);
++    }
++}
++
++
++
++static int bce_vhci_urb_data_start(struct bce_vhci_urb *urb, unsigned long *timeout);
++
++int bce_vhci_urb_create(struct bce_vhci_transfer_queue *q, struct urb *urb)
++{
++    unsigned long flags;
++    int status = 0;
++    struct bce_vhci_urb *vurb;
++    vurb = kzalloc(sizeof(struct bce_vhci_urb), GFP_KERNEL);
++    urb->hcpriv = vurb;
++
++    vurb->q = q;
++    vurb->urb = urb;
++    vurb->dir = usb_urb_dir_in(urb) ? DMA_FROM_DEVICE : DMA_TO_DEVICE;
++    vurb->is_control = (usb_endpoint_num(&urb->ep->desc) == 0);
++
++    spin_lock_irqsave(&q->urb_lock, flags);
++    status = usb_hcd_link_urb_to_ep(q->vhci->hcd, urb);
++    if (status) {
++        spin_unlock_irqrestore(&q->urb_lock, flags);
++        urb->hcpriv = NULL;
++        kfree(vurb);
++        return status;
++    }
++
++    if (q->active) {
++        if (bce_vhci_transfer_queue_can_init_urb(vurb->q))
++            status = bce_vhci_urb_init(vurb);
++        else
++            vurb->state = BCE_VHCI_URB_INIT_PENDING;
++    } else {
++        if (q->stalled)
++            bce_vhci_transfer_queue_request_reset(q);
++        vurb->state = BCE_VHCI_URB_INIT_PENDING;
++    }
++    if (status) {
++        usb_hcd_unlink_urb_from_ep(q->vhci->hcd, urb);
++        urb->hcpriv = NULL;
++        kfree(vurb);
++    } else {
++        bce_vhci_transfer_queue_deliver_pending(q);
++    }
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++    pr_debug("bce-vhci: [%02x] URB enqueued (dir = %s, size = %i)\n", q->endp_addr,
++            usb_urb_dir_in(urb) ? "IN" : "OUT", urb->transfer_buffer_length);
++    return status;
++}
++
++static int bce_vhci_urb_init(struct bce_vhci_urb *vurb)
++{
++    int status = 0;
++
++    if (vurb->q->remaining_active_requests == 0) {
++        pr_err("bce-vhci: cannot init request (remaining_active_requests = 0)\n");
++        return -EINVAL;
++    }
++
++    if (vurb->is_control) {
++        vurb->state = BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_REQUEST;
++    } else {
++        status = bce_vhci_urb_data_start(vurb, NULL);
++    }
++
++    if (!status) {
++        --vurb->q->remaining_active_requests;
++    }
++    return status;
++}
++
++static void bce_vhci_urb_complete(struct bce_vhci_urb *urb, int status)
++{
++    struct bce_vhci_transfer_queue *q = urb->q;
++    struct bce_vhci *vhci = q->vhci;
++    struct urb *real_urb = urb->urb;
++    pr_debug("bce-vhci: [%02x] URB complete %i\n", q->endp_addr, status);
++    usb_hcd_unlink_urb_from_ep(vhci->hcd, real_urb);
++    real_urb->hcpriv = NULL;
++    real_urb->status = status;
++    if (urb->state != BCE_VHCI_URB_INIT_PENDING)
++        ++urb->q->remaining_active_requests;
++    kfree(urb);
++    list_add_tail(&real_urb->urb_list, &q->giveback_urb_list);
++}
++
++int bce_vhci_urb_request_cancel(struct bce_vhci_transfer_queue *q, struct urb *urb, int status)
++{
++    struct bce_vhci_urb *vurb;
++    unsigned long flags;
++    int ret;
++    enum bce_vhci_urb_state old_state;
++
++    spin_lock_irqsave(&q->urb_lock, flags);
++    if ((ret = usb_hcd_check_unlink_urb(q->vhci->hcd, urb, status))) {
++        spin_unlock_irqrestore(&q->urb_lock, flags);
++        return ret;
++    }
++
++    vurb = urb->hcpriv;
++
++    old_state = vurb->state; /* save old state to use later because we'll set state as cancelled */
++
++    if (old_state == BCE_VHCI_URB_CANCELLED) {
++        spin_unlock_irqrestore(&q->urb_lock, flags);
++        pr_debug("bce-vhci: URB %p is already cancelled, skipping\n", urb);
++        return 0;
++    }
++
++    vurb->state = BCE_VHCI_URB_CANCELLED;
++
++    /* If the URB wasn't posted to the device yet, we can still remove it on the host without pausing the queue. */
++    if (old_state != BCE_VHCI_URB_INIT_PENDING) {
++        pr_debug("bce-vhci: [%02x] Cancelling URB\n", q->endp_addr);
++
++        spin_unlock_irqrestore(&q->urb_lock, flags);
++        bce_vhci_transfer_queue_pause(q, BCE_VHCI_PAUSE_INTERNAL_WQ);
++        spin_lock_irqsave(&q->urb_lock, flags);
++
++        ++q->remaining_active_requests;
++    }
++
++    usb_hcd_unlink_urb_from_ep(q->vhci->hcd, urb);
++
++    spin_unlock_irqrestore(&q->urb_lock, flags);
++
++    usb_hcd_giveback_urb(q->vhci->hcd, urb, status);
++
++    if (old_state != BCE_VHCI_URB_INIT_PENDING)
++        bce_vhci_transfer_queue_resume(q, BCE_VHCI_PAUSE_INTERNAL_WQ);
++
++    kfree(vurb);
++
++    return 0;
++}
++
++static int bce_vhci_urb_data_transfer_in(struct bce_vhci_urb *urb, unsigned long *timeout)
++{
++    struct bce_vhci_message msg;
++    struct bce_qe_submission *s;
++    u32 tr_len;
++    int reservation1, reservation2 = -EFAULT;
++
++    pr_debug("bce-vhci: [%02x] DMA from device %llx %x\n", urb->q->endp_addr,
++             (u64) urb->urb->transfer_dma, urb->urb->transfer_buffer_length);
++
++    /* Reserve both a message and a submission, so we don't run into issues later. */
++    reservation1 = bce_reserve_submission(urb->q->vhci->msg_asynchronous.sq, timeout);
++    if (!reservation1)
++        reservation2 = bce_reserve_submission(urb->q->sq_in, timeout);
++    if (reservation1 || reservation2) {
++        pr_err("bce-vhci: Failed to reserve a submission for URB data transfer\n");
++        if (!reservation1)
++            bce_cancel_submission_reservation(urb->q->vhci->msg_asynchronous.sq);
++        return -ENOMEM;
++    }
++
++    urb->send_offset = urb->receive_offset;
++
++    tr_len = urb->urb->transfer_buffer_length - urb->send_offset;
++
++    spin_lock(&urb->q->vhci->msg_asynchronous_lock);
++    msg.cmd = BCE_VHCI_CMD_TRANSFER_REQUEST;
++    msg.status = 0;
++    msg.param1 = ((urb->urb->ep->desc.bEndpointAddress & 0x8Fu) << 8) | urb->q->dev_addr;
++    msg.param2 = tr_len;
++    bce_vhci_message_queue_write(&urb->q->vhci->msg_asynchronous, &msg);
++    spin_unlock(&urb->q->vhci->msg_asynchronous_lock);
++
++    s = bce_next_submission(urb->q->sq_in);
++    bce_set_submission_single(s, urb->urb->transfer_dma + urb->send_offset, tr_len);
++    bce_submit_to_device(urb->q->sq_in);
++
++    urb->state = BCE_VHCI_URB_WAITING_FOR_COMPLETION;
++    return 0;
++}
++
++static int bce_vhci_urb_data_start(struct bce_vhci_urb *urb, unsigned long *timeout)
++{
++    if (urb->dir == DMA_TO_DEVICE) {
++        if (urb->urb->transfer_buffer_length > 0)
++            urb->state = BCE_VHCI_URB_WAITING_FOR_TRANSFER_REQUEST;
++        else
++            urb->state = BCE_VHCI_URB_DATA_TRANSFER_COMPLETE;
++        return 0;
++    } else {
++        return bce_vhci_urb_data_transfer_in(urb, timeout);
++    }
++}
++
++static int bce_vhci_urb_send_out_data(struct bce_vhci_urb *urb, dma_addr_t addr, size_t size)
++{
++    struct bce_qe_submission *s;
++    unsigned long timeout = 0;
++    if (bce_reserve_submission(urb->q->sq_out, &timeout)) {
++        pr_err("bce-vhci: Failed to reserve a submission for URB data transfer\n");
++        return -EPIPE;
++    }
++
++    pr_debug("bce-vhci: [%02x] DMA to device %llx %lx\n", urb->q->endp_addr, (u64) addr, size);
++
++    s = bce_next_submission(urb->q->sq_out);
++    bce_set_submission_single(s, addr, size);
++    bce_submit_to_device(urb->q->sq_out);
++    return 0;
++}
++
++static int bce_vhci_urb_data_update(struct bce_vhci_urb *urb, struct bce_vhci_message *msg)
++{
++    u32 tr_len;
++    int status;
++    if (urb->state == BCE_VHCI_URB_WAITING_FOR_TRANSFER_REQUEST) {
++        if (msg->cmd == BCE_VHCI_CMD_TRANSFER_REQUEST) {
++            tr_len = min(urb->urb->transfer_buffer_length - urb->send_offset, (u32) msg->param2);
++            if ((status = bce_vhci_urb_send_out_data(urb, urb->urb->transfer_dma + urb->send_offset, tr_len)))
++                return status;
++            urb->send_offset += tr_len;
++            urb->state = BCE_VHCI_URB_WAITING_FOR_COMPLETION;
++            return 0;
++        }
++    }
++
++    /* 0x1000 in out queues aren't really unexpected */
++    if (msg->cmd == BCE_VHCI_CMD_TRANSFER_REQUEST && urb->q->sq_out != NULL)
++        return -EAGAIN;
++    pr_err("bce-vhci: [%02x] %s URB unexpected message (state = %x, msg: %x %x %x %llx)\n",
++            urb->q->endp_addr, (urb->is_control ? "Control (data update)" : "Data"), urb->state,
++            msg->cmd, msg->status, msg->param1, msg->param2);
++    return -EAGAIN;
++}
++
++static int bce_vhci_urb_data_transfer_completion(struct bce_vhci_urb *urb, struct bce_sq_completion_data *c)
++{
++    if (urb->state == BCE_VHCI_URB_WAITING_FOR_COMPLETION) {
++        urb->receive_offset += c->data_size;
++        if (urb->dir == DMA_FROM_DEVICE || urb->receive_offset >= urb->urb->transfer_buffer_length) {
++            urb->urb->actual_length = (u32) urb->receive_offset;
++            urb->state = BCE_VHCI_URB_DATA_TRANSFER_COMPLETE;
++            if (!urb->is_control) {
++                bce_vhci_urb_complete(urb, 0);
++                return -ENOENT;
++            }
++        }
++    } else {
++        pr_err("bce-vhci: [%02x] Data URB unexpected completion\n", urb->q->endp_addr);
++    }
++    return 0;
++}
++
++
++static int bce_vhci_urb_control_check_status(struct bce_vhci_urb *urb)
++{
++    struct bce_vhci_transfer_queue *q = urb->q;
++    if (urb->received_status == 0)
++        return 0;
++    if (urb->state == BCE_VHCI_URB_DATA_TRANSFER_COMPLETE ||
++        (urb->received_status != BCE_VHCI_SUCCESS && urb->state != BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_REQUEST &&
++        urb->state != BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_COMPLETION)) {
++        urb->state = BCE_VHCI_URB_CONTROL_COMPLETE;
++        if (urb->received_status != BCE_VHCI_SUCCESS) {
++            pr_err("bce-vhci: [%02x] URB failed: %x\n", urb->q->endp_addr, urb->received_status);
++            urb->q->active = false;
++            urb->q->stalled = true;
++            bce_vhci_urb_complete(urb, -EPIPE);
++            if (!list_empty(&q->endp->urb_list))
++                bce_vhci_transfer_queue_request_reset(q);
++            return -ENOENT;
++        }
++        bce_vhci_urb_complete(urb, 0);
++        return -ENOENT;
++    }
++    return 0;
++}
++
++static int bce_vhci_urb_control_update(struct bce_vhci_urb *urb, struct bce_vhci_message *msg)
++{
++    int status;
++    if (msg->cmd == BCE_VHCI_CMD_CONTROL_TRANSFER_STATUS) {
++        urb->received_status = msg->status;
++        return bce_vhci_urb_control_check_status(urb);
++    }
++
++    if (urb->state == BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_REQUEST) {
++        if (msg->cmd == BCE_VHCI_CMD_TRANSFER_REQUEST) {
++            if (bce_vhci_urb_send_out_data(urb, urb->urb->setup_dma, sizeof(struct usb_ctrlrequest))) {
++                pr_err("bce-vhci: [%02x] Failed to start URB setup transfer\n", urb->q->endp_addr);
++                return 0; /* TODO: fail the URB? */
++            }
++            urb->state = BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_COMPLETION;
++            pr_debug("bce-vhci: [%02x] Sent setup %llx\n", urb->q->endp_addr, urb->urb->setup_dma);
++            return 0;
++        }
++    } else if (urb->state == BCE_VHCI_URB_WAITING_FOR_TRANSFER_REQUEST ||
++               urb->state == BCE_VHCI_URB_WAITING_FOR_COMPLETION) {
++        if ((status = bce_vhci_urb_data_update(urb, msg)))
++            return status;
++        return bce_vhci_urb_control_check_status(urb);
++    }
++
++    /* 0x1000 in out queues aren't really unexpected */
++    if (msg->cmd == BCE_VHCI_CMD_TRANSFER_REQUEST && urb->q->sq_out != NULL)
++        return -EAGAIN;
++    pr_err("bce-vhci: [%02x] Control URB unexpected message (state = %x, msg: %x %x %x %llx)\n", urb->q->endp_addr,
++            urb->state, msg->cmd, msg->status, msg->param1, msg->param2);
++    return -EAGAIN;
++}
++
++static int bce_vhci_urb_control_transfer_completion(struct bce_vhci_urb *urb, struct bce_sq_completion_data *c)
++{
++    int status;
++    unsigned long timeout;
++
++    if (urb->state == BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_COMPLETION) {
++        if (c->data_size != sizeof(struct usb_ctrlrequest))
++            pr_err("bce-vhci: [%02x] transfer complete data size mistmatch for usb_ctrlrequest (%llx instead of %lx)\n",
++                   urb->q->endp_addr, c->data_size, sizeof(struct usb_ctrlrequest));
++
++        timeout = 1000;
++        status = bce_vhci_urb_data_start(urb, &timeout);
++        if (status) {
++            bce_vhci_urb_complete(urb, status);
++            return -ENOENT;
++        }
++        return 0;
++    } else if (urb->state == BCE_VHCI_URB_WAITING_FOR_TRANSFER_REQUEST ||
++               urb->state == BCE_VHCI_URB_WAITING_FOR_COMPLETION) {
++        if ((status = bce_vhci_urb_data_transfer_completion(urb, c)))
++            return status;
++        return bce_vhci_urb_control_check_status(urb);
++    } else {
++        pr_err("bce-vhci: [%02x] Control URB unexpected completion (state = %x)\n", urb->q->endp_addr, urb->state);
++    }
++    return 0;
++}
++
++static int bce_vhci_urb_update(struct bce_vhci_urb *urb, struct bce_vhci_message *msg)
++{
++    if (urb->state == BCE_VHCI_URB_INIT_PENDING)
++        return -EAGAIN;
++    if (urb->is_control)
++        return bce_vhci_urb_control_update(urb, msg);
++    else
++        return bce_vhci_urb_data_update(urb, msg);
++}
++
++static int bce_vhci_urb_transfer_completion(struct bce_vhci_urb *urb, struct bce_sq_completion_data *c)
++{
++    if (urb->is_control)
++        return bce_vhci_urb_control_transfer_completion(urb, c);
++    else
++        return bce_vhci_urb_data_transfer_completion(urb, c);
++}
++
++static void bce_vhci_urb_resume(struct bce_vhci_urb *urb)
++{
++    int status = 0;
++    if (urb->state == BCE_VHCI_URB_WAITING_FOR_COMPLETION) {
++        status = bce_vhci_urb_data_transfer_in(urb, NULL);
++    }
++    if (status)
++        bce_vhci_urb_complete(urb, status);
++}
+diff --git a/drivers/staging/apple-bce/vhci/transfer.h b/drivers/staging/apple-bce/vhci/transfer.h
+new file mode 100644
+index 000000000000..b5403d5703ed
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/transfer.h
+@@ -0,0 +1,75 @@
++#ifndef BCEDRIVER_TRANSFER_H
++#define BCEDRIVER_TRANSFER_H
++
++#include <linux/usb.h>
++#include "queue.h"
++#include "command.h"
++#include "../queue.h"
++
++struct bce_vhci_list_message {
++    struct list_head list;
++    struct bce_vhci_message msg;
++};
++enum bce_vhci_pause_source {
++    BCE_VHCI_PAUSE_INTERNAL_WQ = 1,
++    BCE_VHCI_PAUSE_FIRMWARE = 2,
++    BCE_VHCI_PAUSE_SUSPEND = 4,
++    BCE_VHCI_PAUSE_SHUTDOWN = 8
++};
++struct bce_vhci_transfer_queue {
++    struct bce_vhci *vhci;
++    struct usb_host_endpoint *endp;
++    enum bce_vhci_endpoint_state state;
++    u32 max_active_requests, remaining_active_requests;
++    bool active, stalled;
++    u32 paused_by;
++    bce_vhci_device_t dev_addr;
++    u8 endp_addr;
++    struct bce_queue_cq *cq;
++    struct bce_queue_sq *sq_in;
++    struct bce_queue_sq *sq_out;
++    struct list_head evq;
++    struct spinlock urb_lock;
++    struct mutex pause_lock;
++    struct list_head giveback_urb_list;
++
++    struct work_struct w_reset;
++};
++enum bce_vhci_urb_state {
++    BCE_VHCI_URB_INIT_PENDING,
++
++    BCE_VHCI_URB_WAITING_FOR_TRANSFER_REQUEST,
++    BCE_VHCI_URB_WAITING_FOR_COMPLETION,
++    BCE_VHCI_URB_DATA_TRANSFER_COMPLETE,
++
++    BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_REQUEST,
++    BCE_VHCI_URB_CONTROL_WAITING_FOR_SETUP_COMPLETION,
++    BCE_VHCI_URB_CONTROL_COMPLETE,
++
++    BCE_VHCI_URB_CANCELLED
++};
++struct bce_vhci_urb {
++    struct urb *urb;
++    struct bce_vhci_transfer_queue *q;
++    enum dma_data_direction dir;
++    bool is_control;
++    enum bce_vhci_urb_state state;
++    int received_status;
++    u32 send_offset;
++    u32 receive_offset;
++};
++
++void bce_vhci_create_transfer_queue(struct bce_vhci *vhci, struct bce_vhci_transfer_queue *q,
++        struct usb_host_endpoint *endp, bce_vhci_device_t dev_addr, enum dma_data_direction dir);
++void bce_vhci_destroy_transfer_queue(struct bce_vhci *vhci, struct bce_vhci_transfer_queue *q);
++void bce_vhci_transfer_queue_event(struct bce_vhci_transfer_queue *q, struct bce_vhci_message *msg);
++int bce_vhci_transfer_queue_do_pause(struct bce_vhci_transfer_queue *q);
++int bce_vhci_transfer_queue_do_resume(struct bce_vhci_transfer_queue *q);
++int bce_vhci_transfer_queue_pause(struct bce_vhci_transfer_queue *q, enum bce_vhci_pause_source src);
++int bce_vhci_transfer_queue_resume(struct bce_vhci_transfer_queue *q, enum bce_vhci_pause_source src);
++void bce_vhci_transfer_queue_request_reset(struct bce_vhci_transfer_queue *q);
++
++int bce_vhci_urb_create(struct bce_vhci_transfer_queue *q, struct urb *urb);
++int bce_vhci_urb_request_cancel(struct bce_vhci_transfer_queue *q, struct urb *urb, int status);
++
++#endif //BCEDRIVER_TRANSFER_H
+diff --git a/drivers/staging/apple-bce/vhci/vhci.c b/drivers/staging/apple-bce/vhci/vhci.c
+new file mode 100644
+index 000000000000..3394e0aa2eef
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/vhci.c
+@@ -0,0 +1,763 @@
++#include "vhci.h"
++#include "../apple_bce.h"
++#include "command.h"
++#include <linux/usb.h>
++#include <linux/usb/hcd.h>
++#include <linux/module.h>
++#include <linux/version.h>
++
++static dev_t bce_vhci_chrdev;
++static struct class *bce_vhci_class;
++static const struct hc_driver bce_vhci_driver;
++static u16 bce_vhci_port_mask = U16_MAX;
++
++static int bce_vhci_create_event_queues(struct bce_vhci *vhci);
++static void bce_vhci_destroy_event_queues(struct bce_vhci *vhci);
++static int bce_vhci_create_message_queues(struct bce_vhci *vhci);
++static void bce_vhci_destroy_message_queues(struct bce_vhci *vhci);
++static void bce_vhci_handle_firmware_events_w(struct work_struct *ws);
++static void bce_vhci_firmware_event_completion(struct bce_queue_sq *sq);
++
++int bce_vhci_create(struct apple_bce_device *dev, struct bce_vhci *vhci)
++{
++    int status;
++
++    spin_lock_init(&vhci->hcd_spinlock);
++
++    vhci->dev = dev;
++
++    vhci->vdevt = bce_vhci_chrdev;
++    vhci->vdev = device_create(bce_vhci_class, dev->dev, vhci->vdevt, NULL, "bce-vhci");
++    if (IS_ERR_OR_NULL(vhci->vdev)) {
++        status = PTR_ERR(vhci->vdev);
++        goto fail_dev;
++    }
++
++    if ((status = bce_vhci_create_message_queues(vhci)))
++        goto fail_mq;
++    if ((status = bce_vhci_create_event_queues(vhci)))
++        goto fail_eq;
++
++    vhci->tq_state_wq = alloc_ordered_workqueue("bce-vhci-tq-state", 0);
++    INIT_WORK(&vhci->w_fw_events, bce_vhci_handle_firmware_events_w);
++
++    vhci->hcd = usb_create_hcd(&bce_vhci_driver, vhci->vdev, "bce-vhci");
++    if (!vhci->hcd) {
++        status = -ENOMEM;
++        goto fail_hcd;
++    }
++    vhci->hcd->self.sysdev = &dev->pci->dev;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
++    vhci->hcd->self.uses_dma = 1;
++#endif
++    *((struct bce_vhci **) vhci->hcd->hcd_priv) = vhci;
++    vhci->hcd->speed = HCD_USB2;
++
++    if ((status = usb_add_hcd(vhci->hcd, 0, 0)))
++        goto fail_hcd;
++
++    return 0;
++
++fail_hcd:
++    bce_vhci_destroy_event_queues(vhci);
++fail_eq:
++    bce_vhci_destroy_message_queues(vhci);
++fail_mq:
++    device_destroy(bce_vhci_class, vhci->vdevt);
++fail_dev:
++    if (!status)
++        status = -EINVAL;
++    return status;
++}
++
++void bce_vhci_destroy(struct bce_vhci *vhci)
++{
++    usb_remove_hcd(vhci->hcd);
++    bce_vhci_destroy_event_queues(vhci);
++    bce_vhci_destroy_message_queues(vhci);
++    device_destroy(bce_vhci_class, vhci->vdevt);
++}
++
++struct bce_vhci *bce_vhci_from_hcd(struct usb_hcd *hcd)
++{
++    return *((struct bce_vhci **) hcd->hcd_priv);
++}
++
++int bce_vhci_start(struct usb_hcd *hcd)
++{
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    int status;
++    u16 port_mask = 0;
++    bce_vhci_port_t port_no = 0;
++    if ((status = bce_vhci_cmd_controller_enable(&vhci->cq, 1, &port_mask)))
++        return status;
++    vhci->port_mask = port_mask;
++    vhci->port_power_mask = 0;
++    if ((status = bce_vhci_cmd_controller_start(&vhci->cq)))
++        return status;
++    port_mask = vhci->port_mask;
++    while (port_mask) {
++        port_no += 1;
++        port_mask >>= 1;
++    }
++    vhci->port_count = port_no;
++    return 0;
++}
++
++void bce_vhci_stop(struct usb_hcd *hcd)
++{
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    bce_vhci_cmd_controller_disable(&vhci->cq);
++}
++
++static int bce_vhci_hub_status_data(struct usb_hcd *hcd, char *buf)
++{
++    return 0;
++}
++
++static int bce_vhci_reset_device(struct bce_vhci *vhci, int index, u16 timeout);
++
++static int bce_vhci_hub_control(struct usb_hcd *hcd, u16 typeReq, u16 wValue, u16 wIndex, char *buf, u16 wLength)
++{
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    int status;
++    struct usb_hub_descriptor *hd;
++    struct usb_hub_status *hs;
++    struct usb_port_status *ps;
++    u32 port_status;
++    // pr_info("bce-vhci: bce_vhci_hub_control %x %i %i [bufl=%i]\n", typeReq, wValue, wIndex, wLength);
++    if (typeReq == GetHubDescriptor && wLength >= sizeof(struct usb_hub_descriptor)) {
++        hd = (struct usb_hub_descriptor *) buf;
++        memset(hd, 0, sizeof(*hd));
++        hd->bDescLength = sizeof(struct usb_hub_descriptor);
++        hd->bDescriptorType = USB_DT_HUB;
++        hd->bNbrPorts = (u8) vhci->port_count;
++        hd->wHubCharacteristics = HUB_CHAR_INDV_PORT_LPSM | HUB_CHAR_INDV_PORT_OCPM;
++        hd->bPwrOn2PwrGood = 0;
++        hd->bHubContrCurrent = 0;
++        return 0;
++    } else if (typeReq == GetHubStatus && wLength >= sizeof(struct usb_hub_status)) {
++        hs = (struct usb_hub_status *) buf;
++        memset(hs, 0, sizeof(*hs));
++        hs->wHubStatus = 0;
++        hs->wHubChange = 0;
++        return 0;
++    } else if (typeReq == GetPortStatus && wLength >= 4 /* usb 2.0 */) {
++        ps = (struct usb_port_status *) buf;
++        ps->wPortStatus = 0;
++        ps->wPortChange = 0;
++
++        if (vhci->port_power_mask & BIT(wIndex))
++            ps->wPortStatus |= USB_PORT_STAT_POWER;
++
++        if (!(bce_vhci_port_mask & BIT(wIndex)))
++            return 0;
++
++        if ((status = bce_vhci_cmd_port_status(&vhci->cq, (u8) wIndex, 0, &port_status)))
++            return status;
++
++        if (port_status & 16)
++            ps->wPortStatus |= USB_PORT_STAT_ENABLE | USB_PORT_STAT_HIGH_SPEED;
++        if (port_status & 4)
++            ps->wPortStatus |= USB_PORT_STAT_CONNECTION;
++        if (port_status & 2)
++            ps->wPortStatus |= USB_PORT_STAT_OVERCURRENT;
++        if (port_status & 8)
++            ps->wPortStatus |= USB_PORT_STAT_RESET;
++        if (port_status & 0x60)
++            ps->wPortStatus |= USB_PORT_STAT_SUSPEND;
++
++        if (port_status & 0x40000)
++            ps->wPortChange |= USB_PORT_STAT_C_CONNECTION;
++
++        pr_debug("bce-vhci: Translated status %x to %x:%x\n", port_status, ps->wPortStatus, ps->wPortChange);
++        return 0;
++    } else if (typeReq == SetPortFeature) {
++        if (wValue == USB_PORT_FEAT_POWER) {
++            status = bce_vhci_cmd_port_power_on(&vhci->cq, (u8) wIndex);
++            /* As far as I am aware, power status is not part of the port status so store it separately */
++            if (!status)
++                vhci->port_power_mask |= BIT(wIndex);
++            return status;
++        }
++        if (wValue == USB_PORT_FEAT_RESET) {
++            return bce_vhci_reset_device(vhci, wIndex, wValue);
++        }
++        if (wValue == USB_PORT_FEAT_SUSPEND) {
++            /* TODO: Am I supposed to also suspend the endpoints? */
++            pr_debug("bce-vhci: Suspending port %i\n", wIndex);
++            return bce_vhci_cmd_port_suspend(&vhci->cq, (u8) wIndex);
++        }
++    } else if (typeReq == ClearPortFeature) {
++        if (wValue == USB_PORT_FEAT_ENABLE)
++            return bce_vhci_cmd_port_disable(&vhci->cq, (u8) wIndex);
++        if (wValue == USB_PORT_FEAT_POWER) {
++            status = bce_vhci_cmd_port_power_off(&vhci->cq, (u8) wIndex);
++            if (!status)
++                vhci->port_power_mask &= ~BIT(wIndex);
++            return status;
++        }
++        if (wValue == USB_PORT_FEAT_C_CONNECTION)
++            return bce_vhci_cmd_port_status(&vhci->cq, (u8) wIndex, 0x40000, &port_status);
++        if (wValue == USB_PORT_FEAT_C_RESET) { /* I don't think I can transfer it in any way */
++            return 0;
++        }
++        if (wValue == USB_PORT_FEAT_SUSPEND) {
++            pr_debug("bce-vhci: Resuming port %i\n", wIndex);
++            return bce_vhci_cmd_port_resume(&vhci->cq, (u8) wIndex);
++        }
++    }
++    pr_err("bce-vhci: bce_vhci_hub_control unhandled request: %x %i %i [bufl=%i]\n", typeReq, wValue, wIndex, wLength);
++    dump_stack();
++    return -EIO;
++}
++
++static int bce_vhci_enable_device(struct usb_hcd *hcd, struct usb_device *udev)
++{
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    struct bce_vhci_device *vdev;
++    bce_vhci_device_t devid;
++    pr_info("bce_vhci_enable_device\n");
++
++    if (vhci->port_to_device[udev->portnum])
++        return 0;
++
++    /* We need to early address the device */
++    if (bce_vhci_cmd_device_create(&vhci->cq, udev->portnum, &devid))
++        return -EIO;
++
++    pr_info("bce_vhci_cmd_device_create %i -> %i\n", udev->portnum, devid);
++
++    vdev = kzalloc(sizeof(struct bce_vhci_device), GFP_KERNEL);
++    vhci->port_to_device[udev->portnum] = devid;
++    vhci->devices[devid] = vdev;
++
++    bce_vhci_create_transfer_queue(vhci, &vdev->tq[0], &udev->ep0, devid, DMA_BIDIRECTIONAL);
++    udev->ep0.hcpriv = &vdev->tq[0];
++    vdev->tq_mask |= BIT(0);
++
++    bce_vhci_cmd_endpoint_create(&vhci->cq, devid, &udev->ep0.desc);
++    return 0;
++}
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,8,0)
++static int bce_vhci_address_device(struct usb_hcd *hcd, struct usb_device *udev)
++#else
++static int bce_vhci_address_device(struct usb_hcd *hcd, struct usb_device *udev, unsigned int timeout_ms) //TODO: follow timeout
++#endif
++{
++    /* This is the same as enable_device, but instead in the old scheme */
++    return bce_vhci_enable_device(hcd, udev);
++}
++
++static void bce_vhci_free_device(struct usb_hcd *hcd, struct usb_device *udev)
++{
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    int i;
++    bce_vhci_device_t devid;
++    struct bce_vhci_device *dev;
++    pr_info("bce_vhci_free_device %i\n", udev->portnum);
++    if (!vhci->port_to_device[udev->portnum])
++        return;
++    devid = vhci->port_to_device[udev->portnum];
++    dev = vhci->devices[devid];
++    for (i = 0; i < 32; i++) {
++        if (dev->tq_mask & BIT(i)) {
++            bce_vhci_transfer_queue_pause(&dev->tq[i], BCE_VHCI_PAUSE_SHUTDOWN);
++            bce_vhci_cmd_endpoint_destroy(&vhci->cq, devid, (u8) i);
++            bce_vhci_destroy_transfer_queue(vhci, &dev->tq[i]);
++        }
++    }
++    vhci->devices[devid] = NULL;
++    vhci->port_to_device[udev->portnum] = 0;
++    bce_vhci_cmd_device_destroy(&vhci->cq, devid);
++    kfree(dev);
++}
++
++static int bce_vhci_reset_device(struct bce_vhci *vhci, int index, u16 timeout)
++{
++    struct bce_vhci_device *dev = NULL;
++    bce_vhci_device_t devid;
++    int i;
++    int status;
++    enum dma_data_direction dir;
++    pr_info("bce_vhci_reset_device %i\n", index);
++
++    devid = vhci->port_to_device[index];
++    if (devid) {
++        dev = vhci->devices[devid];
++
++        for (i = 0; i < 32; i++) {
++            if (dev->tq_mask & BIT(i)) {
++                bce_vhci_transfer_queue_pause(&dev->tq[i], BCE_VHCI_PAUSE_SHUTDOWN);
++                bce_vhci_cmd_endpoint_destroy(&vhci->cq, devid, (u8) i);
++                bce_vhci_destroy_transfer_queue(vhci, &dev->tq[i]);
++            }
++        }
++        vhci->devices[devid] = NULL;
++        vhci->port_to_device[index] = 0;
++        bce_vhci_cmd_device_destroy(&vhci->cq, devid);
++    }
++    status = bce_vhci_cmd_port_reset(&vhci->cq, (u8) index, timeout);
++
++    if (dev) {
++        if ((status = bce_vhci_cmd_device_create(&vhci->cq, index, &devid)))
++            return status;
++        vhci->devices[devid] = dev;
++        vhci->port_to_device[index] = devid;
++
++        for (i = 0; i < 32; i++) {
++            if (dev->tq_mask & BIT(i)) {
++                dir = usb_endpoint_dir_in(&dev->tq[i].endp->desc) ? DMA_FROM_DEVICE : DMA_TO_DEVICE;
++                if (i == 0)
++                    dir = DMA_BIDIRECTIONAL;
++                bce_vhci_create_transfer_queue(vhci, &dev->tq[i], dev->tq[i].endp, devid, dir);
++                bce_vhci_cmd_endpoint_create(&vhci->cq, devid, &dev->tq[i].endp->desc);
++            }
++        }
++    }
++
++    return status;
++}
++
++static int bce_vhci_check_bandwidth(struct usb_hcd *hcd, struct usb_device *udev)
++{
++    return 0;
++}
++
++static int bce_vhci_get_frame_number(struct usb_hcd *hcd)
++{
++    return 0;
++}
++
++static int bce_vhci_bus_suspend(struct usb_hcd *hcd)
++{
++    int i, j;
++    int status;
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    pr_info("bce_vhci: suspend started\n");
++
++    pr_info("bce_vhci: suspend endpoints\n");
++    for (i = 0; i < 16; i++) {
++        if (!vhci->port_to_device[i])
++            continue;
++        for (j = 0; j < 32; j++) {
++            if (!(vhci->devices[vhci->port_to_device[i]]->tq_mask & BIT(j)))
++                continue;
++            bce_vhci_transfer_queue_pause(&vhci->devices[vhci->port_to_device[i]]->tq[j],
++                    BCE_VHCI_PAUSE_SUSPEND);
++        }
++    }
++
++    pr_info("bce_vhci: suspend ports\n");
++    for (i = 0; i < 16; i++) {
++        if (!vhci->port_to_device[i])
++            continue;
++        bce_vhci_cmd_port_suspend(&vhci->cq, i);
++    }
++    pr_info("bce_vhci: suspend controller\n");
++    if ((status = bce_vhci_cmd_controller_pause(&vhci->cq)))
++        return status;
++
++    bce_vhci_event_queue_pause(&vhci->ev_commands);
++    bce_vhci_event_queue_pause(&vhci->ev_system);
++    bce_vhci_event_queue_pause(&vhci->ev_isochronous);
++    bce_vhci_event_queue_pause(&vhci->ev_interrupt);
++    bce_vhci_event_queue_pause(&vhci->ev_asynchronous);
++    pr_info("bce_vhci: suspend done\n");
++    return 0;
++}
++
++static int bce_vhci_bus_resume(struct usb_hcd *hcd)
++{
++    int i, j;
++    int status;
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    pr_info("bce_vhci: resume started\n");
++
++    bce_vhci_event_queue_resume(&vhci->ev_system);
++    bce_vhci_event_queue_resume(&vhci->ev_isochronous);
++    bce_vhci_event_queue_resume(&vhci->ev_interrupt);
++    bce_vhci_event_queue_resume(&vhci->ev_asynchronous);
++    bce_vhci_event_queue_resume(&vhci->ev_commands);
++
++    pr_info("bce_vhci: resume controller\n");
++    if ((status = bce_vhci_cmd_controller_start(&vhci->cq)))
++        return status;
++
++    pr_info("bce_vhci: resume ports\n");
++    for (i = 0; i < 16; i++) {
++        if (!vhci->port_to_device[i])
++            continue;
++        bce_vhci_cmd_port_resume(&vhci->cq, i);
++    }
++    pr_info("bce_vhci: resume endpoints\n");
++    for (i = 0; i < 16; i++) {
++        if (!vhci->port_to_device[i])
++            continue;
++        for (j = 0; j < 32; j++) {
++            if (!(vhci->devices[vhci->port_to_device[i]]->tq_mask & BIT(j)))
++                continue;
++            bce_vhci_transfer_queue_resume(&vhci->devices[vhci->port_to_device[i]]->tq[j],
++                    BCE_VHCI_PAUSE_SUSPEND);
++        }
++    }
++
++    pr_info("bce_vhci: resume done\n");
++    return 0;
++}
++
++static int bce_vhci_urb_enqueue(struct usb_hcd *hcd, struct urb *urb, gfp_t mem_flags)
++{
++    struct bce_vhci_transfer_queue *q = urb->ep->hcpriv;
++    pr_debug("bce_vhci_urb_enqueue %i:%x\n", q->dev_addr, urb->ep->desc.bEndpointAddress);
++    if (!q)
++        return -ENOENT;
++    return bce_vhci_urb_create(q, urb);
++}
++
++static int bce_vhci_urb_dequeue(struct usb_hcd *hcd, struct urb *urb, int status)
++{
++    struct bce_vhci_transfer_queue *q = urb->ep->hcpriv;
++    pr_debug("bce_vhci_urb_dequeue %x\n", urb->ep->desc.bEndpointAddress);
++    return bce_vhci_urb_request_cancel(q, urb, status);
++}
++
++static void bce_vhci_endpoint_reset(struct usb_hcd *hcd, struct usb_host_endpoint *ep)
++{
++    struct bce_vhci_transfer_queue *q = ep->hcpriv;
++    pr_debug("bce_vhci_endpoint_reset\n");
++    if (q)
++        bce_vhci_transfer_queue_request_reset(q);
++}
++
++static u8 bce_vhci_endpoint_index(u8 addr)
++{
++    if (addr & 0x80)
++        return (u8) (0x10 + (addr & 0xf));
++    return (u8) (addr & 0xf);
++}
++
++static int bce_vhci_add_endpoint(struct usb_hcd *hcd, struct usb_device *udev, struct usb_host_endpoint *endp)
++{
++    u8 endp_index = bce_vhci_endpoint_index(endp->desc.bEndpointAddress);
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    bce_vhci_device_t devid = vhci->port_to_device[udev->portnum];
++    struct bce_vhci_device *vdev = vhci->devices[devid];
++    pr_debug("bce_vhci_add_endpoint %x/%x:%x\n", udev->portnum, devid, endp_index);
++
++    if (udev->bus->root_hub == udev) /* The USB hub */
++        return 0;
++    if (vdev == NULL)
++        return -ENODEV;
++    if (vdev->tq_mask & BIT(endp_index)) {
++        endp->hcpriv = &vdev->tq[endp_index];
++        return 0;
++    }
++
++    bce_vhci_create_transfer_queue(vhci, &vdev->tq[endp_index], endp, devid,
++            usb_endpoint_dir_in(&endp->desc) ? DMA_FROM_DEVICE : DMA_TO_DEVICE);
++    endp->hcpriv = &vdev->tq[endp_index];
++    vdev->tq_mask |= BIT(endp_index);
++
++    bce_vhci_cmd_endpoint_create(&vhci->cq, devid, &endp->desc);
++    return 0;
++}
++
++static int bce_vhci_drop_endpoint(struct usb_hcd *hcd, struct usb_device *udev, struct usb_host_endpoint *endp)
++{
++    u8 endp_index = bce_vhci_endpoint_index(endp->desc.bEndpointAddress);
++    struct bce_vhci *vhci = bce_vhci_from_hcd(hcd);
++    bce_vhci_device_t devid = vhci->port_to_device[udev->portnum];
++    struct bce_vhci_transfer_queue *q = endp->hcpriv;
++    struct bce_vhci_device *vdev = vhci->devices[devid];
++    pr_info("bce_vhci_drop_endpoint %x:%x\n", udev->portnum, endp_index);
++    if (!q) {
++        if (vdev && vdev->tq_mask & BIT(endp_index)) {
++            pr_err("something deleted the hcpriv?\n");
++            q = &vdev->tq[endp_index];
++        } else {
++            return 0;
++        }
++    }
++
++    bce_vhci_cmd_endpoint_destroy(&vhci->cq, devid, (u8) (endp->desc.bEndpointAddress & 0x8Fu));
++    vhci->devices[devid]->tq_mask &= ~BIT(endp_index);
++    bce_vhci_destroy_transfer_queue(vhci, q);
++    return 0;
++}
++
++static int bce_vhci_create_message_queues(struct bce_vhci *vhci)
++{
++    if (bce_vhci_message_queue_create(vhci, &vhci->msg_commands, "VHC1HostCommands") ||
++        bce_vhci_message_queue_create(vhci, &vhci->msg_system, "VHC1HostSystemEvents") ||
++        bce_vhci_message_queue_create(vhci, &vhci->msg_isochronous, "VHC1HostIsochronousEvents") ||
++        bce_vhci_message_queue_create(vhci, &vhci->msg_interrupt, "VHC1HostInterruptEvents") ||
++        bce_vhci_message_queue_create(vhci, &vhci->msg_asynchronous, "VHC1HostAsynchronousEvents")) {
++        bce_vhci_destroy_message_queues(vhci);
++        return -EINVAL;
++    }
++    spin_lock_init(&vhci->msg_asynchronous_lock);
++    bce_vhci_command_queue_create(&vhci->cq, &vhci->msg_commands);
++    return 0;
++}
++
++static void bce_vhci_destroy_message_queues(struct bce_vhci *vhci)
++{
++    bce_vhci_command_queue_destroy(&vhci->cq);
++    bce_vhci_message_queue_destroy(vhci, &vhci->msg_commands);
++    bce_vhci_message_queue_destroy(vhci, &vhci->msg_system);
++    bce_vhci_message_queue_destroy(vhci, &vhci->msg_isochronous);
++    bce_vhci_message_queue_destroy(vhci, &vhci->msg_interrupt);
++    bce_vhci_message_queue_destroy(vhci, &vhci->msg_asynchronous);
++}
++
++static void bce_vhci_handle_system_event(struct bce_vhci_event_queue *q, struct bce_vhci_message *msg);
++static void bce_vhci_handle_usb_event(struct bce_vhci_event_queue *q, struct bce_vhci_message *msg);
++
++static int bce_vhci_create_event_queues(struct bce_vhci *vhci)
++{
++    vhci->ev_cq = bce_create_cq(vhci->dev, 0x100);
++    if (!vhci->ev_cq)
++        return -EINVAL;
++#define CREATE_EVENT_QUEUE(field, name, cb) bce_vhci_event_queue_create(vhci, &vhci->field, name, cb)
++    if (__bce_vhci_event_queue_create(vhci, &vhci->ev_commands, "VHC1FirmwareCommands",
++            bce_vhci_firmware_event_completion) ||
++        CREATE_EVENT_QUEUE(ev_system,       "VHC1FirmwareSystemEvents",       bce_vhci_handle_system_event) ||
++        CREATE_EVENT_QUEUE(ev_isochronous,  "VHC1FirmwareIsochronousEvents",  bce_vhci_handle_usb_event) ||
++        CREATE_EVENT_QUEUE(ev_interrupt,    "VHC1FirmwareInterruptEvents",    bce_vhci_handle_usb_event) ||
++        CREATE_EVENT_QUEUE(ev_asynchronous, "VHC1FirmwareAsynchronousEvents", bce_vhci_handle_usb_event)) {
++        bce_vhci_destroy_event_queues(vhci);
++        return -EINVAL;
++    }
++#undef CREATE_EVENT_QUEUE
++    return 0;
++}
++
++static void bce_vhci_destroy_event_queues(struct bce_vhci *vhci)
++{
++    bce_vhci_event_queue_destroy(vhci, &vhci->ev_commands);
++    bce_vhci_event_queue_destroy(vhci, &vhci->ev_system);
++    bce_vhci_event_queue_destroy(vhci, &vhci->ev_isochronous);
++    bce_vhci_event_queue_destroy(vhci, &vhci->ev_interrupt);
++    bce_vhci_event_queue_destroy(vhci, &vhci->ev_asynchronous);
++    if (vhci->ev_cq)
++        bce_destroy_cq(vhci->dev, vhci->ev_cq);
++}
++
++static void bce_vhci_send_fw_event_response(struct bce_vhci *vhci, struct bce_vhci_message *req, u16 status)
++{
++    unsigned long timeout = 1000;
++    struct bce_vhci_message r = *req;
++    r.cmd = (u16) (req->cmd | 0x8000u);
++    r.status = status;
++    r.param1 = req->param1;
++    r.param2 = 0;
++
++    if (bce_reserve_submission(vhci->msg_system.sq, &timeout)) {
++        pr_err("bce-vhci: Cannot reserve submision for FW event reply\n");
++        return;
++    }
++    bce_vhci_message_queue_write(&vhci->msg_system, &r);
++}
++
++static int bce_vhci_handle_firmware_event(struct bce_vhci *vhci, struct bce_vhci_message *msg)
++{
++    unsigned long flags;
++    bce_vhci_device_t devid;
++    u8 endp;
++    struct bce_vhci_device *dev;
++    struct bce_vhci_transfer_queue *tq;
++    if (msg->cmd == BCE_VHCI_CMD_ENDPOINT_REQUEST_STATE || msg->cmd == BCE_VHCI_CMD_ENDPOINT_SET_STATE) {
++        devid = (bce_vhci_device_t) (msg->param1 & 0xff);
++        endp = bce_vhci_endpoint_index((u8) ((msg->param1 >> 8) & 0xff));
++        dev = vhci->devices[devid];
++        if (!dev || !(dev->tq_mask & BIT(endp)))
++            return BCE_VHCI_BAD_ARGUMENT;
++        tq = &dev->tq[endp];
++    }
++
++    if (msg->cmd == BCE_VHCI_CMD_ENDPOINT_REQUEST_STATE) {
++        if (msg->param2 == BCE_VHCI_ENDPOINT_ACTIVE) {
++            bce_vhci_transfer_queue_resume(tq, BCE_VHCI_PAUSE_FIRMWARE);
++            return BCE_VHCI_SUCCESS;
++        } else if (msg->param2 == BCE_VHCI_ENDPOINT_PAUSED) {
++            bce_vhci_transfer_queue_pause(tq, BCE_VHCI_PAUSE_FIRMWARE);
++            return BCE_VHCI_SUCCESS;
++        }
++        return BCE_VHCI_BAD_ARGUMENT;
++    } else if (msg->cmd == BCE_VHCI_CMD_ENDPOINT_SET_STATE) {
++        if (msg->param2 == BCE_VHCI_ENDPOINT_STALLED) {
++            tq->state = msg->param2;
++            spin_lock_irqsave(&tq->urb_lock, flags);
++            tq->stalled = true;
++            spin_unlock_irqrestore(&tq->urb_lock, flags);
++            return BCE_VHCI_SUCCESS;
++        }
++        return BCE_VHCI_BAD_ARGUMENT;
++    }
++    pr_warn("bce-vhci: Unhandled firmware event: %x s=%x p1=%x p2=%llx\n",
++            msg->cmd, msg->status, msg->param1, msg->param2);
++    return BCE_VHCI_BAD_ARGUMENT;
++}
++
++static void bce_vhci_handle_firmware_events_w(struct work_struct *ws)
++{
++    size_t cnt = 0;
++    int result;
++    struct bce_vhci *vhci = container_of(ws, struct bce_vhci, w_fw_events);
++    struct bce_queue_sq *sq = vhci->ev_commands.sq;
++    struct bce_sq_completion_data *cq;
++    struct bce_vhci_message *msg, *msg2 = NULL;
++
++    while (true) {
++        if (msg2) {
++            msg = msg2;
++            msg2 = NULL;
++        } else if ((cq = bce_next_completion(sq))) {
++            if (cq->status == BCE_COMPLETION_ABORTED) {
++                bce_notify_submission_complete(sq);
++                continue;
++            }
++            msg = &vhci->ev_commands.data[sq->head];
++        } else {
++            break;
++        }
++
++        pr_debug("bce-vhci: Got fw event: %x s=%x p1=%x p2=%llx\n", msg->cmd, msg->status, msg->param1, msg->param2);
++        if ((cq = bce_next_completion(sq))) {
++            msg2 = &vhci->ev_commands.data[(sq->head + 1) % sq->el_count];
++            pr_debug("bce-vhci: Got second fw event: %x s=%x p1=%x p2=%llx\n",
++                    msg->cmd, msg->status, msg->param1, msg->param2);
++            if (cq->status != BCE_COMPLETION_ABORTED &&
++                msg2->cmd == (msg->cmd | 0x4000) && msg2->param1 == msg->param1) {
++                /* Take two elements */
++                pr_debug("bce-vhci: Cancelled\n");
++                bce_vhci_send_fw_event_response(vhci, msg, BCE_VHCI_ABORT);
++
++                bce_notify_submission_complete(sq);
++                bce_notify_submission_complete(sq);
++                msg2 = NULL;
++                cnt += 2;
++                continue;
++            }
++
++            pr_warn("bce-vhci: Handle fw event - unexpected cancellation\n");
++        }
++
++        result = bce_vhci_handle_firmware_event(vhci, msg);
++        bce_vhci_send_fw_event_response(vhci, msg, (u16) result);
++
++
++        bce_notify_submission_complete(sq);
++        ++cnt;
++    }
++    bce_vhci_event_queue_submit_pending(&vhci->ev_commands, cnt);
++    if (atomic_read(&sq->available_commands) == sq->el_count - 1) {
++        pr_debug("bce-vhci: complete\n");
++        complete(&vhci->ev_commands.queue_empty_completion);
++    }
++}
++
++static void bce_vhci_firmware_event_completion(struct bce_queue_sq *sq)
++{
++    struct bce_vhci_event_queue *q = sq->userdata;
++    queue_work(q->vhci->tq_state_wq, &q->vhci->w_fw_events);
++}
++
++static void bce_vhci_handle_system_event(struct bce_vhci_event_queue *q, struct bce_vhci_message *msg)
++{
++    if (msg->cmd & 0x8000) {
++        bce_vhci_command_queue_deliver_completion(&q->vhci->cq, msg);
++    } else {
++        pr_warn("bce-vhci: Unhandled system event: %x s=%x p1=%x p2=%llx\n",
++                msg->cmd, msg->status, msg->param1, msg->param2);
++    }
++}
++
++static void bce_vhci_handle_usb_event(struct bce_vhci_event_queue *q, struct bce_vhci_message *msg)
++{
++    bce_vhci_device_t devid;
++    u8 endp;
++    struct bce_vhci_device *dev;
++    if (msg->cmd & 0x8000) {
++        bce_vhci_command_queue_deliver_completion(&q->vhci->cq, msg);
++    } else if (msg->cmd == BCE_VHCI_CMD_TRANSFER_REQUEST || msg->cmd == BCE_VHCI_CMD_CONTROL_TRANSFER_STATUS) {
++        devid = (bce_vhci_device_t) (msg->param1 & 0xff);
++        endp = bce_vhci_endpoint_index((u8) ((msg->param1 >> 8) & 0xff));
++        dev = q->vhci->devices[devid];
++        if (!dev || (dev->tq_mask & BIT(endp)) == 0) {
++            pr_err("bce-vhci: Didn't find destination for transfer queue event\n");
++            return;
++        }
++        bce_vhci_transfer_queue_event(&dev->tq[endp], msg);
++    } else {
++        pr_warn("bce-vhci: Unhandled USB event: %x s=%x p1=%x p2=%llx\n",
++                msg->cmd, msg->status, msg->param1, msg->param2);
++    }
++}
++
++
++
++static const struct hc_driver bce_vhci_driver = {
++        .description = "bce-vhci",
++        .product_desc = "BCE VHCI Host Controller",
++        .hcd_priv_size = sizeof(struct bce_vhci *),
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
++        .flags = HCD_USB2,
++#else
++        .flags = HCD_USB2 | HCD_DMA,
++#endif
++
++        .start = bce_vhci_start,
++        .stop = bce_vhci_stop,
++        .hub_status_data = bce_vhci_hub_status_data,
++        .hub_control = bce_vhci_hub_control,
++        .urb_enqueue = bce_vhci_urb_enqueue,
++        .urb_dequeue = bce_vhci_urb_dequeue,
++        .enable_device = bce_vhci_enable_device,
++        .free_dev = bce_vhci_free_device,
++        .address_device = bce_vhci_address_device,
++        .add_endpoint = bce_vhci_add_endpoint,
++        .drop_endpoint = bce_vhci_drop_endpoint,
++        .endpoint_reset = bce_vhci_endpoint_reset,
++        .check_bandwidth = bce_vhci_check_bandwidth,
++        .get_frame_number = bce_vhci_get_frame_number,
++        .bus_suspend = bce_vhci_bus_suspend,
++        .bus_resume = bce_vhci_bus_resume
++};
++
++
++int __init bce_vhci_module_init(void)
++{
++    int result;
++    if ((result = alloc_chrdev_region(&bce_vhci_chrdev, 0, 1, "bce-vhci")))
++        goto fail_chrdev;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,4,0)
++    bce_vhci_class = class_create(THIS_MODULE, "bce-vhci");
++#else
++    bce_vhci_class = class_create("bce-vhci");
++#endif
++    if (IS_ERR(bce_vhci_class)) {
++        result = PTR_ERR(bce_vhci_class);
++        goto fail_class;
++    }
++    return 0;
++
++fail_class:
++    class_destroy(bce_vhci_class);
++fail_chrdev:
++    unregister_chrdev_region(bce_vhci_chrdev, 1);
++    if (!result)
++        result = -EINVAL;
++    return result;
++}
++void __exit bce_vhci_module_exit(void)
++{
++    class_destroy(bce_vhci_class);
++    unregister_chrdev_region(bce_vhci_chrdev, 1);
++}
++
++module_param_named(vhci_port_mask, bce_vhci_port_mask, ushort, 0444);
++MODULE_PARM_DESC(vhci_port_mask, "Specifies which VHCI ports are enabled");
+diff --git a/drivers/staging/apple-bce/vhci/vhci.h b/drivers/staging/apple-bce/vhci/vhci.h
+new file mode 100644
+index 000000000000..6c2e22622f4c
+--- /dev/null
++++ b/drivers/staging/apple-bce/vhci/vhci.h
+@@ -0,0 +1,52 @@
++#ifndef BCE_VHCI_H
++#define BCE_VHCI_H
++
++#include "queue.h"
++#include "transfer.h"
++
++struct usb_hcd;
++struct bce_queue_cq;
++
++struct bce_vhci_device {
++    struct bce_vhci_transfer_queue tq[32];
++    u32 tq_mask;
++};
++struct bce_vhci {
++    struct apple_bce_device *dev;
++    dev_t vdevt;
++    struct device *vdev;
++    struct usb_hcd *hcd;
++    struct spinlock hcd_spinlock;
++    struct bce_vhci_message_queue msg_commands;
++    struct bce_vhci_message_queue msg_system;
++    struct bce_vhci_message_queue msg_isochronous;
++    struct bce_vhci_message_queue msg_interrupt;
++    struct bce_vhci_message_queue msg_asynchronous;
++    struct spinlock msg_asynchronous_lock;
++    struct bce_vhci_command_queue cq;
++    struct bce_queue_cq *ev_cq;
++    struct bce_vhci_event_queue ev_commands;
++    struct bce_vhci_event_queue ev_system;
++    struct bce_vhci_event_queue ev_isochronous;
++    struct bce_vhci_event_queue ev_interrupt;
++    struct bce_vhci_event_queue ev_asynchronous;
++    u16 port_mask;
++    u8 port_count;
++    u16 port_power_mask;
++    bce_vhci_device_t port_to_device[16];
++    struct bce_vhci_device *devices[16];
++    struct workqueue_struct *tq_state_wq;
++    struct work_struct w_fw_events;
++};
++
++int __init bce_vhci_module_init(void);
++void __exit bce_vhci_module_exit(void);
++
++int bce_vhci_create(struct apple_bce_device *dev, struct bce_vhci *vhci);
++void bce_vhci_destroy(struct bce_vhci *vhci);
++int bce_vhci_start(struct usb_hcd *hcd);
++void bce_vhci_stop(struct usb_hcd *hcd);
++
++struct bce_vhci *bce_vhci_from_hcd(struct usb_hcd *hcd);
++
++#endif //BCE_VHCI_H
+diff --git a/include/linux/hid.h b/include/linux/hid.h
+index 7f260e0e2049..0075b9956d05 100644
+--- a/include/linux/hid.h
++++ b/include/linux/hid.h
+@@ -594,7 +594,9 @@ struct hid_input {
+ enum hid_type {
+ 	HID_TYPE_OTHER = 0,
+ 	HID_TYPE_USBMOUSE,
+-	HID_TYPE_USBNONE
++	HID_TYPE_USBNONE,
++	HID_TYPE_SPI_KEYBOARD,
++	HID_TYPE_SPI_MOUSE,
+ };
+ 
+ enum hid_battery_status {
+@@ -755,6 +757,8 @@ struct hid_descriptor {
+ 	.bus = BUS_BLUETOOTH, .vendor = (ven), .product = (prod)
+ #define HID_I2C_DEVICE(ven, prod)				\
+ 	.bus = BUS_I2C, .vendor = (ven), .product = (prod)
++#define HID_SPI_DEVICE(ven, prod)				\
++	.bus = BUS_SPI, .vendor = (ven), .product = (prod)
+ 
+ #define HID_REPORT_ID(rep) \
+ 	.report_type = (rep)
+diff --git a/include/linux/soc/apple/dockchannel.h b/include/linux/soc/apple/dockchannel.h
+new file mode 100644
+index 000000000000..0b7093935ddf
+--- /dev/null
++++ b/include/linux/soc/apple/dockchannel.h
+@@ -0,0 +1,26 @@
++/* SPDX-License-Identifier: GPL-2.0-only OR MIT */
++/*
++ * Apple Dockchannel devices
++ * Copyright (C) The Asahi Linux Contributors
++ */
++#ifndef _LINUX_APPLE_DOCKCHANNEL_H_
++#define _LINUX_APPLE_DOCKCHANNEL_H_
++
++#include <linux/device.h>
++#include <linux/types.h>
++#include <linux/of_platform.h>
++
++#if IS_ENABLED(CONFIG_APPLE_DOCKCHANNEL)
++
++struct dockchannel;
++
++struct dockchannel *dockchannel_init(struct platform_device *pdev);
++
++int dockchannel_send(struct dockchannel *dockchannel, const void *buf, size_t count);
++int dockchannel_recv(struct dockchannel *dockchannel, void *buf, size_t count);
++int dockchannel_await(struct dockchannel *dockchannel,
++		      void (*callback)(void *cookie, size_t avail),
++		      void *cookie, size_t count);
++
++#endif
++#endif
+-- 
+2.51.2
+

--- a/Files
+++ b/Files
@@ -1136,4 +1136,4 @@
 ├── Files
 └── README.md
 
-144 directories, 992 files
+144 directories, 993 files

--- a/Files
+++ b/Files
@@ -1102,6 +1102,7 @@
 │   │   ├── 0001-clang-polly.patch
 │   │   ├── 0001-handheld.patch
 │   │   ├── 0001-rt-i915.patch
+│   │   ├── 0006-t2.patch
 │   │   ├── dkms-clang.patch
 │   │   └── nvidia
 │   │       ├── 0001-Enable-atomic-kernel-modesetting-by-default.patch


### PR DESCRIPTION
This is primarily an update of the T2 patch to use commit [da3e8fa](https://github.com/t2linux/linux-t2-patches/commit/da3e8faa7f8e58c7a7c8dfb1999fd7be928a5771) under the `linux-t2-patches` repository, which allows writes to the Apple SMC fan controller particularly in the contexts of older T2 Macs, including the Macbook Air 8,1 and iMac Pro 1,1 which require `iowrite8` instead of `iowrite32`. 

This is particularly helpful on these machines as it allows fan control.

According to the original patch writer (@fedesapuppo), the modified registers are read via `ioread8` already, so this should continue to allow operability with all T2 machines. See the original patch for more technical details on this. 

Tested on an iMac Pro 1,1 under `7.0.2-2-cachyos`. 