### PR TITLE
6.18：fix bore cachy patch

### DIFF
--- a/6.18/sched-dev/0001-bore-cachy.patch
+++ b/6.18/sched-dev/0001-bore-cachy.patch
@@ -1,32 +1,32 @@
-From 09045ee39c548dfac5bfebdb400b7e9d362957a9 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Fri, 10 Apr 2026 08:28:12 +0200
+From d57926731435d57a127a4772256f976b5e6cc84d Mon Sep 17 00:00:00 2001
+From: loner <2788892716@qq.com>
+Date: Sun, 24 May 2026 19:33:41 +0800
 Subject: [PATCH] bore-cachy
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
- include/linux/sched.h      |  34 +++
- include/linux/sched/bore.h |  41 ++++
+ include/linux/sched.h      |  28 +++
+ include/linux/sched/bore.h |  46 ++++
  init/Kconfig               |  17 ++
  kernel/Kconfig.hz          |  17 ++
  kernel/exit.c              |   4 +
- kernel/fork.c              |  13 ++
+ kernel/fork.c              |  13 +
  kernel/futex/waitwake.c    |  11 +
  kernel/sched/Makefile      |   1 +
- kernel/sched/bore.c        | 434 +++++++++++++++++++++++++++++++++++++
+ kernel/sched/bore.c        | 470 +++++++++++++++++++++++++++++++++++++
  kernel/sched/core.c        |  12 +
- kernel/sched/debug.c       |  61 ++++++
- kernel/sched/fair.c        | 139 ++++++++++--
+ kernel/sched/debug.c       |  65 +++++
+ kernel/sched/fair.c        | 137 +++++++++--
+ kernel/sched/features.h    |   7 +
  kernel/sched/sched.h       |   9 +
- 13 files changed, 769 insertions(+), 24 deletions(-)
+ 14 files changed, 813 insertions(+), 24 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 3e2005e9e..fd47e4572 100644
+index 5dea369fc..964c45836 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -817,6 +817,37 @@ struct kmap_ctrl {
+@@ -817,6 +817,31 @@ struct kmap_ctrl {
  #endif
  };
  
@@ -47,13 +47,7 @@ index 3e2005e9e..fd47e4572 100644
 +	u64				burst_time;
 +	u16				prev_penalty;
 +	u16				curr_penalty;
-+	union {
-+		u16			penalty;
-+		struct {
-+			u8		_;
-+			u8		score;
-+		};
-+	};
++	u16				penalty;
 +	bool			stop_update;
 +	bool			futex_waiting;
 +	struct bore_bc	subtree;
@@ -64,7 +58,7 @@ index 3e2005e9e..fd47e4572 100644
  struct task_struct {
  #ifdef CONFIG_THREAD_INFO_IN_TASK
  	/*
-@@ -875,6 +906,9 @@ struct task_struct {
+@@ -875,6 +900,9 @@ struct task_struct {
  #ifdef CONFIG_SCHED_CLASS_EXT
  	struct sched_ext_entity		scx;
  #endif
@@ -76,10 +70,10 @@ index 3e2005e9e..fd47e4572 100644
  #ifdef CONFIG_SCHED_CORE
 diff --git a/include/linux/sched/bore.h b/include/linux/sched/bore.h
 new file mode 100644
-index 000000000..9215c13a9
+index 000000000..0d433c4ef
 --- /dev/null
 +++ b/include/linux/sched/bore.h
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,46 @@
 +#ifndef _KERNEL_SCHED_BORE_H
 +#define _KERNEL_SCHED_BORE_H
 +
@@ -93,7 +87,7 @@ index 000000000..9215c13a9
 +#define SCHED_BORE_AUTHOR   "Masahito Suzuki"
 +#define SCHED_BORE_PROGNAME "BORE CPU Scheduler modification"
 +
-+#define SCHED_BORE_VERSION  "6.6.3"
++#define SCHED_BORE_VERSION  "6.7.3"
 +
 +extern u8   __read_mostly sched_bore;
 +DECLARE_STATIC_KEY_TRUE(sched_bore_key);
@@ -104,6 +98,7 @@ index 000000000..9215c13a9
 +extern uint __read_mostly sched_burst_cache_lifetime;
 +
 +extern u8   effective_prio_bore(struct task_struct *p);
++extern u32  get_score_bore(struct task_struct *p);
 +extern void update_curr_bore(struct task_struct *p, u64 delta_exec);
 +extern void restart_burst_bore(struct task_struct *p);
 +extern void restart_burst_rescale_deadline_bore(struct task_struct *p);
@@ -113,6 +108,10 @@ index 000000000..9215c13a9
 +extern void reset_task_bore(struct task_struct *p);
 +
 +extern int  sched_bore_update_handler(const struct ctl_table *table,
++	int write, void __user *buffer, size_t *lenp, loff_t *ppos);
++extern int  sched_burst_penalty_offset_update_handler(const struct ctl_table *table,
++	int write, void __user *buffer, size_t *lenp, loff_t *ppos);
++extern int  sched_burst_penalty_scale_update_handler(const struct ctl_table *table,
 +	int write, void __user *buffer, size_t *lenp, loff_t *ppos);
 +extern int  sched_burst_inherit_type_update_handler(const struct ctl_table *table,
 +	int write, void __user *buffer, size_t *lenp, loff_t *ppos);
@@ -150,7 +149,7 @@ index 3a664a42c..5f55a077b 100644
  	bool "Automatic process group scheduling"
  	select CGROUPS
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index e1359db55..31053e619 100644
+index e1359db55..d41735c4b 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -81,3 +81,20 @@ config HZ
@@ -164,18 +163,18 @@ index e1359db55..31053e619 100644
 +	help
 +	 The BORE Scheduler automatically calculates the optimal base
 +	 slice for the configured HZ using the following equation:
-+	 
++
 +	 base_slice_ns =
-+	 	1000000000/HZ * DIV_ROUNDUP(min_base_slice_ns, 1000000000/HZ)
-+	 
++		1000000000/HZ * DIV_ROUNDUP(min_base_slice_ns, 1000000000/HZ)
++
 +	 This option sets the default lower bound limit of the base slice
 +	 to prevent the loss of task throughput due to overscheduling.
-+	 
++
 +	 Setting this value too high can cause the system to boot with
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
 diff --git a/kernel/exit.c b/kernel/exit.c
-index c8c3ff935..0ec0d3db7 100644
+index c83294682..2ca968eda 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -147,7 +147,11 @@ static void __unhash_process(struct release_task_post *post, struct task_struct
@@ -191,10 +190,10 @@ index c8c3ff935..0ec0d3db7 100644
  	}
  	list_del_rcu(&p->thread_node);
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 911e4073b..58af709bf 100644
+index 30a48bbdb..aa48ef894 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
-@@ -116,6 +116,10 @@
+@@ -117,6 +117,10 @@
  /* For dup_mmap(). */
  #include "../mm/internal.h"
  
@@ -270,10 +269,10 @@ index 8ae86371d..b688084bc 100644
 +obj-$(CONFIG_SCHED_BORE) += bore.o
 diff --git a/kernel/sched/bore.c b/kernel/sched/bore.c
 new file mode 100644
-index 000000000..c27a22cd6
+index 000000000..11e79d165
 --- /dev/null
 +++ b/kernel/sched/bore.c
-@@ -0,0 +1,434 @@
+@@ -0,0 +1,470 @@
 +/*
 + *  Burst-Oriented Response Enhancer (BORE) CPU Scheduler
 + *  Copyright (C) 2021-2025 Masahito Suzuki <firelzrd@gmail.com>
@@ -291,6 +290,7 @@ index 000000000..c27a22cd6
 +u8   __read_mostly sched_burst_penalty_offset   = 24;
 +uint __read_mostly sched_burst_penalty_scale    = 1536;
 +uint __read_mostly sched_burst_cache_lifetime   = 75000000;
++static u32 __read_mostly scaled_tolerance;
 +static int __maybe_unused maxval_prio    =   39;
 +static int __maybe_unused maxval_6_bits  =   63;
 +static int __maybe_unused maxval_8_bits  =  255;
@@ -314,13 +314,8 @@ index 000000000..c27a22cd6
 +}
 +
 +static inline u32 calc_burst_penalty(u64 burst_time) {
-+	u32 greed = log2p1_u64_u32fp(burst_time, 8),
-+		tolerance = sched_burst_penalty_offset << 8;
-+	s32 diff = (s32)(greed - tolerance);
-+	u32 penalty = diff & ~(diff >> 31);
-+	u32 scaled_penalty = penalty * sched_burst_penalty_scale >> 10;
-+	s32 overflow = scaled_penalty - MAX_BURST_PENALTY;
-+	return scaled_penalty - (overflow & ~(overflow >> 31));
++	u32 greed = log2p1_u64_u32fp(burst_time, 8);
++	return greed * sched_burst_penalty_scale >> 10;
 +}
 +
 +static inline u64 rescale_slice(u64 delta, u8 old_prio, u8 new_prio) {
@@ -353,13 +348,28 @@ index 000000000..c27a22cd6
 +	se->load.inv_weight = sched_prio_to_wmult[prio];
 +}
 +
++static inline u32 adj_score(u16 penalty) {
++	s32 diff = (s32)(u32)penalty - (s32)scaled_tolerance;
++	return (u32)(diff & ~(diff >> 31));
++}
++
++static inline u32 scaled_penalty_score(u16 greed) {
++	u32 penalty = adj_score(greed);
++	s32 overflow = (s32)penalty - (s32)MAX_BURST_PENALTY;
++	penalty -= (overflow & ~(overflow >> 31));
++	return penalty >> 8;
++}
++
++u32 get_score_bore(struct task_struct *p)
++{ return scaled_penalty_score(p->bore.penalty); }
++
 +u8 effective_prio_bore(struct task_struct *p) {
 +	int prio = p->static_prio - MAX_RT_PRIO;
 +	if (static_branch_likely(&sched_bore_key))
-+		prio += p->bore.score;
++		prio += scaled_penalty_score(p->bore.penalty);
 +	prio &= ~(prio >> 31);
-+	s32 diff = prio - maxval_prio;
-+	prio -= (diff & ~(diff >> 31));
++	s32 pdiff = prio - maxval_prio;
++	prio -= (pdiff & ~(pdiff >> 31));
 +	return (u8)prio;
 +}
 +
@@ -424,9 +434,8 @@ index 000000000..c27a22cd6
 +
 +static inline u32 count_children_upto2(struct task_struct *p) {
 +	struct list_head *head = &p->children;
-+	struct list_head *first = READ_ONCE(head->next);
-+	struct list_head *second = READ_ONCE(first->next);
-+	return (first != head) + (second != head);
++	struct list_head *next = head->next;
++	return (next != head) + (next->next != head);
 +}
 +
 +static inline bool burst_cache_expired(struct bore_bc *bc, u64 now) {
@@ -441,7 +450,8 @@ index 000000000..c27a22cd6
 +		(u32)(((u64)total * bore_reciprocal_lut[count]) >> 32);
 +
 +	struct bore_bc new_bc = {
-+		.penalty = max(average, p->bore.penalty),
++		.penalty = min(max(average, adj_score(p->bore.penalty))
++			+ scaled_tolerance, (u32)MAX_BURST_PENALTY + scaled_tolerance),
 +		.timestamp = now >> BORE_BC_TIMESTAMP_SHIFT
 +	};
 +	WRITE_ONCE(bc->value, new_bc.value);
@@ -465,7 +475,7 @@ index 000000000..c27a22cd6
 +
 +			if (!task_is_bore_eligible(child)) continue;
 +			count++;
-+			total += child->bore.penalty;
++			total += adj_score(child->bore.penalty);
 +		}
 +
 +		update_burst_cache(bc, parent, count, total, now);
@@ -501,17 +511,13 @@ index 000000000..c27a22cd6
 +			if (scan_count++ >= BURST_CACHE_SCAN_LIMIT) break;
 +
 +			struct task_struct *descendant = direct_child;
-+			while (count_children_upto2(descendant) == 1) {
-+				struct task_struct *next_descendant =
-+					list_first_or_null_rcu(&descendant->children,
-+											struct task_struct, sibling);
-+				if (!next_descendant) break;
-+				descendant = next_descendant;
-+			}
++			while (count_children_upto2(descendant) == 1)
++				descendant = list_first_entry(&descendant->children,
++												struct task_struct, sibling);
 +
 +			if (!task_is_bore_eligible(descendant)) continue;
 +			count++;
-+			total += descendant->bore.penalty;
++			total += adj_score(descendant->bore.penalty);
 +		}
 +
 +		update_burst_cache(bc, ancestor, count, total, now);
@@ -528,15 +534,14 @@ index 000000000..c27a22cd6
 +
 +	if (burst_cache_expired(bc, now)) {
 +		struct task_struct *sibling;
-+		u32 count = 0, total = 0, scan_count = 0;
++		u32 count = 0, total = 0;
 +
 +		for_each_thread(leader, sibling) {
 +			if (count >= BURST_CACHE_SAMPLE_LIMIT) break;
-+			if (scan_count++ >= BURST_CACHE_SCAN_LIMIT) break;
 +
 +			if (!task_is_bore_eligible(sibling)) continue;
 +			count++;
-+			total += sibling->bore.penalty;
++			total += adj_score(sibling->bore.penalty);
 +		}
 +
 +		update_burst_cache(bc, leader, count, total, now);
@@ -591,6 +596,11 @@ index 000000000..c27a22cd6
 +	}
 +}
 +
++static inline void update_scaled_tolerance(void) {
++	scaled_tolerance =
++		(u32)(sched_burst_penalty_offset << 8) * sched_burst_penalty_scale >> 10;
++}
++
 +void __init sched_init_bore(void) {
 +	printk(KERN_INFO "%s %s by %s\n",
 +		SCHED_BORE_PROGNAME, SCHED_BORE_VERSION, SCHED_BORE_AUTHOR);
@@ -600,6 +610,7 @@ index 000000000..c27a22cd6
 +
 +	reset_task_bore(&init_task);
 +	update_inherit_type();
++	update_scaled_tolerance();
 +}
 +
 +static void readjust_all_task_weights(void) {
@@ -628,6 +639,30 @@ index 000000000..c27a22cd6
 +	else
 +		static_branch_disable(&sched_bore_key);
 +
++	readjust_all_task_weights();
++
++	return 0;
++}
++
++int sched_burst_penalty_offset_update_handler(const struct ctl_table *table,
++		int write, void __user *buffer, size_t *lenp, loff_t *ppos) {
++	int ret = proc_dou8vec_minmax(table, write, buffer, lenp, ppos);
++	if (ret || !write)
++		return ret;
++
++	update_scaled_tolerance();
++	readjust_all_task_weights();
++
++	return 0;
++}
++
++int sched_burst_penalty_scale_update_handler(const struct ctl_table *table,
++		int write, void __user *buffer, size_t *lenp, loff_t *ppos) {
++	int ret = proc_douintvec_minmax(table, write, buffer, lenp, ppos);
++	if (ret || !write)
++		return ret;
++
++	update_scaled_tolerance();
 +	readjust_all_task_weights();
 +
 +	return 0;
@@ -678,7 +713,7 @@ index 000000000..c27a22cd6
 +		.data		= &sched_burst_penalty_offset,
 +		.maxlen		= sizeof(u8),
 +		.mode		= 0644,
-+		.proc_handler = proc_dou8vec_minmax,
++		.proc_handler = sched_burst_penalty_offset_update_handler,
 +		.extra1		= SYSCTL_ZERO,
 +		.extra2		= &maxval_6_bits,
 +	},
@@ -687,7 +722,7 @@ index 000000000..c27a22cd6
 +		.data		= &sched_burst_penalty_scale,
 +		.maxlen		= sizeof(uint),
 +		.mode		= 0644,
-+		.proc_handler = proc_douintvec_minmax,
++		.proc_handler = sched_burst_penalty_scale_update_handler,
 +		.extra1		= SYSCTL_ZERO,
 +		.extra2		= &maxval_12_bits,
 +	},
@@ -709,7 +744,7 @@ index 000000000..c27a22cd6
 +#endif // CONFIG_SYSCTL
 +#endif /* CONFIG_SCHED_BORE */
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index c325305d7..5e60e07ce 100644
+index d4edc2a91..727f4f8af 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -100,6 +100,10 @@
@@ -735,7 +770,7 @@ index c325305d7..5e60e07ce 100644
  	struct load_weight lw;
  
  	if (task_has_idle_policy(p)) {
-@@ -8657,6 +8665,10 @@ void __init sched_init(void)
+@@ -8658,6 +8666,10 @@ void __init sched_init(void)
  	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
  #endif
  
@@ -747,10 +782,21 @@ index c325305d7..5e60e07ce 100644
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 93f009e10..ed90b4f94 100644
+index 3504ec9bd..106368b0d 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
-@@ -169,6 +169,53 @@ static const struct file_operations sched_feat_fops = {
+@@ -10,6 +10,10 @@
+ #include <linux/nmi.h>
+ #include "sched.h"
+ 
++#ifdef CONFIG_SCHED_BORE
++#include <linux/sched/bore.h>
++#endif /* CONFIG_SCHED_BORE */
++
+ /*
+  * This allows printing both to /sys/kernel/debug/sched/debug and
+  * to the console
+@@ -169,6 +173,53 @@ static const struct file_operations sched_feat_fops = {
  	.release	= single_release,
  };
  
@@ -804,7 +850,7 @@ index 93f009e10..ed90b4f94 100644
  static ssize_t sched_scaling_write(struct file *filp, const char __user *ubuf,
  				   size_t cnt, loff_t *ppos)
  {
-@@ -214,6 +261,7 @@ static const struct file_operations sched_scaling_fops = {
+@@ -214,6 +265,7 @@ static const struct file_operations sched_scaling_fops = {
  	.llseek		= seq_lseek,
  	.release	= single_release,
  };
@@ -812,7 +858,7 @@ index 93f009e10..ed90b4f94 100644
  
  #ifdef CONFIG_PREEMPT_DYNAMIC
  
-@@ -501,12 +549,19 @@ static __init int sched_init_debug(void)
+@@ -501,12 +553,19 @@ static __init int sched_init_debug(void)
  	debugfs_create_file("preempt", 0644, debugfs_sched, NULL, &sched_dynamic_fops);
  #endif
  
@@ -832,28 +878,28 @@ index 93f009e10..ed90b4f94 100644
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
  
-@@ -748,6 +803,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
+@@ -748,6 +807,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
 +#ifdef CONFIG_SCHED_BORE
-+	SEQ_printf(m, " %2d", p->bore.score);
++	SEQ_printf(m, " %2d", get_score_bore(p));
 +#endif /* CONFIG_SCHED_BORE */
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, "   %d      %d", task_node(p), task_numa_group_id(p));
  #endif
-@@ -1225,6 +1283,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
+@@ -1227,6 +1289,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  	__PS("nr_involuntary_switches", p->nivcsw);
  
  	P(se.load.weight);
 +#ifdef CONFIG_SCHED_BORE
-+	P(bore.score);
++	__PS("bore.score", get_score_bore(p));
 +#endif /* CONFIG_SCHED_BORE */
  	P(se.avg.load_sum);
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index b2e4fd207..c70d6484b 100644
+index d479bc9f8..0410918ae 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -58,6 +58,10 @@
@@ -946,7 +992,18 @@ index b2e4fd207..c70d6484b 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -970,7 +982,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -786,6 +798,10 @@ static void update_entity_lag(struct cfs_rq *cfs_rq, struct sched_entity *se)
+ 
+ 	vlag = avg_vruntime(cfs_rq) - se->vruntime;
+ 	limit = calc_delta_fair(max_slice, se);
++#ifdef CONFIG_SCHED_BORE
++	if (static_branch_likely(&sched_bore_key))
++		limit >>= 1;
++#endif /* CONFIG_SCHED_BORE */
+ 
+ 	se->vlag = clamp(vlag, -limit, limit);
+ }
+@@ -970,7 +986,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   */
  static inline void set_protect_slice(struct cfs_rq *cfs_rq, struct sched_entity *se)
  {
@@ -958,7 +1015,7 @@ index b2e4fd207..c70d6484b 100644
  	u64 vprot = se->deadline;
  
  	if (sched_feat(RUN_TO_PARITY))
-@@ -1038,6 +1054,11 @@ static struct sched_entity *__pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
+@@ -1048,6 +1068,11 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
  		curr = NULL;
  
  	if (curr && protect && protect_slice(curr))
@@ -970,7 +1027,7 @@ index b2e4fd207..c70d6484b 100644
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -1099,6 +1120,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -1104,6 +1129,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
  /**************************************************************
   * Scheduling class statistics methods:
   */
@@ -978,7 +1035,7 @@ index b2e4fd207..c70d6484b 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -1110,6 +1132,7 @@ int sched_update_scaling(void)
+@@ -1115,6 +1141,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -986,7 +1043,7 @@ index b2e4fd207..c70d6484b 100644
  
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
  
-@@ -1307,6 +1330,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1315,6 +1342,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	resched = update_deadline(cfs_rq, curr);
  
  	if (entity_is_task(curr)) {
@@ -998,7 +1055,7 @@ index b2e4fd207..c70d6484b 100644
  		/*
  		 * If the fair_server is active, we need to account for the
  		 * fair_server time whether or not the task is running on
-@@ -3842,17 +3870,23 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se)
+@@ -3850,7 +3882,7 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se)
  
  static void place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags);
  
@@ -1007,40 +1064,7 @@ index b2e4fd207..c70d6484b 100644
  			    unsigned long weight)
  {
  	bool curr = cfs_rq->curr == se;
- 	bool rel_vprot = false;
- 	u64 vprot;
-+#ifdef CONFIG_SCHED_BORE
-+	s64 vlag_unscaled = 0;
-+#endif /* !CONFIG_SCHED_BORE */
- 
- 	if (se->on_rq) {
- 		/* commit outstanding execution time */
- 		update_curr(cfs_rq);
- 		update_entity_lag(cfs_rq, se);
-+#ifdef CONFIG_SCHED_BORE
-+		vlag_unscaled = se->vlag;
-+#endif /* !CONFIG_SCHED_BORE */
- 		se->deadline -= se->vruntime;
- 		se->rel_deadline = 1;
- 		if (curr && protect_slice(se)) {
-@@ -3888,6 +3922,16 @@ static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
- 
- 	enqueue_load_avg(cfs_rq, se);
- 	if (se->on_rq) {
-+#ifdef CONFIG_SCHED_BORE
-+		if (curr) {
-+			se->vruntime += vlag_unscaled - se->vlag;
-+			if (se->rel_deadline) {
-+				se->deadline += se->vruntime;
-+				se->rel_deadline = 0;
-+			}
-+		}
-+		else
-+#endif /* !CONFIG_SCHED_BORE */
- 		place_entity(cfs_rq, se, 0);
- 		if (rel_vprot)
- 			se->vprot = se->vruntime + vprot;
-@@ -5205,12 +5249,11 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
+@@ -5213,12 +5245,11 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
  static void
  place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  {
@@ -1054,7 +1078,7 @@ index b2e4fd207..c70d6484b 100644
  
  	/*
  	 * Due to how V is constructed as the weighted average of entities,
-@@ -5295,7 +5338,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5303,7 +5334,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		se->rel_deadline = 0;
  		return;
  	}
@@ -1074,7 +1098,7 @@ index b2e4fd207..c70d6484b 100644
  	/*
  	 * When joining the competition; the existing tasks will be,
  	 * on average, halfway through their slice, as such start tasks
-@@ -5304,6 +5358,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5312,6 +5354,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
  		vslice /= 2;
  
@@ -1084,7 +1108,7 @@ index b2e4fd207..c70d6484b 100644
  	/*
  	 * EEVDF: vd_i = ve_i + r_i/w_i
  	 */
-@@ -5314,7 +5371,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
+@@ -5322,7 +5367,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
  static inline int cfs_rq_throttled(struct cfs_rq *cfs_rq);
  
  static void
@@ -1093,7 +1117,7 @@ index b2e4fd207..c70d6484b 100644
  
  static void
  enqueue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
-@@ -5472,6 +5529,10 @@ dequeue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5480,6 +5525,10 @@ dequeue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		if (sched_feat(DELAY_DEQUEUE) && delay &&
  		    !entity_eligible(cfs_rq, se)) {
  			update_load_avg(cfs_rq, se, 0);
@@ -1104,7 +1128,7 @@ index b2e4fd207..c70d6484b 100644
  			set_delayed(se);
  			return false;
  		}
-@@ -6957,7 +7018,7 @@ static int sched_idle_cpu(int cpu)
+@@ -6950,7 +6999,7 @@ static int sched_idle_cpu(int cpu)
  }
  
  static void
@@ -1113,7 +1137,7 @@ index b2e4fd207..c70d6484b 100644
  {
  	struct cfs_rq *cfs_rq = cfs_rq_of(se);
  
-@@ -6970,13 +7031,22 @@ requeue_delayed_entity(struct sched_entity *se)
+@@ -6963,13 +7012,22 @@ requeue_delayed_entity(struct sched_entity *se)
  	WARN_ON_ONCE(!se->on_rq);
  
  	if (sched_feat(DELAY_ZERO)) {
@@ -1137,7 +1161,7 @@ index b2e4fd207..c70d6484b 100644
  			if (se != cfs_rq->curr)
  				__enqueue_entity(cfs_rq, se);
  			cfs_rq->nr_queued++;
-@@ -7016,7 +7086,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -7009,7 +7067,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_enqueue(&rq->cfs, p);
  
  	if (flags & ENQUEUE_DELAYED) {
@@ -1146,7 +1170,7 @@ index b2e4fd207..c70d6484b 100644
  		return;
  	}
  
-@@ -7034,7 +7104,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -7027,7 +7085,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	for_each_sched_entity(se) {
  		if (se->on_rq) {
  			if (se->sched_delayed)
@@ -1155,7 +1179,7 @@ index b2e4fd207..c70d6484b 100644
  			break;
  		}
  		cfs_rq = cfs_rq_of(se);
-@@ -7247,6 +7317,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -7238,6 +7296,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_dequeue(&rq->cfs, p);
  
  	util_est_update(&rq->cfs, p, flags & DEQUEUE_SLEEP);
@@ -1171,7 +1195,24 @@ index b2e4fd207..c70d6484b 100644
  	if (dequeue_entities(rq, &p->se, flags) < 0)
  		return false;
  
-@@ -9067,16 +9146,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -8942,6 +9009,16 @@ static void check_preempt_wakeup_fair(struct rq *rq, struct task_struct *p, int
+ 		goto pick;
+ 	}
+ 
++#ifdef CONFIG_SCHED_BORE
++	if (static_branch_likely(&sched_bore_key) &&
++			sched_feat(PREEMPT_SHORT_BORE) &&
++			entity_is_task(pse) && entity_is_task(se) &&
++			task_of(pse)->bore.penalty < task_of(se)->bore.penalty) {
++		preempt_action = PREEMPT_WAKEUP_SHORT;
++		goto preempt;
++	}
++#endif /* CONFIG_SCHED_BORE */
++
+ 	/*
+ 	 * Ignore wakee preemption on WF_FORK as it is less likely that
+ 	 * there is shared data as exec often follow fork. Do not
+@@ -9163,16 +9240,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -1197,7 +1238,7 @@ index b2e4fd207..c70d6484b 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -13530,6 +13618,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
+@@ -13626,6 +13712,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  	WARN_ON_ONCE(p->se.sched_delayed);
  
  	attach_task_cfs_rq(p);
@@ -1207,8 +1248,26 @@ index b2e4fd207..c70d6484b 100644
  
  	set_task_max_allowed_capacity(p);
  
+diff --git a/kernel/sched/features.h b/kernel/sched/features.h
+index 136a6584b..68c9a8f1a 100644
+--- a/kernel/sched/features.h
++++ b/kernel/sched/features.h
+@@ -23,6 +23,13 @@ SCHED_FEAT(RUN_TO_PARITY, true)
+  * current.
+  */
+ SCHED_FEAT(PREEMPT_SHORT, true)
++/*
++ * Allow preemption of tasks with a higher BORE penalty by tasks with a lower
++ * penalty, using the PREEMPT_SHORT mechanism.
++ */
++#ifdef CONFIG_SCHED_BORE
++SCHED_FEAT(PREEMPT_SHORT_BORE, true)
++#endif /* CONFIG_SCHED_BORE */
+ 
+ /*
+  * Prefer to schedule the task we woke last (assuming it failed
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 35ae55b93..b719dcee3 100644
+index 3a9fc9438..8bc0af374 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
 @@ -2141,7 +2141,11 @@ extern int group_balance_cpu(struct sched_group *sg);


### PR DESCRIPTION
Update 0001-bore-cachy.patch for kernel 6.18.33

The failure was caught during a Nix build using `cachyos-6.18.33-1.tar.gz`:

```
  ➜ nix build .#linuxPackages_cachyos-lts.kernel.configfile -L --accept-flake-config
linux-cachyos-config> Running phase: unpackPhase
linux-cachyos-config> unpacking source archive /nix/store/8f7amidhcllnw63k73rf3rfd68c0px21-cachyos-6.18.33-1.tar.gz
linux-cachyos-config> source root is cachyos-6.18.33-1
linux-cachyos-config> setting SOURCE_DATE_EPOCH to timestamp 1779538615 of file "cachyos-6.18.33-1/virt/lib/irqbypass.c"
linux-cachyos-config> Running phase: patchPhase
linux-cachyos-config> applying patch /nix/store/j8qp14x8lnf84p5cldh0nxcizigm2sqd-source/6.18/sched/0001-bore-cachy.patch
linux-cachyos-config> patching file include/linux/sched.h
linux-cachyos-config> patching file include/linux/sched/bore.h
linux-cachyos-config> patching file init/Kconfig
linux-cachyos-config> patching file kernel/Kconfig.hz
linux-cachyos-config> patching file kernel/exit.c
linux-cachyos-config> patching file kernel/fork.c
linux-cachyos-config> Hunk #1 succeeded at 117 (offset 1 line).
linux-cachyos-config> patching file kernel/futex/waitwake.c
linux-cachyos-config> patching file kernel/sched/Makefile
linux-cachyos-config> patching file kernel/sched/bore.c
linux-cachyos-config> patching file kernel/sched/core.c
linux-cachyos-config> Hunk #3 succeeded at 8666 (offset 1 line).
linux-cachyos-config> patching file kernel/sched/debug.c
linux-cachyos-config> Hunk #6 succeeded at 1289 (offset 2 lines).
linux-cachyos-config> patching file kernel/sched/fair.c
linux-cachyos-config> Hunk #8 succeeded at 1068 (offset 10 lines).
linux-cachyos-config> Hunk #9 succeeded at 1129 (offset 5 lines).
linux-cachyos-config> Hunk #10 succeeded at 1141 (offset 5 lines).
linux-cachyos-config> Hunk #11 succeeded at 1342 (offset 8 lines).
linux-cachyos-config> Hunk #12 succeeded at 3882 (offset 8 lines).
linux-cachyos-config> Hunk #13 succeeded at 5245 (offset 8 lines).
linux-cachyos-config> Hunk #14 succeeded at 5334 (offset 8 lines).
linux-cachyos-config> Hunk #15 succeeded at 5354 (offset 8 lines).
linux-cachyos-config> Hunk #16 succeeded at 5367 (offset 8 lines).
linux-cachyos-config> Hunk #17 succeeded at 5525 (offset 8 lines).
linux-cachyos-config> Hunk #18 succeeded at 6999 (offset -7 lines).
linux-cachyos-config> Hunk #19 succeeded at 7012 (offset -7 lines).
linux-cachyos-config> Hunk #20 succeeded at 7067 (offset -7 lines).
linux-cachyos-config> Hunk #21 succeeded at 7085 (offset -7 lines).
linux-cachyos-config> Hunk #22 succeeded at 7296 (offset -9 lines).
linux-cachyos-config> Hunk #23 FAILED at 8960.
linux-cachyos-config> Hunk #24 succeeded at 9230 (offset 96 lines).
linux-cachyos-config> Hunk #25 succeeded at 13702 (offset 96 lines).
linux-cachyos-config> 1 out of 25 hunks FAILED -- saving rejects to file kernel/sched/fair.c.rej
linux-cachyos-config> patching file kernel/sched/features.h
linux-cachyos-config> patching file kernel/sched/sched.h
error: Cannot build '/nix/store/698sy0gn6pzn58fn9xjww64k8c0c3vxf-linux-cachyos-config.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/6lcmg1n58g9v8x9ysfn5l18cb61h0hgq-linux-cachyos-config
       Last 25 log lines:
       > Hunk #3 succeeded at 8666 (offset 1 line).
       > patching file kernel/sched/debug.c
       > Hunk #6 succeeded at 1289 (offset 2 lines).
       > patching file kernel/sched/fair.c
       > Hunk #8 succeeded at 1068 (offset 10 lines).
       > Hunk #9 succeeded at 1129 (offset 5 lines).
       > Hunk #10 succeeded at 1141 (offset 5 lines).
       > Hunk #11 succeeded at 1342 (offset 8 lines).
       > Hunk #12 succeeded at 3882 (offset 8 lines).
       > Hunk #13 succeeded at 5245 (offset 8 lines).
       > Hunk #14 succeeded at 5334 (offset 8 lines).
       > Hunk #15 succeeded at 5354 (offset 8 lines).
       > Hunk #16 succeeded at 5367 (offset 8 lines).
       > Hunk #17 succeeded at 5525 (offset 8 lines).
       > Hunk #18 succeeded at 6999 (offset -7 lines).
       > Hunk #19 succeeded at 7012 (offset -7 lines).
       > Hunk #20 succeeded at 7067 (offset -7 lines).
       > Hunk #21 succeeded at 7085 (offset -7 lines).
       > Hunk #22 succeeded at 7296 (offset -9 lines).
       > Hunk #23 FAILED at 8960.
       > Hunk #24 succeeded at 9230 (offset 96 lines).
       > Hunk #25 succeeded at 13702 (offset 96 lines).
       > 1 out of 25 hunks FAILED -- saving rejects to file kernel/sched/fair.c.rej
       > patching file kernel/sched/features.h
       > patching file kernel/sched/sched.h
       For full logs, run:
         nix log /nix/store/698sy0gn6pzn58fn9xjww64k8c0c3vxf-linux-cachyos-config.drv
```