### PR TITLE
7.0: drop obsolete GCC 16 gcc-common.h patch for 7.0.11

### DIFF
--- a/7.0/misc/0001-hardened.patch
+++ b/7.0/misc/0001-hardened.patch
@@ -1,9 +1,8 @@
-From f8a1d38107767868ac980e96343d2479e5ff0bdb Mon Sep 17 00:00:00 2001
-From: Peter Jung <admin@ptr1337.dev>
-Date: Sat, 23 May 2026 12:08:51 +0200
-Subject: [PATCH] hardened
+From b46cff7444c604222a592e0bf7cc3440d91e7c4e Mon Sep 17 00:00:00 2001
+From: loner <2788892716@qq.com>
+Date: Wed, 3 Jun 2026 07:02:14 +0800
+Subject: [PATCH] hardened: forward-port patch to CachyOS 7.0.11
 
-Signed-off-by: Peter Jung <admin@ptr1337.dev>
 ---
  .../admin-guide/kernel-parameters.txt         |  16 +-
  Documentation/admin-guide/sysctl/kernel.rst   |  22 ++
@@ -82,7 +81,6 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  net/ipv4/tcp_input.c                          |   3 +-
  scripts/Makefile.modpost                      |   1 +
  scripts/gcc-plugins/Kconfig                   |   5 +
- scripts/gcc-plugins/gcc-common.h              |   5 +
  scripts/mod/modpost.c                         |  33 +-
  security/Kconfig                              |  28 +-
  security/Kconfig.hardening                    |  21 ++
@@ -91,17 +89,17 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  security/yama/Kconfig                         |   2 +-
  tools/perf/Documentation/security.txt         |   1 +
  tools/perf/util/evsel.c                       |   1 +
- 86 files changed, 920 insertions(+), 175 deletions(-)
+ 85 files changed, 915 insertions(+), 175 deletions(-)
  create mode 100644 drivers/usb/core/sysctl.c
 
 diff --git a/Documentation/admin-guide/kernel-parameters.txt b/Documentation/admin-guide/kernel-parameters.txt
-index ba3b6da4c71f..52abcf299d70 100644
+index ba3b6da4c..52abcf299 100644
 --- a/Documentation/admin-guide/kernel-parameters.txt
 +++ b/Documentation/admin-guide/kernel-parameters.txt
 @@ -778,17 +778,6 @@ Kernel parameters
  			Format: { "0" | "1" }
  			Default: 0 (1 if CONFIG_DEBUG_VM is set)
- 
+
 -	checkreqprot=	[SELINUX] Set initial checkreqprot flag value.
 -			Format: { "0" | "1" }
 -			See security/selinux/Kconfig help text.
@@ -115,36 +113,36 @@ index ba3b6da4c71f..52abcf299d70 100644
 -
  	cio_ignore=	[S390]
  			See Documentation/arch/s390/common_io.rst for details.
- 
+
 @@ -5058,6 +5047,11 @@ Kernel parameters
  			the specified number of seconds.  This is to be used if
  			your oopses keep scrolling off the screen.
- 
+
 +	extra_latent_entropy
 +			Enable a very simple form of latent entropy extraction
 +			from the first 4GB of memory as the bootmem allocator
 +			passes the memory pages to the buddy allocator.
 +
  	pcbit=		[HW,ISDN]
- 
+
  	pci=option[,option...]	[PCI,EARLY] various PCI subsystem options.
 diff --git a/Documentation/admin-guide/sysctl/kernel.rst b/Documentation/admin-guide/sysctl/kernel.rst
-index 9aed74e65cf4..2b001d43b137 100644
+index 9aed74e65..2b001d43b 100644
 --- a/Documentation/admin-guide/sysctl/kernel.rst
 +++ b/Documentation/admin-guide/sysctl/kernel.rst
 @@ -1014,6 +1014,8 @@ with respect to CAP_PERFMON use cases.
  >=1  Disallow CPU event access by users without ``CAP_PERFMON``.
- 
+
  >=2  Disallow kernel profiling by users without ``CAP_PERFMON``.
 +
 +>=3  Disallow use of any event by users without ``CAP_PERFMON``.
  ===  ==================================================================
- 
- 
+
+
 @@ -1596,6 +1598,26 @@ allow them to remain in low power states longer.
- 
+
  Default is set (1).
- 
+
 +tiocsti_restrict
 +================
 +
@@ -167,15 +165,15 @@ index 9aed74e65cf4..2b001d43b137 100644
 +
  traceoff_on_warning
  ===================
- 
+
 diff --git a/Documentation/networking/ip-sysctl.rst b/Documentation/networking/ip-sysctl.rst
-index 6921d8594b84..3dcd0f39cf84 100644
+index 6921d8594..3dcd0f39c 100644
 --- a/Documentation/networking/ip-sysctl.rst
 +++ b/Documentation/networking/ip-sysctl.rst
 @@ -909,6 +909,24 @@ tcp_backlog_ack_defer - BOOLEAN
- 
+
  	Default: 1 (enabled)
- 
+
 +tcp_simult_connect - BOOLEAN
 +	Enable TCP simultaneous connect that adds a weakness in Linux's strict
 +	implementation of TCP that allows two clients to connect to each other
@@ -198,7 +196,7 @@ index 6921d8594b84..3dcd0f39cf84 100644
  	If enabled, provide RFC2861 behavior and time out the congestion
  	window after an idle period.  An idle period is defined at
 diff --git a/arch/Kconfig b/arch/Kconfig
-index 1a90882eccc1..60dc95b26e17 100644
+index 1a90882ec..60dc95b26 100644
 --- a/arch/Kconfig
 +++ b/arch/Kconfig
 @@ -1235,7 +1235,7 @@ config ARCH_MMAP_RND_BITS
@@ -228,7 +226,7 @@ index 1a90882eccc1..60dc95b26e17 100644
  	  Kernel stack offset randomization is controlled by kernel boot param
  	  "randomize_kstack_offset=on/off", and this config chooses the default
 diff --git a/arch/arm64/Kconfig b/arch/arm64/Kconfig
-index 9ea19b74b6c3..c33af2cb319c 100644
+index 9ea19b74b..c33af2cb3 100644
 --- a/arch/arm64/Kconfig
 +++ b/arch/arm64/Kconfig
 @@ -1702,6 +1702,7 @@ config MITIGATE_SPECTRE_BRANCH_HISTORY
@@ -248,7 +246,7 @@ index 9ea19b74b6c3..c33af2cb319c 100644
  	  Randomizes the virtual address at which the kernel image is
  	  loaded, as a security feature that deters exploit attempts
 diff --git a/arch/arm64/configs/defconfig b/arch/arm64/configs/defconfig
-index b67d5b1fc45b..54c8002590fb 100644
+index b67d5b1fc..54c800259 100644
 --- a/arch/arm64/configs/defconfig
 +++ b/arch/arm64/configs/defconfig
 @@ -1,4 +1,3 @@
@@ -257,11 +255,11 @@ index b67d5b1fc45b..54c8002590fb 100644
  CONFIG_AUDIT=y
  CONFIG_NO_HZ_IDLE=y
 diff --git a/arch/arm64/include/asm/elf.h b/arch/arm64/include/asm/elf.h
-index d2779d604c7b..ed0d158955e2 100644
+index d2779d604..ed0d15895 100644
 --- a/arch/arm64/include/asm/elf.h
 +++ b/arch/arm64/include/asm/elf.h
 @@ -124,14 +124,10 @@
- 
+
  /*
   * This is the base location for PIE (ET_DYN with INTERP) loads. On
 - * 64-bit, this is above 4GB to leave the entire 32-bit address
@@ -274,9 +272,9 @@ index d2779d604c7b..ed0d158955e2 100644
 -#define ELF_ET_DYN_BASE		(2 * DEFAULT_MAP_WINDOW_64 / 3)
 -#endif /* CONFIG_ARM64_FORCE_52BIT */
 +#define ELF_ET_DYN_BASE		0x100000000UL
- 
+
  #ifndef __ASSEMBLER__
- 
+
 @@ -189,10 +185,10 @@ extern int arch_setup_additional_pages(struct linux_binprm *bprm,
  /* 1GB of VA */
  #ifdef CONFIG_COMPAT
@@ -289,15 +287,15 @@ index d2779d604c7b..ed0d158955e2 100644
 -#define STACK_RND_MASK			(0x3ffff >> (PAGE_SHIFT - 12))
 +#define STACK_RND_MASK			(((1UL << mmap_rnd_bits) - 1) >> (PAGE_SHIFT - 12))
  #endif
- 
+
  #ifdef __AARCH64EB__
 diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
-index 428a96e5d363..4ec390c0c2d3 100644
+index 428a96e5d..4ec390c0c 100644
 --- a/arch/x86/Kconfig
 +++ b/arch/x86/Kconfig
 @@ -1242,8 +1242,7 @@ config VM86
  	default X86_LEGACY_VM86
- 
+
  config X86_16BIT
 -	bool "Enable support for 16-bit segments" if EXPERT
 -	default y
@@ -316,7 +314,7 @@ index 428a96e5d363..4ec390c0c2d3 100644
  	  to be able to issue three syscalls by calling fixed addresses in
 @@ -2319,8 +2318,7 @@ config CMDLINE_OVERRIDE
  	  be set to 'N' under normal conditions.
- 
+
  config MODIFY_LDT_SYSCALL
 -	bool "Enable the LDT (local descriptor table)" if EXPERT
 -	default y
@@ -325,7 +323,7 @@ index 428a96e5d363..4ec390c0c2d3 100644
  	  Linux can allow user programs to install a per-process x86
  	  Local Descriptor Table (LDT) using the modify_ldt(2) system
 diff --git a/arch/x86/configs/x86_64_defconfig b/arch/x86/configs/x86_64_defconfig
-index 7d7310cdf8b0..21ebfefe9c90 100644
+index 7d7310cdf..21ebfefe9 100644
 --- a/arch/x86/configs/x86_64_defconfig
 +++ b/arch/x86/configs/x86_64_defconfig
 @@ -1,5 +1,4 @@
@@ -335,11 +333,11 @@ index 7d7310cdf8b0..21ebfefe9c90 100644
  CONFIG_AUDIT=y
  CONFIG_NO_HZ=y
 diff --git a/arch/x86/include/asm/elf.h b/arch/x86/include/asm/elf.h
-index 2ba5f166e58f..8189290a13a5 100644
+index 2ba5f166e..8189290a1 100644
 --- a/arch/x86/include/asm/elf.h
 +++ b/arch/x86/include/asm/elf.h
 @@ -229,11 +229,11 @@ extern int force_personality32;
- 
+
  /*
   * This is the base location for PIE (ET_DYN with INTERP) loads. On
 - * 64-bit, this is above 4GB to leave the entire 32-bit address
@@ -349,23 +347,23 @@ index 2ba5f166e58f..8189290a13a5 100644
  #define ELF_ET_DYN_BASE		(mmap_is_ia32() ? 0x000400000UL : \
 -						  (DEFAULT_MAP_WINDOW / 3 * 2))
 +						  0x100000000UL)
- 
+
  /* This yields a mask that user programs can use to figure out what
     instruction set this CPU supports.  This could be done in user space,
 @@ -315,8 +315,8 @@ extern unsigned long get_sigframe_size(void);
- 
+
  #ifdef CONFIG_X86_32
- 
+
 -#define __STACK_RND_MASK(is32bit) (0x7ff)
 -#define STACK_RND_MASK (0x7ff)
 +#define __STACK_RND_MASK(is32bit) ((1UL << mmap_rnd_bits) - 1)
 +#define STACK_RND_MASK ((1UL << mmap_rnd_bits) - 1)
- 
+
  #define ARCH_DLINFO		ARCH_DLINFO_IA32
- 
+
 @@ -325,7 +325,11 @@ extern unsigned long get_sigframe_size(void);
  #else /* CONFIG_X86_32 */
- 
+
  /* 1GB for 64bit, 8MB for 32bit */
 -#define __STACK_RND_MASK(is32bit) ((is32bit) ? 0x7ff : 0x3fffff)
 +#ifdef CONFIG_COMPAT
@@ -374,14 +372,14 @@ index 2ba5f166e58f..8189290a13a5 100644
 +#define __STACK_RND_MASK(is32bit) ((1UL << mmap_rnd_bits) - 1)
 +#endif
  #define STACK_RND_MASK __STACK_RND_MASK(mmap_is_ia32())
- 
+
  #define ARCH_DLINFO							\
 diff --git a/arch/x86/include/asm/tlbflush.h b/arch/x86/include/asm/tlbflush.h
-index 0545fe75c3fa..d37c738cb23a 100644
+index 0545fe75c..d37c738cb 100644
 --- a/arch/x86/include/asm/tlbflush.h
 +++ b/arch/x86/include/asm/tlbflush.h
 @@ -510,6 +510,7 @@ extern void enter_lazy_tlb(struct mm_struct *mm, struct task_struct *tsk)
- 
+
  static inline void __native_tlb_flush_global(unsigned long cr4)
  {
 +	BUG_ON(cr4 != __read_cr4());
@@ -389,7 +387,7 @@ index 0545fe75c3fa..d37c738cb23a 100644
  	native_write_cr4(cr4);
  }
 diff --git a/arch/x86/kernel/cpu/common.c b/arch/x86/kernel/cpu/common.c
-index dde11f1665b6..a8d39bac45cf 100644
+index dde11f166..a8d39bac4 100644
 --- a/arch/x86/kernel/cpu/common.c
 +++ b/arch/x86/kernel/cpu/common.c
 @@ -494,6 +494,7 @@ EXPORT_SYMBOL_GPL(native_write_cr4);
@@ -397,11 +395,11 @@ index dde11f1665b6..a8d39bac45cf 100644
  {
  	unsigned long newval, cr4 = this_cpu_read(cpu_tlbstate.cr4);
 +	BUG_ON(cr4 != __read_cr4());
- 
+
  	lockdep_assert_irqs_disabled();
- 
+
 diff --git a/arch/x86/kernel/process.c b/arch/x86/kernel/process.c
-index 4c718f8adc59..63c96edc60a5 100644
+index 4c718f8ad..63c96edc6 100644
 --- a/arch/x86/kernel/process.c
 +++ b/arch/x86/kernel/process.c
 @@ -706,6 +706,7 @@ void speculation_ctrl_update_current(void)
@@ -409,7 +407,7 @@ index 4c718f8adc59..63c96edc60a5 100644
  {
  	unsigned long newval, cr4 = this_cpu_read(cpu_tlbstate.cr4);
 +	BUG_ON(cr4 != __read_cr4());
- 
+
  	newval = cr4 ^ mask;
  	if (newval != cr4) {
 @@ -1026,9 +1027,9 @@ unsigned long arch_align_stack(unsigned long sp)
@@ -418,18 +416,18 @@ index 4c718f8adc59..63c96edc60a5 100644
  	if (mmap_is_ia32())
 -		return randomize_page(mm->brk, SZ_32M);
 +		return mm->brk + get_random_long() % SZ_32M + PAGE_SIZE;
- 
+
 -	return randomize_page(mm->brk, SZ_1G);
 +	return mm->brk + get_random_long() % SZ_1G + PAGE_SIZE;
  }
- 
+
  /*
 diff --git a/arch/x86/mm/init_32.c b/arch/x86/mm/init_32.c
-index 0908c44d51e6..edf0b9ea159c 100644
+index 0908c44d5..edf0b9ea1 100644
 --- a/arch/x86/mm/init_32.c
 +++ b/arch/x86/mm/init_32.c
 @@ -499,9 +499,9 @@ static void __init pagetable_init(void)
- 
+
  #define DEFAULT_PTE_MASK ~(_PAGE_NX | _PAGE_GLOBAL)
  /* Bits supported by the hardware: */
 -pteval_t __supported_pte_mask __read_mostly = DEFAULT_PTE_MASK;
@@ -441,12 +439,12 @@ index 0908c44d51e6..edf0b9ea159c 100644
  /* Used in PAGE_KERNEL_* macros which are reasonably used out-of-tree: */
  EXPORT_SYMBOL(__default_kernel_pte_mask);
 diff --git a/arch/x86/mm/init_64.c b/arch/x86/mm/init_64.c
-index df2261fa4f98..b8bf29695e0d 100644
+index df2261fa4..b8bf29695 100644
 --- a/arch/x86/mm/init_64.c
 +++ b/arch/x86/mm/init_64.c
 @@ -104,9 +104,9 @@ static inline pgprot_t prot_sethuge(pgprot_t prot)
   */
- 
+
  /* Bits supported by the hardware: */
 -pteval_t __supported_pte_mask __read_mostly = ~0;
 +pteval_t __supported_pte_mask __ro_after_init = ~0;
@@ -457,23 +455,23 @@ index df2261fa4f98..b8bf29695e0d 100644
  /* Used in PAGE_KERNEL_* macros which are reasonably used out-of-tree: */
  EXPORT_SYMBOL(__default_kernel_pte_mask);
 diff --git a/drivers/ata/libata-core.c b/drivers/ata/libata-core.c
-index 374993031895..ef51e7adf101 100644
+index f8c2e3192..edb798d0f 100644
 --- a/drivers/ata/libata-core.c
 +++ b/drivers/ata/libata-core.c
 @@ -4929,6 +4929,7 @@ void __ata_qc_complete(struct ata_queued_cmd *qc)
  	struct ata_port *ap;
  	struct ata_link *link;
- 
+
 +	BUG_ON(qc == NULL); /* ata_qc_from_tag _might_ return NULL */
  	if (WARN_ON_ONCE(!(qc->flags & ATA_QCFLAG_ACTIVE)))
  		return;
- 
+
 diff --git a/drivers/char/Kconfig b/drivers/char/Kconfig
-index 2a3a37b2cf3c..8d669c63ad7c 100644
+index 2a3a37b2c..8d669c63a 100644
 --- a/drivers/char/Kconfig
 +++ b/drivers/char/Kconfig
 @@ -284,7 +284,6 @@ config NSC_GPIO
- 
+
  config DEVMEM
  	bool "/dev/mem virtual device support"
 -	default y
@@ -489,11 +487,11 @@ index 2a3a37b2cf3c..8d669c63ad7c 100644
  	  Say Y here if you want to support the /dev/port device. The /dev/port
  	  device is similar to /dev/mem, but for I/O ports.
 diff --git a/drivers/tty/Kconfig b/drivers/tty/Kconfig
-index 149f3d53b760..a3e62d52ebcf 100644
+index 149f3d53b..a3e62d52e 100644
 --- a/drivers/tty/Kconfig
 +++ b/drivers/tty/Kconfig
 @@ -116,7 +116,6 @@ config UNIX98_PTYS
- 
+
  config LEGACY_PTYS
  	bool "Legacy (BSD) PTY support"
 -	default y
@@ -501,7 +499,7 @@ index 149f3d53b760..a3e62d52ebcf 100644
  	  A pseudo terminal (PTY) is a software device consisting of two
  	  halves: a master and a slave. The slave device behaves identical to
 @@ -146,7 +145,6 @@ config LEGACY_PTY_COUNT
- 
+
  config LEGACY_TIOCSTI
  	bool "Allow legacy TIOCSTI usage"
 -	default y
@@ -509,7 +507,7 @@ index 149f3d53b760..a3e62d52ebcf 100644
  	  Historically the kernel has allowed TIOCSTI, which will push
  	  characters into a controlling TTY. This continues to be used
 diff --git a/drivers/tty/tty_io.c b/drivers/tty/tty_io.c
-index a5d0457e0e28..dc32c90a4424 100644
+index a5d0457e0..dc32c90a4 100644
 --- a/drivers/tty/tty_io.c
 +++ b/drivers/tty/tty_io.c
 @@ -171,6 +171,7 @@ static void free_tty_struct(struct tty_struct *tty)
@@ -519,10 +517,10 @@ index a5d0457e0e28..dc32c90a4424 100644
 +	put_user_ns(tty->owner_user_ns);
  	kfree(tty);
  }
- 
+
 @@ -2256,6 +2257,7 @@ static int tty_fasync(int fd, struct file *filp, int on)
  }
- 
+
  static bool tty_legacy_tiocsti __read_mostly = IS_ENABLED(CONFIG_LEGACY_TIOCSTI);
 +static int tty_tiocsti_restrict __read_mostly = IS_ENABLED(CONFIG_SECURITY_TIOCSTI_RESTRICT);
  /**
@@ -531,7 +529,7 @@ index a5d0457e0e28..dc32c90a4424 100644
 @@ -2277,6 +2279,12 @@ static int tiocsti(struct tty_struct *tty, u8 __user *p)
  	if (!tty_legacy_tiocsti && !capable(CAP_SYS_ADMIN))
  		return -EIO;
- 
+
 +	if (tty_tiocsti_restrict &&
 +		!ns_capable(tty->owner_user_ns, CAP_SYS_ADMIN)) {
 +		dev_warn_ratelimited(tty->dev,
@@ -546,7 +544,7 @@ index a5d0457e0e28..dc32c90a4424 100644
  	tty_line_name(driver, idx, tty->name);
  	tty->dev = tty_get_device(tty);
 +	tty->owner_user_ns = get_user_ns(current_user_ns());
- 
+
  	return tty;
  }
 @@ -3617,6 +3626,15 @@ static const struct ctl_table tty_table[] = {
@@ -563,10 +561,10 @@ index a5d0457e0e28..dc32c90a4424 100644
 +		.extra2		= SYSCTL_ONE,
 +	},
  };
- 
+
  /*
 diff --git a/drivers/usb/core/Makefile b/drivers/usb/core/Makefile
-index 60ea76160122..cb5ed42e12c2 100644
+index 60ea76160..cb5ed42e1 100644
 --- a/drivers/usb/core/Makefile
 +++ b/drivers/usb/core/Makefile
 @@ -15,6 +15,7 @@ usbcore-$(CONFIG_OF)		+= of.o
@@ -574,11 +572,11 @@ index 60ea76160122..cb5ed42e12c2 100644
  usbcore-$(CONFIG_USB_PCI)		+= hcd-pci.o
  usbcore-$(CONFIG_ACPI)		+= usb-acpi.o
 +usbcore-$(CONFIG_SYSCTL)		+= sysctl.o
- 
+
  ifdef CONFIG_USB_ONBOARD_DEV
  usbcore-y			+= ../misc/onboard_usb_dev_pdevs.o
 diff --git a/drivers/usb/core/hub.c b/drivers/usb/core/hub.c
-index 24960ba9caa9..457d28bc990f 100644
+index 24960ba9c..457d28bc9 100644
 --- a/drivers/usb/core/hub.c
 +++ b/drivers/usb/core/hub.c
 @@ -5448,6 +5448,12 @@ static void hub_port_connect(struct usb_hub *hub, int port1, u16 portstatus,
@@ -596,7 +594,7 @@ index 24960ba9caa9..457d28bc990f 100644
  	else
 diff --git a/drivers/usb/core/sysctl.c b/drivers/usb/core/sysctl.c
 new file mode 100644
-index 000000000000..813db3f0b1cb
+index 000000000..813db3f0b
 --- /dev/null
 +++ b/drivers/usb/core/sysctl.c
 @@ -0,0 +1,35 @@
@@ -636,13 +634,13 @@ index 000000000000..813db3f0b1cb
 +	usb_sysctl_table = NULL;
 +}
 diff --git a/drivers/usb/core/usb.c b/drivers/usb/core/usb.c
-index df166cafe106..e32de22b9aad 100644
+index df166cafe..e32de22b9 100644
 --- a/drivers/usb/core/usb.c
 +++ b/drivers/usb/core/usb.c
 @@ -73,6 +73,9 @@ MODULE_PARM_DESC(autosuspend, "default autosuspend delay");
  #define usb_autosuspend_delay		0
  #endif
- 
+
 +int deny_new_usb __read_mostly = 0;
 +EXPORT_SYMBOL(deny_new_usb);
 +
@@ -651,7 +649,7 @@ index df166cafe106..e32de22b9aad 100644
  		struct usb_endpoint_descriptor **bulk_out,
 @@ -1220,6 +1223,9 @@ static int __init usb_init(void)
  	usb_debugfs_init();
- 
+
  	usb_acpi_register();
 +	retval = usb_register_sysctl();
 +	if (retval)
@@ -677,13 +675,13 @@ index df166cafe106..e32de22b9aad 100644
  	usb_debugfs_cleanup();
  	idr_destroy(&usb_bus_idr);
 diff --git a/fs/inode.c b/fs/inode.c
-index cc12b68e021b..9209fa27b417 100644
+index e10439d8d..17374f00a 100644
 --- a/fs/inode.c
 +++ b/fs/inode.c
 @@ -168,6 +168,10 @@ late_initcall(mg_debugfs_init);
- 
+
  #endif /* CONFIG_DEBUG_FS */
- 
+
 +/* sysctl */
 +int device_sidechannel_restrict __read_mostly = 1;
 +EXPORT_SYMBOL(device_sidechannel_restrict);
@@ -705,16 +703,16 @@ index cc12b68e021b..9209fa27b417 100644
 +		.extra2		= SYSCTL_ONE,
 +	},
  };
- 
+
  static int __init init_fs_inode_sysctls(void)
 diff --git a/fs/namei.c b/fs/namei.c
-index 9e5500dad14f..1c7cc151c721 100644
+index 9e5500dad..1c7cc151c 100644
 --- a/fs/namei.c
 +++ b/fs/namei.c
 @@ -1196,10 +1196,10 @@ static inline void put_link(struct nameidata *nd)
  		path_put(&last->link);
  }
- 
+
 -static int sysctl_protected_symlinks __read_mostly;
 -static int sysctl_protected_hardlinks __read_mostly;
 -static int sysctl_protected_fifos __read_mostly;
@@ -723,11 +721,11 @@ index 9e5500dad14f..1c7cc151c721 100644
 +static int sysctl_protected_hardlinks __read_mostly = 1;
 +static int sysctl_protected_fifos __read_mostly = 2;
 +static int sysctl_protected_regular __read_mostly = 2;
- 
+
  #ifdef CONFIG_SYSCTL
  static const struct ctl_table namei_sysctls[] = {
 diff --git a/fs/nfs/Kconfig b/fs/nfs/Kconfig
-index 6bb30543eff0..c6951309ff24 100644
+index 6bb30543e..c6951309f 100644
 --- a/fs/nfs/Kconfig
 +++ b/fs/nfs/Kconfig
 @@ -198,7 +198,6 @@ config NFS_USE_KERNEL_DNS
@@ -735,16 +733,16 @@ index 6bb30543eff0..c6951309ff24 100644
  	bool
  	depends on NFS_FS && SUNRPC_DEBUG
 -	default y
- 
+
  config NFS_DISABLE_UDP_SUPPORT
         bool "NFS: Disable NFS UDP protocol support"
 diff --git a/fs/overlayfs/Kconfig b/fs/overlayfs/Kconfig
-index 2ac67e04a6fb..3340e13c959c 100644
+index 2ac67e04a..3340e13c9 100644
 --- a/fs/overlayfs/Kconfig
 +++ b/fs/overlayfs/Kconfig
 @@ -134,3 +134,19 @@ config OVERLAY_FS_DEBUG
  	  Say Y here to enable extra debugging checks in overlayfs.
- 
+
  	  If unsure, say N.
 +
 +config OVERLAY_FS_UNPRIVILEGED
@@ -763,7 +761,7 @@ index 2ac67e04a6fb..3340e13c959c 100644
 +
 +	  If unsure, say N.
 diff --git a/fs/overlayfs/super.c b/fs/overlayfs/super.c
-index 0822987cfb51..b2faf437dc36 100644
+index 0822987cf..b2faf437d 100644
 --- a/fs/overlayfs/super.c
 +++ b/fs/overlayfs/super.c
 @@ -1577,7 +1577,9 @@ struct file_system_type ovl_fs_type = {
@@ -777,7 +775,7 @@ index 0822987cfb51..b2faf437dc36 100644
  };
  MODULE_ALIAS_FS("overlay");
 diff --git a/fs/proc/Kconfig b/fs/proc/Kconfig
-index 6ae966c561e7..27d78d669f95 100644
+index 6ae966c56..27d78d669 100644
 --- a/fs/proc/Kconfig
 +++ b/fs/proc/Kconfig
 @@ -41,7 +41,6 @@ config PROC_KCORE
@@ -787,9 +785,9 @@ index 6ae966c561e7..27d78d669f95 100644
 -	default y
  	help
  	  Exports the dump image of crashed kernel in ELF format.
- 
+
 diff --git a/fs/proc/proc_sysctl.c b/fs/proc/proc_sysctl.c
-index 49ab74e0bfde..4be54d32a60a 100644
+index 49ab74e0b..4be54d32a 100644
 --- a/fs/proc/proc_sysctl.c
 +++ b/fs/proc/proc_sysctl.c
 @@ -1154,6 +1154,7 @@ static int sysctl_check_table(const char *path, struct ctl_table_header *header)
@@ -801,13 +799,13 @@ index 49ab74e0bfde..4be54d32a60a 100644
  		    (entry->proc_handler == proc_dointvec_jiffies) ||
  		    (entry->proc_handler == proc_dointvec_userhz_jiffies) ||
 diff --git a/fs/stat.c b/fs/stat.c
-index 89909746bed1..92642e583e8c 100644
+index 89909746b..92642e583 100644
 --- a/fs/stat.c
 +++ b/fs/stat.c
 @@ -52,7 +52,10 @@ void fill_mg_cmtime(struct kstat *stat, u32 request_mask, struct inode *inode)
  		return;
  	}
- 
+
 -	stat->mtime = inode_get_mtime(inode);
 +	if (is_sidechannel_device(inode) && !capable_noaudit(CAP_MKNOD))
 +		stat->mtime = inode_get_ctime(inode);
@@ -821,7 +819,7 @@ index 89909746bed1..92642e583e8c 100644
  	vfsuid_t vfsuid = i_uid_into_vfsuid(idmap, inode);
  	vfsgid_t vfsgid = i_gid_into_vfsgid(idmap, inode);
 +	bool sidechannel_device = false;
- 
+
  	stat->dev = inode->i_sb->s_dev;
  	stat->ino = inode->i_ino;
 @@ -93,13 +97,22 @@ void generic_fillattr(struct mnt_idmap *idmap, u32 request_mask,
@@ -836,7 +834,7 @@ index 89909746bed1..92642e583e8c 100644
 +		stat->atime = inode_get_ctime(inode);
 +	else
 +		stat->atime = inode_get_atime(inode);
- 
+
  	if (is_mgtime(inode)) {
  		fill_mg_cmtime(stat, request_mask, inode);
  	} else {
@@ -847,10 +845,10 @@ index 89909746bed1..92642e583e8c 100644
 +		else
 +			stat->mtime = inode_get_mtime(inode);
  	}
- 
+
  	stat->blksize = i_blocksize(inode);
 @@ -212,6 +225,10 @@ int vfs_getattr_nosec(const struct path *path, struct kstat *stat,
- 
+
  		ret = inode->i_op->getattr(idmap, path, stat, request_mask,
  				query_flags);
 +		if (!ret && is_sidechannel_device(inode) && !capable_noaudit(CAP_MKNOD)) {
@@ -861,20 +859,20 @@ index 89909746bed1..92642e583e8c 100644
  			return ret;
  	} else {
 diff --git a/include/linux/cache.h b/include/linux/cache.h
-index e69768f50d53..432c30a1fc7e 100644
+index e69768f50..432c30a1f 100644
 --- a/include/linux/cache.h
 +++ b/include/linux/cache.h
 @@ -60,6 +60,8 @@
  #define __ro_after_init __section(".data..ro_after_init")
  #endif
- 
+
 +#define __read_only __ro_after_init
 +
  #ifndef ____cacheline_aligned_in_smp
  #ifdef CONFIG_SMP
  #define ____cacheline_aligned_in_smp ____cacheline_aligned
 diff --git a/include/linux/capability.h b/include/linux/capability.h
-index 37db92b3d6f8..873416ba884c 100644
+index 37db92b3d..873416ba8 100644
 --- a/include/linux/capability.h
 +++ b/include/linux/capability.h
 @@ -145,6 +145,7 @@ extern bool has_capability_noaudit(struct task_struct *t, int cap);
@@ -897,13 +895,13 @@ index 37db92b3d6f8..873416ba884c 100644
  {
  	return true;
 diff --git a/include/linux/fs.h b/include/linux/fs.h
-index ef17f9e211e4..ba776fdcbee5 100644
+index ef17f9e21..ba776fdcb 100644
 --- a/include/linux/fs.h
 +++ b/include/linux/fs.h
 @@ -3656,4 +3656,15 @@ static inline bool extensible_ioctl_valid(unsigned int cmd_a,
  	return true;
  }
- 
+
 +extern int device_sidechannel_restrict;
 +
 +static inline bool is_sidechannel_device(const struct inode *inode)
@@ -917,27 +915,27 @@ index ef17f9e211e4..ba776fdcbee5 100644
 +
  #endif /* _LINUX_FS_H */
 diff --git a/include/linux/fsnotify.h b/include/linux/fsnotify.h
-index 079c18bcdbde..eb8a9e769394 100644
+index 079c18bcd..eb8a9e769 100644
 --- a/include/linux/fsnotify.h
 +++ b/include/linux/fsnotify.h
 @@ -124,6 +124,9 @@ static inline int fsnotify_file(struct file *file, __u32 mask)
  	if (FMODE_FSNOTIFY_NONE(file->f_mode))
  		return 0;
- 
+
 +	if (mask & (FS_ACCESS | FS_MODIFY) && is_sidechannel_device(file_inode(file)))
 +		return 0;
 +
  	return fsnotify_path(&file->f_path, mask);
  }
- 
+
 diff --git a/include/linux/highmem.h b/include/linux/highmem.h
-index af03db851a1d..26885da1a943 100644
+index d7aac9de1..e998775fc 100644
 --- a/include/linux/highmem.h
 +++ b/include/linux/highmem.h
-@@ -355,6 +355,13 @@ static inline bool tag_clear_highpages(struct page *page, int numpages)
- 
+@@ -356,6 +356,13 @@ static inline bool tag_clear_highpages(struct page *page, int numpages,
+
  #endif
- 
+
 +static inline void verify_zero_highpage(struct page *page)
 +{
 +	void *kaddr = kmap_atomic(page);
@@ -949,39 +947,39 @@ index af03db851a1d..26885da1a943 100644
   * If we pass in a base or tail page, we can zero up to PAGE_SIZE.
   * If we pass in a head page, we can zero up to the size of the compound page.
 diff --git a/include/linux/interrupt.h b/include/linux/interrupt.h
-index 6cd26ffb0505..479fb0cacbd1 100644
+index 6cd26ffb0..479fb0cac 100644
 --- a/include/linux/interrupt.h
 +++ b/include/linux/interrupt.h
 @@ -604,7 +604,7 @@ static inline void do_softirq_post_smp_call_flush(unsigned int unused)
  }
  #endif
- 
+
 -extern void open_softirq(int nr, void (*action)(void));
 +extern void __init open_softirq(int nr, void (*action)(void));
  extern void softirq_init(void);
  extern void __raise_softirq_irqoff(unsigned int nr);
- 
+
 diff --git a/include/linux/kobject_ns.h b/include/linux/kobject_ns.h
-index 4f0990e09b93..94d775949d2b 100644
+index 4f0990e09..94d775949 100644
 --- a/include/linux/kobject_ns.h
 +++ b/include/linux/kobject_ns.h
 @@ -46,7 +46,7 @@ struct kobj_ns_type_operations {
  	void (*drop_ns)(struct ns_common *);
  };
- 
+
 -int kobj_ns_type_register(const struct kobj_ns_type_operations *ops);
 +int __init kobj_ns_type_register(const struct kobj_ns_type_operations *ops);
  int kobj_ns_type_registered(enum kobj_ns_type type);
  const struct kobj_ns_type_operations *kobj_child_ns_ops(const struct kobject *parent);
  const struct kobj_ns_type_operations *kobj_ns_ops(const struct kobject *kobj);
 diff --git a/include/linux/perf_event.h b/include/linux/perf_event.h
-index 7c1dac8da5e5..e0dfa8557ea5 100644
+index 7c1dac8da..e0dfa8557 100644
 --- a/include/linux/perf_event.h
 +++ b/include/linux/perf_event.h
 @@ -1792,6 +1792,14 @@ static inline int perf_is_paranoid(void)
- 
+
  extern int perf_allow_kernel(void);
- 
+
 +static inline int perf_allow_open(void)
 +{
 +	if (sysctl_perf_event_paranoid > 2 && !perfmon_capable())
@@ -994,7 +992,7 @@ index 7c1dac8da5e5..e0dfa8557ea5 100644
  {
  	if (sysctl_perf_event_paranoid > 0 && !perfmon_capable())
 diff --git a/include/linux/sysctl.h b/include/linux/sysctl.h
-index 2886fbceb5d6..3e0b05485321 100644
+index 2886fbceb..3e0b05485 100644
 --- a/include/linux/sysctl.h
 +++ b/include/linux/sysctl.h
 @@ -84,6 +84,8 @@ int proc_dobool(const struct ctl_table *table, int write, void *buffer,
@@ -1007,7 +1005,7 @@ index 2886fbceb5d6..3e0b05485321 100644
  		       size_t *lenp, loff_t *ppos,
  		       int (*conv)(bool *negp, unsigned long *u_ptr, int *k_ptr,
 diff --git a/include/linux/tty.h b/include/linux/tty.h
-index 0a46e4054dec..99c733852fb2 100644
+index 0a46e4054..99c733852 100644
 --- a/include/linux/tty.h
 +++ b/include/linux/tty.h
 @@ -14,6 +14,7 @@
@@ -1015,25 +1013,25 @@ index 0a46e4054dec..99c733852fb2 100644
  #include <linux/rwsem.h>
  #include <linux/llist.h>
 +#include <linux/user_namespace.h>
- 
- 
+
+
  /*
 @@ -240,6 +241,7 @@ struct tty_struct {
  	struct list_head tty_files;
- 
+
  	struct work_struct SAK_work;
 +	struct user_namespace *owner_user_ns;
  } __randomize_layout;
- 
+
  /* Each of a tty's open files has private_data pointing to tty_file_private */
 diff --git a/include/linux/usb.h b/include/linux/usb.h
-index 60bd4a8e919a..9ef7409ee97c 100644
+index 60bd4a8e9..9ef7409ee 100644
 --- a/include/linux/usb.h
 +++ b/include/linux/usb.h
 @@ -2110,6 +2110,17 @@ extern void usb_led_activity(enum usb_led_event ev);
  static inline void usb_led_activity(enum usb_led_event ev) {}
  #endif
- 
+
 +/* sysctl.c */
 +extern int deny_new_usb;
 +#ifdef CONFIG_SYSCTL
@@ -1046,16 +1044,16 @@ index 60bd4a8e919a..9ef7409ee97c 100644
 +
 +
  #endif  /* __KERNEL__ */
- 
+
  #endif
 diff --git a/include/linux/user_namespace.h b/include/linux/user_namespace.h
-index 9c3be157397e..bb05d4a07c46 100644
+index 9c3be1573..bb05d4a07 100644
 --- a/include/linux/user_namespace.h
 +++ b/include/linux/user_namespace.h
 @@ -173,6 +173,8 @@ static inline struct user_namespace *to_user_ns(struct ns_common *ns)
- 
+
  #ifdef CONFIG_USER_NS
- 
+
 +extern int unprivileged_userns_clone;
 +
  static inline struct user_namespace *get_user_ns(struct user_namespace *ns)
@@ -1064,26 +1062,26 @@ index 9c3be157397e..bb05d4a07c46 100644
 @@ -206,6 +208,8 @@ extern bool current_in_userns(const struct user_namespace *target_ns);
  struct ns_common *ns_get_owner(struct ns_common *ns);
  #else
- 
+
 +#define unprivileged_userns_clone 0
 +
  static inline struct user_namespace *get_user_ns(struct user_namespace *ns)
  {
  	return &init_user_ns;
 diff --git a/include/net/tcp.h b/include/net/tcp.h
-index b55682a3c3fa..381a89e30d49 100644
+index 74b3360e1..ff9bc0ea5 100644
 --- a/include/net/tcp.h
 +++ b/include/net/tcp.h
-@@ -287,6 +287,7 @@ static_assert((1 << ATO_BITS) > TCP_DELACK_MAX);
+@@ -285,6 +285,7 @@ static_assert((1 << ATO_BITS) > TCP_DELACK_MAX);
  /* sysctl variables for tcp */
  extern int sysctl_tcp_max_orphans;
  extern long sysctl_tcp_mem[3];
 +extern int sysctl_tcp_simult_connect;
- 
+
  #define TCP_RACK_LOSS_DETECTION  0x1 /* Use RACK to detect losses */
  #define TCP_RACK_STATIC_REO_WND  0x2 /* Use static RACK reo wnd */
 diff --git a/init/Kconfig b/init/Kconfig
-index 8de7c610d80c..c3c6db85a1c9 100644
+index 8de7c610d..c3c6db85a 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -531,6 +531,7 @@ config CROSS_MEMORY_ATTACH
@@ -1095,9 +1093,9 @@ index 8de7c610d80c..c3c6db85a1c9 100644
  	  Enable auditing infrastructure that can be used with another
  	  kernel subsystem, such as SELinux (which requires this for
 @@ -1418,6 +1419,22 @@ config USER_NS
- 
+
  	  If unsure, say N.
- 
+
 +config USER_NS_UNPRIVILEGED
 +	bool "Allow unprivileged users to create namespaces"
 +	depends on USER_NS
@@ -1119,7 +1117,7 @@ index 8de7c610d80c..c3c6db85a1c9 100644
  	default y
 @@ -1703,9 +1720,8 @@ menuconfig EXPERT
  	  Only use this if you really know what you are doing.
- 
+
  config UID16
 -	bool "Enable 16-bit UID system calls" if EXPERT
 +	bool "Enable 16-bit UID system calls"
@@ -1127,10 +1125,10 @@ index 8de7c610d80c..c3c6db85a1c9 100644
 -	default y
  	help
  	  This enables the legacy 16-bit UID syscall wrappers.
- 
+
 @@ -1891,8 +1907,7 @@ config SHMEM
  	  which may be appropriate on small systems without swap.
- 
+
  config AIO
 -	bool "Enable AIO support" if EXPERT
 -	default y
@@ -1139,17 +1137,17 @@ index 8de7c610d80c..c3c6db85a1c9 100644
  	  This option enables POSIX asynchronous I/O which may by used
  	  by some high performance threaded applications. Disabling
 diff --git a/io_uring/io_uring.c b/io_uring/io_uring.c
-index 97260bca67e7..4f4b7dbb563c 100644
+index cc4011d84..3018cc64b 100644
 --- a/io_uring/io_uring.c
 +++ b/io_uring/io_uring.c
 @@ -124,7 +124,7 @@ static __read_mostly DEFINE_STATIC_KEY_DEFERRED_FALSE(io_key_has_sqarray, HZ);
  struct kmem_cache *req_cachep;
  static struct workqueue_struct *iou_wq __ro_after_init;
- 
+
 -static int __read_mostly sysctl_io_uring_disabled;
 +static int __read_mostly sysctl_io_uring_disabled = 1;
  static int __read_mostly sysctl_io_uring_group = -1;
- 
+
  #ifdef CONFIG_SYSCTL
 @@ -134,8 +134,9 @@ static const struct ctl_table kernel_io_uring_disabled_table[] = {
  		.data		= &sysctl_io_uring_disabled,
@@ -1163,11 +1161,11 @@ index 97260bca67e7..4f4b7dbb563c 100644
  	},
  	{
 diff --git a/kernel/audit.c b/kernel/audit.c
-index 5a0216056524..e52ec85dcb77 100644
+index d3a826899..485d169d8 100644
 --- a/kernel/audit.c
 +++ b/kernel/audit.c
-@@ -1782,6 +1782,9 @@ static int __init audit_enable(char *str)
- 
+@@ -1786,6 +1786,9 @@ static int __init audit_enable(char *str)
+
  	if (audit_default == AUDIT_OFF)
  		audit_initialized = AUDIT_DISABLED;
 +	else if (!audit_ever_enabled)
@@ -1177,7 +1175,7 @@ index 5a0216056524..e52ec85dcb77 100644
  		pr_err("audit: error setting audit state (%d)\n",
  		       audit_default);
 diff --git a/kernel/bpf/core.c b/kernel/bpf/core.c
-index 7b675a451ec8..9e0a50883380 100644
+index 048d275ac..0a614753c 100644
 --- a/kernel/bpf/core.c
 +++ b/kernel/bpf/core.c
 @@ -547,7 +547,7 @@ void bpf_prog_kallsyms_del_all(struct bpf_prog *fp)
@@ -1188,9 +1186,9 @@ index 7b675a451ec8..9e0a50883380 100644
 +int bpf_jit_harden   __read_mostly = 2;
  long bpf_jit_limit   __read_mostly;
  long bpf_jit_limit_max __read_mostly;
- 
+
 diff --git a/kernel/capability.c b/kernel/capability.c
-index 829f49ae07b9..5bb7ee4028ad 100644
+index 829f49ae0..5bb7ee402 100644
 --- a/kernel/capability.c
 +++ b/kernel/capability.c
 @@ -416,6 +416,12 @@ bool capable(int cap)
@@ -1204,10 +1202,10 @@ index 829f49ae07b9..5bb7ee4028ad 100644
 +}
 +EXPORT_SYMBOL(capable_noaudit);
  #endif /* CONFIG_MULTIUSER */
- 
+
  /**
 diff --git a/kernel/events/core.c b/kernel/events/core.c
-index 89b40e439717..b9205d90e6dd 100644
+index 89b40e439..b9205d90e 100644
 --- a/kernel/events/core.c
 +++ b/kernel/events/core.c
 @@ -491,8 +491,13 @@ static __always_inline bool is_guest_mediated_pmu_loaded(void)
@@ -1221,20 +1219,20 @@ index 89b40e439717..b9205d90e6dd 100644
 +#else
  int sysctl_perf_event_paranoid __read_mostly = 2;
 +#endif
- 
+
  /* Minimum for 512 kiB + 1 user control page. 'free' kiB per user. */
  static int sysctl_perf_event_mlock __read_mostly = 512 + (PAGE_SIZE / 1024);
 @@ -13829,7 +13834,7 @@ SYSCALL_DEFINE5(perf_event_open,
  		return err;
- 
+
  	/* Do we allow access to perf_event_open(2) ? */
 -	err = security_perf_event_open(PERF_SECURITY_OPEN);
 +	err = perf_allow_open();
  	if (err)
  		return err;
- 
+
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 7e2c7d1a72bf..7b8b07cb14d5 100644
+index cf0597f89..18a0936e6 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -83,6 +83,7 @@
@@ -1246,9 +1244,9 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
  #include <linux/khugepaged.h>
  #include <linux/signalfd.h>
 @@ -125,12 +126,6 @@
- 
+
  #include <kunit/visibility.h>
- 
+
 -#ifdef CONFIG_USER_NS
 -static int unprivileged_userns_clone = 1;
 -#else
@@ -1258,10 +1256,10 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
  /*
   * Minimum number of threads to boot the kernel
   */
-@@ -1991,6 +1986,10 @@ __latent_entropy struct task_struct *copy_process(
+@@ -1993,6 +1988,10 @@ __latent_entropy struct task_struct *copy_process(
  	if ((clone_flags & (CLONE_NEWUSER|CLONE_FS)) == (CLONE_NEWUSER|CLONE_FS))
  		return ERR_PTR(-EINVAL);
- 
+
 +	if ((clone_flags & CLONE_NEWUSER) && !unprivileged_userns_clone)
 +		if (!capable(CAP_SYS_ADMIN))
 +			return ERR_PTR(-EPERM);
@@ -1269,10 +1267,10 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
  	/*
  	 * Thread groups must share signals as well, and detached threads
  	 * can only be started up within the thread group.
-@@ -2035,11 +2034,6 @@ __latent_entropy struct task_struct *copy_process(
+@@ -2037,11 +2036,6 @@ __latent_entropy struct task_struct *copy_process(
  			return ERR_PTR(-EINVAL);
  	}
- 
+
 -	if ((clone_flags & CLONE_NEWUSER) && !unprivileged_userns_clone) {
 -		if (!capable(CAP_SYS_ADMIN))
 -			return ERR_PTR(-EPERM);
@@ -1281,7 +1279,7 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
  	/*
  	 * Force any signals received before this point to be delivered
  	 * before the fork happens.  Collect up signals sent to multiple
-@@ -3082,10 +3076,6 @@ static int check_unshare_flags(unsigned long unshare_flags)
+@@ -3080,10 +3074,6 @@ static int check_unshare_flags(unsigned long unshare_flags)
  		if (!current_is_single_threaded())
  			return -EINVAL;
  	}
@@ -1289,13 +1287,13 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
 -		if (!capable(CAP_SYS_ADMIN))
 -			return -EPERM;
 -	}
- 
+
  	return 0;
  }
-@@ -3168,6 +3158,12 @@ int ksys_unshare(unsigned long unshare_flags)
+@@ -3166,6 +3156,12 @@ int ksys_unshare(unsigned long unshare_flags)
  	if (unshare_flags & CLONE_NEWNS)
  		unshare_flags |= CLONE_FS;
- 
+
 +	if ((unshare_flags & CLONE_NEWUSER) && !unprivileged_userns_clone) {
 +		err = -EPERM;
 +		if (!capable(CAP_SYS_ADMIN))
@@ -1305,7 +1303,7 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
  	err = check_unshare_flags(unshare_flags);
  	if (err)
  		goto bad_unshare_out;
-@@ -3316,15 +3312,6 @@ static const struct ctl_table fork_sysctl_table[] = {
+@@ -3317,15 +3313,6 @@ static const struct ctl_table fork_sysctl_table[] = {
  		.mode		= 0644,
  		.proc_handler	= sysctl_max_threads,
  	},
@@ -1319,16 +1317,16 @@ index 7e2c7d1a72bf..7b8b07cb14d5 100644
 -	},
 -#endif
  };
- 
+
  static int __init init_fork_sysctl(void)
 diff --git a/kernel/printk/sysctl.c b/kernel/printk/sysctl.c
-index f15732e93c2e..1b8a2a652b19 100644
+index f15732e93..1b8a2a652 100644
 --- a/kernel/printk/sysctl.c
 +++ b/kernel/printk/sysctl.c
 @@ -10,15 +10,6 @@
- 
+
  static const int ten_thousand = 10000;
- 
+
 -static int proc_dointvec_minmax_sysadmin(const struct ctl_table *table, int write,
 -				void *buffer, size_t *lenp, loff_t *ppos)
 -{
@@ -1342,35 +1340,35 @@ index f15732e93c2e..1b8a2a652b19 100644
  	{
  		.procname	= "printk",
 diff --git a/kernel/softirq.c b/kernel/softirq.c
-index 77198911b8dd..1c508ce336ae 100644
+index 77198911b..1c508ce33 100644
 --- a/kernel/softirq.c
 +++ b/kernel/softirq.c
 @@ -57,7 +57,7 @@ DEFINE_PER_CPU_ALIGNED(irq_cpustat_t, irq_stat);
  EXPORT_PER_CPU_SYMBOL(irq_stat);
  #endif
- 
+
 -static struct softirq_action softirq_vec[NR_SOFTIRQS] __cacheline_aligned_in_smp;
 +static struct softirq_action softirq_vec[NR_SOFTIRQS] __ro_after_init __aligned(PAGE_SIZE);
- 
+
  DEFINE_PER_CPU(struct task_struct *, ksoftirqd);
- 
+
 @@ -790,7 +790,7 @@ void __raise_softirq_irqoff(unsigned int nr)
  	or_softirq_pending(1UL << nr);
  }
- 
+
 -void open_softirq(int nr, void (*action)(void))
 +void __init open_softirq(int nr, void (*action)(void))
  {
  	softirq_vec[nr].action = action;
  }
 diff --git a/kernel/sysctl.c b/kernel/sysctl.c
-index c9efb17cc255..6a9bc5747a76 100644
+index c9efb17cc..6a9bc5747 100644
 --- a/kernel/sysctl.c
 +++ b/kernel/sysctl.c
 @@ -22,6 +22,10 @@
  #include <linux/uaccess.h>
  #include <asm/processor.h>
- 
+
 +#ifdef CONFIG_USER_NS
 +#include <linux/user_namespace.h>
 +#endif
@@ -1381,7 +1379,7 @@ index c9efb17cc255..6a9bc5747a76 100644
 @@ -863,6 +867,35 @@ int proc_douintvec(const struct ctl_table *table, int dir, void *buffer,
  				 do_proc_uint_conv);
  }
- 
+
 +/**
 + * proc_dointvec_minmax_sysadmin - read a vector of integers with min/max values
 + * checking CAP_SYS_ADMIN on write
@@ -1417,7 +1415,7 @@ index c9efb17cc255..6a9bc5747a76 100644
 @@ -1317,6 +1350,12 @@ int proc_doulongvec_minmax(const struct ctl_table *table, int dir,
  	return -ENOSYS;
  }
- 
+
 +int proc_dointvec_minmax_sysadmin(const struct ctl_table *table, int dir,
 +				  void *buffer, size_t *lenp, loff_t *ppos)
 +{
@@ -1429,7 +1427,7 @@ index c9efb17cc255..6a9bc5747a76 100644
  				unsigned long convmul, unsigned long convdiv)
 @@ -1372,6 +1411,17 @@ int proc_do_static_key(const struct ctl_table *table, int dir,
  }
- 
+
  static const struct ctl_table sysctl_subsys_table[] = {
 +#ifdef CONFIG_USER_NS
 +	{
@@ -1454,13 +1452,13 @@ index c9efb17cc255..6a9bc5747a76 100644
  EXPORT_SYMBOL(proc_doulongvec_minmax);
  EXPORT_SYMBOL(proc_do_large_bitmap);
 diff --git a/kernel/user_namespace.c b/kernel/user_namespace.c
-index 0bed462e9b2a..b54a9a25d1c3 100644
+index 0bed462e9..b54a9a25d 100644
 --- a/kernel/user_namespace.c
 +++ b/kernel/user_namespace.c
 @@ -23,6 +23,13 @@
  #include <linux/sort.h>
  #include <linux/nstree.h>
- 
+
 +/* sysctl */
 +#ifdef CONFIG_USER_NS_UNPRIVILEGED
 +int unprivileged_userns_clone = 1;
@@ -1470,15 +1468,15 @@ index 0bed462e9b2a..b54a9a25d1c3 100644
 +
  static struct kmem_cache *user_ns_cachep __ro_after_init;
  static DEFINE_MUTEX(userns_state_mutex);
- 
+
 diff --git a/lib/Kconfig.debug b/lib/Kconfig.debug
-index 93f356d2b3d9..f58bc6893512 100644
+index 93f356d2b..f58bc6893 100644
 --- a/lib/Kconfig.debug
 +++ b/lib/Kconfig.debug
 @@ -526,6 +526,9 @@ config SECTION_MISMATCH_WARN_ONLY
- 
+
  	  If unsure, say Y.
- 
+
 +config DEBUG_WRITABLE_FUNCTION_POINTERS_VERBOSE
 +	bool "Enable verbose reporting of writable function pointers"
 +
@@ -1495,7 +1493,7 @@ index 93f356d2b3d9..f58bc6893512 100644
  	  This selects the default access restrictions for debugfs.
  	  It can be overridden with kernel command line option
 @@ -1095,6 +1098,7 @@ menu "Debug Oops, Lockups and Hangs"
- 
+
  config PANIC_ON_OOPS
  	bool "Panic on Oops"
 +	default y
@@ -1505,10 +1503,10 @@ index 93f356d2b3d9..f58bc6893512 100644
 @@ -1104,7 +1108,7 @@ config PANIC_ON_OOPS
  	  anything erroneous after an oops which could result in data
  	  corruption or other issues.
- 
+
 -	  Say N if unsure.
 +	  Say Y if unsure.
- 
+
  config PANIC_TIMEOUT
  	int "panic timeout"
 @@ -1974,6 +1978,7 @@ config STRICT_DEVMEM
@@ -1520,13 +1518,13 @@ index 93f356d2b3d9..f58bc6893512 100644
  	  If this option is disabled, you allow userspace (root) access to all
  	  io-memory regardless of whether a driver is actively using that
 diff --git a/lib/Kconfig.kfence b/lib/Kconfig.kfence
-index 6fbbebec683a..e494618f7193 100644
+index 6fbbebec6..e494618f7 100644
 --- a/lib/Kconfig.kfence
 +++ b/lib/Kconfig.kfence
 @@ -96,4 +96,13 @@ config KFENCE_KUNIT_TEST
  	  during boot; say M if you want the test to build as a module; say N
  	  if you are unsure.
- 
+
 +config KFENCE_BUG_ON_DATA_CORRUPTION
 +	bool "Trigger a BUG when data corruption is detected"
 +	default y
@@ -1538,53 +1536,53 @@ index 6fbbebec683a..e494618f7193 100644
 +
  endif # KFENCE
 diff --git a/lib/kobject.c b/lib/kobject.c
-index 9c9ff0f5175f..a63903740fab 100644
+index 9c9ff0f51..a63903740 100644
 --- a/lib/kobject.c
 +++ b/lib/kobject.c
 @@ -1019,9 +1019,9 @@ EXPORT_SYMBOL_GPL(kset_create_and_add);
- 
- 
+
+
  static DEFINE_SPINLOCK(kobj_ns_type_lock);
 -static const struct kobj_ns_type_operations *kobj_ns_ops_tbl[KOBJ_NS_TYPES];
 +static const struct kobj_ns_type_operations *kobj_ns_ops_tbl[KOBJ_NS_TYPES] __ro_after_init;
- 
+
 -int kobj_ns_type_register(const struct kobj_ns_type_operations *ops)
 +int __init kobj_ns_type_register(const struct kobj_ns_type_operations *ops)
  {
  	enum kobj_ns_type type = ops->type;
  	int error;
 diff --git a/lib/nlattr.c b/lib/nlattr.c
-index be9c576b6e2d..484d839bcf5e 100644
+index be9c576b6..484d839bc 100644
 --- a/lib/nlattr.c
 +++ b/lib/nlattr.c
 @@ -837,6 +837,8 @@ int nla_memcpy(void *dest, const struct nlattr *src, int count)
  {
  	int minlen = min_t(int, count, nla_len(src));
- 
+
 +	BUG_ON(minlen < 0);
 +
  	memcpy(dest, nla_data(src), minlen);
  	if (count > minlen)
  		memset(dest + minlen, 0, count - minlen);
 diff --git a/lib/vsprintf.c b/lib/vsprintf.c
-index 800b8ac49f53..e56d26c9f3ab 100644
+index 800b8ac49..e56d26c9f 100644
 --- a/lib/vsprintf.c
 +++ b/lib/vsprintf.c
 @@ -856,7 +856,7 @@ static char *default_pointer(char *buf, char *end, const void *ptr,
  	return ptr_to_id(buf, end, ptr, spec);
  }
- 
+
 -int kptr_restrict __read_mostly;
 +int kptr_restrict __read_mostly = 2;
- 
+
  static noinline_for_stack
  char *restricted_pointer(char *buf, char *end, const void *ptr,
 diff --git a/mm/Kconfig b/mm/Kconfig
-index ebd8ea353687..c7a76c4905b5 100644
+index befa8909a..9830506eb 100644
 --- a/mm/Kconfig
 +++ b/mm/Kconfig
 @@ -188,7 +188,6 @@ config SLUB_TINY
- 
+
  config SLAB_MERGE_DEFAULT
  	bool "Allow slab caches to be merged"
 -	default y
@@ -1608,9 +1606,9 @@ index ebd8ea353687..c7a76c4905b5 100644
  	  Many kernel heap attacks try to target slab cache metadata and
  	  other infrastructure. This options makes minor performance
 @@ -234,6 +235,23 @@ config SLAB_BUCKETS
- 
+
  	  If unsure, say Y.
- 
+
 +config SLAB_CANARY
 +	depends on SLUB
 +	depends on !SLAB_MERGE_DEFAULT
@@ -1633,7 +1631,7 @@ index ebd8ea353687..c7a76c4905b5 100644
  	bool "Enable performance statistics"
 @@ -248,7 +266,7 @@ config SLUB_STATS
  	  Try running: slabinfo -DA
- 
+
  config RANDOM_KMALLOC_CACHES
 -	default n
 +	default y
@@ -1641,14 +1639,14 @@ index ebd8ea353687..c7a76c4905b5 100644
  	bool "Randomize slab caches for normal kmalloc"
  	help
 @@ -291,7 +309,6 @@ config SHUFFLE_PAGE_ALLOCATOR
- 
+
  config COMPAT_BRK
  	bool "Disable heap randomization"
 -	default y
  	help
  	  Randomizing heap placement makes heap exploits harder, but it
  	  also breaks ancient binaries (including anything libc5 based).
-@@ -703,7 +720,8 @@ config KSM
+@@ -704,7 +721,8 @@ config KSM
  config DEFAULT_MMAP_MIN_ADDR
  	int "Low address space to protect from user allocation"
  	depends on MMU
@@ -1659,11 +1657,11 @@ index ebd8ea353687..c7a76c4905b5 100644
  	  This is the portion of low virtual memory which should be protected
  	  from userspace allocation.  Keeping a user from writing to low pages
 diff --git a/mm/Kconfig.debug b/mm/Kconfig.debug
-index 7638d75b27db..08ae2acd7b1b 100644
+index 7638d75b2..08ae2acd7 100644
 --- a/mm/Kconfig.debug
 +++ b/mm/Kconfig.debug
 @@ -47,7 +47,7 @@ config DEBUG_PAGEALLOC_ENABLE_DEFAULT
- 
+
  config SLUB_DEBUG
  	default y
 -	bool "Enable SLUB debugging support" if EXPERT
@@ -1678,15 +1676,15 @@ index 7638d75b27db..08ae2acd7b1b 100644
 +	default y
  	help
  	  Generate a warning if any W+X mappings are found at boot.
- 
+
 diff --git a/mm/internal.h b/mm/internal.h
-index e1e64b875885..104e88b73525 100644
+index e1e64b875..104e88b73 100644
 --- a/mm/internal.h
 +++ b/mm/internal.h
 @@ -856,6 +856,9 @@ static inline struct folio *page_rmappable_folio(struct page *page)
  	return folio;
  }
- 
+
 +extern void __init __gather_extra_latent_entropy(struct page *page,
 +						 unsigned int nr_pages);
 +
@@ -1694,30 +1692,30 @@ index e1e64b875885..104e88b73525 100644
  {
  	struct folio *folio = (struct folio *)page;
 diff --git a/mm/kfence/report.c b/mm/kfence/report.c
-index 787e87c26926..4d5099c5dc10 100644
+index 787e87c26..4d5099c5d 100644
 --- a/mm/kfence/report.c
 +++ b/mm/kfence/report.c
 @@ -8,6 +8,7 @@
  #include <linux/stdarg.h>
- 
+
  #include <linux/kernel.h>
 +#include <linux/bug.h>
  #include <linux/lockdep.h>
  #include <linux/math.h>
  #include <linux/printk.h>
 @@ -278,6 +279,10 @@ void kfence_report_error(unsigned long address, bool is_write, struct pt_regs *r
- 
+
  	lockdep_on();
- 
+
 +#ifdef CONFIG_KFENCE_BUG_ON_DATA_CORRUPTION
 +	BUG();
 +#endif
 +
  	check_panic_on_warn("KFENCE");
- 
+
  	/* We encountered a memory safety error, taint the kernel! */
 diff --git a/mm/mm_init.c b/mm/mm_init.c
-index df34797691bd..30f3ee68e3fd 100644
+index df3479769..30f3ee68e 100644
 --- a/mm/mm_init.c
 +++ b/mm/mm_init.c
 @@ -1999,6 +1999,7 @@ static void __init deferred_free_pages(unsigned long pfn,
@@ -1737,19 +1735,19 @@ index df34797691bd..30f3ee68e3fd 100644
  	}
  }
 @@ -2496,6 +2498,7 @@ void __init memblock_free_pages(unsigned long pfn, unsigned int order)
- 
+
  	/* pages were reserved and not allocated */
  	clear_page_tag_ref(page);
 +	__gather_extra_latent_entropy(page, 1 << order);
  	__free_pages_core(page, order, MEMINIT_EARLY);
  }
- 
+
 diff --git a/mm/mmap.c b/mm/mmap.c
-index 843160946aa5..dd6a759ec059 100644
+index 843160946..dd6a759ec 100644
 --- a/mm/mmap.c
 +++ b/mm/mmap.c
 @@ -153,6 +153,13 @@ SYSCALL_DEFINE1(brk, unsigned long, brk)
- 
+
  	newbrk = PAGE_ALIGN(brk);
  	oldbrk = PAGE_ALIGN(mm->brk);
 +	/* properly handle unaligned min_brk as an empty heap */
@@ -1763,13 +1761,13 @@ index 843160946aa5..dd6a759ec059 100644
  		mm->brk = brk;
  		goto success;
 diff --git a/mm/page_alloc.c b/mm/page_alloc.c
-index 3dd25d2162aa..6524889cba88 100644
+index 0626766b0..51af5edf0 100644
 --- a/mm/page_alloc.c
 +++ b/mm/page_alloc.c
 @@ -216,6 +216,15 @@ EXPORT_PER_CPU_SYMBOL(_numa_mem_);
- 
+
  static DEFINE_MUTEX(pcpu_drain_mutex);
- 
+
 +bool __meminitdata extra_latent_entropy;
 +
 +static int __init setup_extra_latent_entropy(char *str)
@@ -1785,7 +1783,7 @@ index 3dd25d2162aa..6524889cba88 100644
 @@ -1633,6 +1642,25 @@ static void __free_pages_ok(struct page *page, unsigned int order,
  		free_one_page(zone, page, pfn, order, fpi_flags);
  }
- 
+
 +void __init __gather_extra_latent_entropy(struct page *page,
 +					  unsigned int nr_pages)
 +{
@@ -1811,7 +1809,7 @@ index 3dd25d2162aa..6524889cba88 100644
 @@ -1874,6 +1902,12 @@ inline void post_alloc_hook(struct page *page, unsigned int order,
  	 */
  	kernel_unpoison_pages(page, 1 << order);
- 
+
 +	if (IS_ENABLED(CONFIG_PAGE_SANITIZE_VERIFY) && want_init_on_free()) {
 +		int i;
 +		for (i = 0; i < (1 << order); i++)
@@ -1822,13 +1820,13 @@ index 3dd25d2162aa..6524889cba88 100644
  	 * As memory initialization might be integrated into KASAN,
  	 * KASAN unpoisoning and memory initialization code must be
 diff --git a/mm/slab.h b/mm/slab.h
-index e9ab292acd22..7ea5a143ca21 100644
+index e9ab292ac..7ea5a143c 100644
 --- a/mm/slab.h
 +++ b/mm/slab.h
 @@ -223,6 +223,12 @@ struct kmem_cache {
  	unsigned long random;
  #endif
- 
+
 +#ifdef CONFIG_SLAB_CANARY
 +	unsigned long random_active;
 +	unsigned long random_inactive;
@@ -1867,22 +1865,22 @@ index e9ab292acd22..7ea5a143ca21 100644
 +	}
  	return false;
  }
- 
+
 diff --git a/mm/slab_common.c b/mm/slab_common.c
-index d5a70a831a2a..51fc267d0f86 100644
+index 8b661fff5..a8995782f 100644
 --- a/mm/slab_common.c
 +++ b/mm/slab_common.c
 @@ -37,10 +37,10 @@
  #define CREATE_TRACE_POINTS
  #include <trace/events/kmem.h>
- 
+
 -enum slab_state slab_state;
 +enum slab_state slab_state __ro_after_init;
  LIST_HEAD(slab_caches);
  DEFINE_MUTEX(slab_mutex);
 -struct kmem_cache *kmem_cache;
 +struct kmem_cache *kmem_cache __ro_after_init;
- 
+
  /*
   * Set of flags that will prevent slab merging.
 @@ -57,7 +57,7 @@ struct kmem_cache *kmem_cache;
@@ -1891,11 +1889,11 @@ index d5a70a831a2a..51fc267d0f86 100644
   */
 -static bool slab_nomerge = !IS_ENABLED(CONFIG_SLAB_MERGE_DEFAULT);
 +static bool slab_nomerge __ro_after_init = !IS_ENABLED(CONFIG_SLAB_MERGE_DEFAULT);
- 
+
  static int __init setup_slab_nomerge(char *str)
  {
 diff --git a/mm/slub.c b/mm/slub.c
-index e423afa27d1a..56819ec51838 100644
+index edd3909f4..6e1f19be9 100644
 --- a/mm/slub.c
 +++ b/mm/slub.c
 @@ -44,6 +44,7 @@
@@ -1909,7 +1907,7 @@ index e423afa27d1a..56819ec51838 100644
 @@ -232,6 +233,12 @@ static inline bool kmem_cache_debug(struct kmem_cache *s)
  	return kmem_cache_debug_flags(s, SLAB_DEBUG_FLAGS);
  }
- 
+
 +static inline bool has_sanitize_verify(struct kmem_cache *s)
 +{
 +	return IS_ENABLED(CONFIG_SLAB_SANITIZE_VERIFY) &&
@@ -1921,37 +1919,37 @@ index e423afa27d1a..56819ec51838 100644
  	if (kmem_cache_debug_flags(s, SLAB_RED_ZONE))
 @@ -736,6 +743,8 @@ static inline void set_orig_size(struct kmem_cache *s,
  		return;
- 
+
  	p += get_info_end(s);
 +	if (IS_ENABLED(CONFIG_SLAB_CANARY))
 +		p = (void *)p + sizeof(void *);
  	p += sizeof(struct track) * 2;
- 
+
  	*(unsigned long *)p = orig_size;
 @@ -752,6 +761,8 @@ static inline unsigned long get_orig_size(struct kmem_cache *s, void *object)
  		return s->object_size;
- 
+
  	p += get_info_end(s);
 +	if (IS_ENABLED(CONFIG_SLAB_CANARY))
 +		p = (void *)p + sizeof(void *);
  	p += sizeof(struct track) * 2;
- 
+
  	return *(unsigned long *)p;
 @@ -875,6 +886,10 @@ static unsigned int obj_exts_offset_in_object(struct kmem_cache *s)
  	if (slub_debug_orig_size(s))
  		offset += sizeof(unsigned long);
- 
+
 +#ifdef CONFIG_SLAB_CANARY
 +	offset += sizeof(void *);
 +#endif
 +
  	offset += kasan_metadata_size(s, false);
- 
+
  	return offset;
 @@ -891,6 +906,85 @@ static inline unsigned int obj_exts_offset_in_object(struct kmem_cache *s)
  }
  #endif
- 
+
 +#ifdef CONFIG_SLAB_CANARY
 +static inline unsigned long *get_canary(struct kmem_cache *s, void *object)
 +{
@@ -2032,7 +2030,7 @@ index e423afa27d1a..56819ec51838 100644
 +#endif
 +
  #ifdef CONFIG_SLUB_DEBUG
- 
+
  /*
 @@ -972,13 +1066,13 @@ static inline void *restore_red_left(struct kmem_cache *s, void *p)
   * Debug settings:
@@ -2044,33 +2042,33 @@ index e423afa27d1a..56819ec51838 100644
 -static slab_flags_t slub_debug;
 +static slab_flags_t slub_debug __ro_after_init;
  #endif
- 
+
  static const char *slub_debug_string __ro_after_init;
 -static int disable_higher_order_debug;
 +static int disable_higher_order_debug __ro_after_init;
- 
+
  /*
   * Object debugging
 @@ -1020,6 +1114,9 @@ static struct track *get_track(struct kmem_cache *s, void *object,
- 
+
  	p = object + get_info_end(s);
- 
+
 +	if (IS_ENABLED(CONFIG_SLAB_CANARY))
 +		p = (void *)p + sizeof(void *);
 +
  	return kasan_reset_tag(p + alloc);
  }
- 
+
 @@ -1181,6 +1278,9 @@ static void print_trailer(struct kmem_cache *s, struct slab *slab, u8 *p)
- 
+
  	off = get_info_end(s);
- 
+
 +	if (IS_ENABLED(CONFIG_SLAB_CANARY))
 +		off += sizeof(void *);
 +
  	if (s->flags & SLAB_STORE_USER)
  		off += 2 * sizeof(struct track);
- 
+
 @@ -1349,10 +1449,11 @@ check_bytes_and_report(struct kmem_cache *s, struct slab *slab,
   *
   * [Metadata starts at object + s->inuse]
@@ -2090,7 +2088,7 @@ index e423afa27d1a..56819ec51838 100644
 @@ -1384,6 +1485,9 @@ static int check_pad_bytes(struct kmem_cache *s, struct slab *slab, u8 *p)
  {
  	unsigned long off = get_info_end(s);	/* The end of info */
- 
+
 +	if (IS_ENABLED(CONFIG_SLAB_CANARY))
 +		off += sizeof(void *);
 +
@@ -2106,7 +2104,7 @@ index e423afa27d1a..56819ec51838 100644
  {
  	/* Are the object contents still accessible? */
  	bool still_accessible = (s->flags & SLAB_TYPESAFE_BY_RCU) && !after_rcu_delay;
- 
+
 +	/*
 +	 * Postpone setting the inactive canary until the metadata
 +	 * has potentially been cleared at the end of this function.
@@ -2117,7 +2115,7 @@ index e423afa27d1a..56819ec51838 100644
 +
  	kmemleak_free_recursive(x, s->flags);
  	kmsan_slab_free(s, x);
- 
+
 @@ -2672,15 +2784,28 @@ bool slab_free_hook(struct kmem_cache *s, void *x, bool init,
  		if (!kasan_has_integrated_init())
  			memset(kasan_reset_tag(x), 0, orig_size);
@@ -2135,7 +2133,7 @@ index e423afa27d1a..56819ec51838 100644
  		 * would be reported
  		 */
  		set_orig_size(s, x, orig_size);
- 
+
 +		if (!IS_ENABLED(CONFIG_SLAB_SANITIZE_VERIFY) && s->ctor)
 +			s->ctor(x);
 +	}
@@ -2149,16 +2147,16 @@ index e423afa27d1a..56819ec51838 100644
  }
 @@ -2696,7 +2821,7 @@ bool slab_free_freelist_hook(struct kmem_cache *s, void **head, void **tail,
  	bool init;
- 
+
  	if (is_kfence_address(next)) {
 -		slab_free_hook(s, next, false, false);
 +		slab_free_hook(s, next, false, false, false);
  		return false;
  	}
- 
+
 @@ -2711,7 +2836,7 @@ bool slab_free_freelist_hook(struct kmem_cache *s, void **head, void **tail,
  		next = get_freepointer(s, object);
- 
+
  		/* If object's reuse doesn't have to be delayed */
 -		if (likely(slab_free_hook(s, object, init, false))) {
 +		if (likely(slab_free_hook(s, object, init, false, true))) {
@@ -2187,7 +2185,7 @@ index e423afa27d1a..56819ec51838 100644
 +				set_freepointer(s, object, NULL);
  		}
  	} while (object != old_tail);
- 
+
 @@ -2732,8 +2873,9 @@ bool slab_free_freelist_hook(struct kmem_cache *s, void **head, void **tail,
  static void *setup_object(struct kmem_cache *s, void *object)
  {
@@ -2202,7 +2200,7 @@ index e423afa27d1a..56819ec51838 100644
 @@ -2812,6 +2954,12 @@ static int refill_sheaf(struct kmem_cache *s, struct slab_sheaf *sheaf,
  	filled = refill_objects(s, &sheaf->objects[sheaf->size], gfp, to_fill,
  				to_fill);
- 
+
 +	/*
 +	 * linux-hardened: refill_objects directly picks objects from slab freelist,
 +	 * we thus need to manually instrument them here for sheaf.
@@ -2210,20 +2208,20 @@ index e423afa27d1a..56819ec51838 100644
 +	check_set_canary_bulk(s, filled, &sheaf->objects[sheaf->size], s->random_inactive, s->sheaf_random_inactive);
 +
  	sheaf->size += filled;
- 
+
  	stat_add(s, SHEAF_REFILL, filled);
 @@ -2822,7 +2970,7 @@ static int refill_sheaf(struct kmem_cache *s, struct slab_sheaf *sheaf,
  	return 0;
  }
- 
+
 -static void sheaf_flush_unused(struct kmem_cache *s, struct slab_sheaf *sheaf);
 +static void sheaf_flush_unused(struct kmem_cache *s, struct slab_sheaf *sheaf, bool canary);
- 
+
  static struct slab_sheaf *alloc_full_sheaf(struct kmem_cache *s, gfp_t gfp)
  {
 @@ -2832,7 +2980,7 @@ static struct slab_sheaf *alloc_full_sheaf(struct kmem_cache *s, gfp_t gfp)
  		return NULL;
- 
+
  	if (refill_sheaf(s, sheaf, gfp | __GFP_NOMEMALLOC | __GFP_NOWARN)) {
 -		sheaf_flush_unused(s, sheaf);
 +		sheaf_flush_unused(s, sheaf, true);
@@ -2231,12 +2229,12 @@ index e423afa27d1a..56819ec51838 100644
  		return NULL;
  	}
 @@ -2880,6 +3028,7 @@ static unsigned int __sheaf_flush_main_batch(struct kmem_cache *s)
- 
+
  	local_unlock(&s->cpu_sheaves->lock);
- 
+
 +	check_set_canary_bulk(s, batch, &objects[0], s->sheaf_random_inactive, s->random_inactive);
  	__kmem_cache_free_bulk(s, batch, &objects[0]);
- 
+
  	stat_add(s, SHEAF_FLUSH, batch);
 @@ -2925,20 +3074,24 @@ static bool sheaf_try_flush_main(struct kmem_cache *s)
   * necessary when flushing cpu's sheaves (both spare and main) during cpu
@@ -2247,17 +2245,17 @@ index e423afa27d1a..56819ec51838 100644
  {
  	if (!sheaf->size)
  		return;
- 
+
  	stat_add(s, SHEAF_FLUSH, sheaf->size);
- 
+
 +	if (canary) {
 +		check_set_canary_bulk(s, sheaf->size, &sheaf->objects[0], s->sheaf_random_inactive, s->random_inactive);
 +	}
  	__kmem_cache_free_bulk(s, sheaf->size, &sheaf->objects[0]);
- 
+
  	sheaf->size = 0;
  }
- 
+
  static bool __rcu_free_sheaf_prepare(struct kmem_cache *s,
 -				     struct slab_sheaf *sheaf)
 +				     struct slab_sheaf *sheaf,
@@ -2268,7 +2266,7 @@ index e423afa27d1a..56819ec51838 100644
 @@ -2951,7 +3104,7 @@ static bool __rcu_free_sheaf_prepare(struct kmem_cache *s,
  		memcg_slab_free_hook(s, slab, p + i, 1);
  		alloc_tagging_slab_free_hook(s, slab, p + i, 1);
- 
+
 -		if (unlikely(!slab_free_hook(s, p[i], init, true))) {
 +		if (unlikely(!slab_free_hook(s, p[i], init, true, canary))) {
  			p[i] = p[--sheaf->size];
@@ -2277,27 +2275,27 @@ index e423afa27d1a..56819ec51838 100644
 @@ -2973,9 +3126,9 @@ static void rcu_free_sheaf_nobarn(struct rcu_head *head)
  	sheaf = container_of(head, struct slab_sheaf, rcu_head);
  	s = sheaf->cache;
- 
+
 -	__rcu_free_sheaf_prepare(s, sheaf);
 +	__rcu_free_sheaf_prepare(s, sheaf, true);
- 
+
 -	sheaf_flush_unused(s, sheaf);
 +	sheaf_flush_unused(s, sheaf, false);
- 
+
  	free_empty_sheaf(s, sheaf);
  }
 @@ -3006,7 +3159,7 @@ static void pcs_flush_all(struct kmem_cache *s)
  	local_unlock(&s->cpu_sheaves->lock);
- 
+
  	if (spare) {
 -		sheaf_flush_unused(s, spare);
 +		sheaf_flush_unused(s, spare, true);
  		free_empty_sheaf(s, spare);
  	}
- 
+
 @@ -3023,9 +3176,9 @@ static void __pcs_flush_all_cpu(struct kmem_cache *s, unsigned int cpu)
  	pcs = per_cpu_ptr(s->cpu_sheaves, cpu);
- 
+
  	/* The cpu is not executing anymore so we don't need pcs->lock */
 -	sheaf_flush_unused(s, pcs->main);
 +	sheaf_flush_unused(s, pcs->main, true);
@@ -2309,14 +2307,14 @@ index e423afa27d1a..56819ec51838 100644
  	}
 @@ -3264,7 +3417,7 @@ static void barn_shrink(struct kmem_cache *s, struct node_barn *barn)
  	spin_unlock_irqrestore(&barn->lock, flags);
- 
+
  	list_for_each_entry_safe(sheaf, sheaf2, &full_list, barn_list) {
 -		sheaf_flush_unused(s, sheaf);
 +		sheaf_flush_unused(s, sheaf, true);
  		free_empty_sheaf(s, sheaf);
  	}
- 
-@@ -4539,6 +4692,8 @@ bool slab_post_alloc_hook(struct kmem_cache *s, struct list_lru *lru,
+
+@@ -4540,6 +4693,8 @@ bool slab_post_alloc_hook(struct kmem_cache *s, struct list_lru *lru,
  		if (p[i] && init && (!kasan_init ||
  				     !kasan_has_integrated_init()))
  			memset(p[i], 0, zero_size);
@@ -2325,7 +2323,7 @@ index e423afa27d1a..56819ec51838 100644
  		if (gfpflags_allow_spinning(flags))
  			kmemleak_alloc_recursive(p[i], s->object_size, 1,
  						 s->flags, init_flags);
-@@ -4619,7 +4774,7 @@ __pcs_replace_empty_main(struct kmem_cache *s, struct slub_percpu_sheaves *pcs,
+@@ -4620,7 +4775,7 @@ __pcs_replace_empty_main(struct kmem_cache *s, struct slub_percpu_sheaves *pcs,
  			 * we must be very low on memory so don't bother
  			 * with the barn
  			 */
@@ -2334,33 +2332,33 @@ index e423afa27d1a..56819ec51838 100644
  			free_empty_sheaf(s, empty);
  		}
  	} else {
-@@ -4735,6 +4890,7 @@ void *alloc_from_pcs(struct kmem_cache *s, gfp_t gfp, int node)
+@@ -4736,6 +4891,7 @@ void *alloc_from_pcs(struct kmem_cache *s, gfp_t gfp, int node)
  	}
- 
+
  	pcs->main->size--;
 +	check_set_canary(s, object, s->sheaf_random_inactive, s->random_active);
- 
+
  	local_unlock(&s->cpu_sheaves->lock);
- 
-@@ -4808,6 +4964,8 @@ unsigned int alloc_from_pcs_bulk(struct kmem_cache *s, gfp_t gfp, size_t size,
+
+@@ -4809,6 +4965,8 @@ unsigned int alloc_from_pcs_bulk(struct kmem_cache *s, gfp_t gfp, size_t size,
  	main->size -= batch;
  	memcpy(p, main->objects + main->size, batch * sizeof(void *));
- 
+
 +	check_set_canary_bulk(s, batch, p, s->sheaf_random_inactive, s->random_active);
 +
  	local_unlock(&s->cpu_sheaves->lock);
- 
+
  	stat_add(s, ALLOC_FASTPATH, batch);
-@@ -4850,11 +5008,25 @@ static __fastpath_inline void *slab_alloc_node(struct kmem_cache *s, struct list
- 
+@@ -4851,11 +5009,25 @@ static __fastpath_inline void *slab_alloc_node(struct kmem_cache *s, struct list
+
  	object = alloc_from_pcs(s, gfpflags, node);
- 
+
 -	if (!object)
 +	if (!object) {
  		object = __slab_alloc_node(s, gfpflags, node, addr, orig_size);
 +		check_set_canary(s, object, s->random_inactive, s->random_active);
 +	}
- 
+
  	maybe_wipe_obj_freeptr(s, object);
 -	init = slab_want_init_on_alloc(gfpflags, s);
 +
@@ -2376,21 +2374,21 @@ index e423afa27d1a..56819ec51838 100644
 +	} else {
 +		init = slab_want_init_on_alloc(gfpflags, s);
 +	}
- 
+
  out:
  	/*
-@@ -4987,6 +5159,9 @@ kmem_cache_prefill_sheaf(struct kmem_cache *s, gfp_t gfp, unsigned int size)
+@@ -4988,6 +5160,9 @@ kmem_cache_prefill_sheaf(struct kmem_cache *s, gfp_t gfp, unsigned int size)
  			return NULL;
  		}
- 
+
 +		/* linux-hardened: We are prefilling a sheaf, the objects needs to be instrumented to sheaf_random_inactive. */
 +		check_set_canary_bulk(s, size, &sheaf->objects[0], s->random_active, s->sheaf_random_inactive);
 +
  		sheaf->size = size;
- 
+
  		return sheaf;
-@@ -5023,7 +5198,7 @@ kmem_cache_prefill_sheaf(struct kmem_cache *s, gfp_t gfp, unsigned int size)
- 
+@@ -5024,7 +5199,7 @@ kmem_cache_prefill_sheaf(struct kmem_cache *s, gfp_t gfp, unsigned int size)
+
  		if (sheaf->size < size &&
  		    __prefill_sheaf_pfmemalloc(s, sheaf, gfp)) {
 -			sheaf_flush_unused(s, sheaf);
@@ -2398,8 +2396,8 @@ index e423afa27d1a..56819ec51838 100644
  			free_empty_sheaf(s, sheaf);
  			sheaf = NULL;
  		}
-@@ -5050,7 +5225,7 @@ void kmem_cache_return_sheaf(struct kmem_cache *s, gfp_t gfp,
- 
+@@ -5051,7 +5226,7 @@ void kmem_cache_return_sheaf(struct kmem_cache *s, gfp_t gfp,
+
  	if (unlikely((sheaf->capacity != s->sheaf_capacity)
  		     || sheaf->pfmemalloc)) {
 -		sheaf_flush_unused(s, sheaf);
@@ -2407,7 +2405,7 @@ index e423afa27d1a..56819ec51838 100644
  		kfree(sheaf);
  		return;
  	}
-@@ -5078,7 +5253,7 @@ void kmem_cache_return_sheaf(struct kmem_cache *s, gfp_t gfp,
+@@ -5079,7 +5254,7 @@ void kmem_cache_return_sheaf(struct kmem_cache *s, gfp_t gfp,
  	 */
  	if (!barn || data_race(barn->nr_full) >= MAX_FULL_SHEAVES ||
  	    refill_sheaf(s, sheaf, gfp)) {
@@ -2416,117 +2414,117 @@ index e423afa27d1a..56819ec51838 100644
  		free_empty_sheaf(s, sheaf);
  		return;
  	}
-@@ -5121,6 +5296,8 @@ int kmem_cache_refill_sheaf(struct kmem_cache *s, gfp_t gfp,
+@@ -5122,6 +5297,8 @@ int kmem_cache_refill_sheaf(struct kmem_cache *s, gfp_t gfp,
  					     &sheaf->objects[sheaf->size])) {
  			return -ENOMEM;
  		}
 +
 +		check_set_canary_bulk(s, sheaf->capacity - sheaf->size, &sheaf->objects[sheaf->size], s->random_active, s->sheaf_random_inactive);
  		sheaf->size = sheaf->capacity;
- 
+
  		return 0;
-@@ -5167,6 +5344,8 @@ kmem_cache_alloc_from_sheaf_noprof(struct kmem_cache *s, gfp_t gfp,
+@@ -5168,6 +5345,8 @@ kmem_cache_alloc_from_sheaf_noprof(struct kmem_cache *s, gfp_t gfp,
  	if (likely(!ret))
  		ret = sheaf->objects[--sheaf->size];
- 
+
 +	check_set_canary(s, ret, s->sheaf_random_inactive, s->random_active);
 +
  	init = slab_want_init_on_alloc(gfp, s);
- 
+
  	/* add __GFP_NOFAIL to force successful memcg charging */
-@@ -5357,6 +5536,7 @@ void *kmalloc_nolock_noprof(size_t size, gfp_t gfp_flags, int node)
+@@ -5358,6 +5537,7 @@ void *kmalloc_nolock_noprof(size_t size, gfp_t gfp_flags, int node)
  	}
- 
+
  success:
 +	check_set_canary(s, ret, s->random_inactive, s->random_active);
  	maybe_wipe_obj_freeptr(s, ret);
  	slab_post_alloc_hook(s, NULL, alloc_gfp, 1, &ret,
  			     slab_want_init_on_alloc(alloc_gfp, s), size);
-@@ -5699,7 +5879,7 @@ __pcs_replace_full_main(struct kmem_cache *s, struct slub_percpu_sheaves *pcs,
+@@ -5700,7 +5880,7 @@ __pcs_replace_full_main(struct kmem_cache *s, struct slub_percpu_sheaves *pcs,
  		pcs->spare = NULL;
  		local_unlock(&s->cpu_sheaves->lock);
- 
+
 -		sheaf_flush_unused(s, to_flush);
 +		sheaf_flush_unused(s, to_flush, true);
  		empty = to_flush;
  		goto got_empty;
  	}
-@@ -5781,6 +5961,7 @@ bool free_to_pcs(struct kmem_cache *s, void *object, bool allow_spin)
+@@ -5782,6 +5962,7 @@ bool free_to_pcs(struct kmem_cache *s, void *object, bool allow_spin)
  			return false;
  	}
- 
+
 +	check_set_canary(s, object, s->random_active, s->sheaf_random_inactive);
  	pcs->main->objects[pcs->main->size++] = object;
- 
+
  	local_unlock(&s->cpu_sheaves->lock);
-@@ -5812,7 +5993,7 @@ static void rcu_free_sheaf(struct rcu_head *head)
+@@ -5813,7 +5994,7 @@ static void rcu_free_sheaf(struct rcu_head *head)
  	 * If it returns true, there was at least one object from pfmemalloc
  	 * slab so simply flush everything.
  	 */
 -	if (__rcu_free_sheaf_prepare(s, sheaf))
 +	if (__rcu_free_sheaf_prepare(s, sheaf, false))
  		goto flush;
- 
+
  	n = get_node(s, sheaf->node);
-@@ -5839,7 +6020,7 @@ static void rcu_free_sheaf(struct rcu_head *head)
- 
+@@ -5840,7 +6021,7 @@ static void rcu_free_sheaf(struct rcu_head *head)
+
  flush:
  	stat(s, BARN_PUT_FAIL);
 -	sheaf_flush_unused(s, sheaf);
 +	sheaf_flush_unused(s, sheaf, true);
- 
+
  empty:
  	if (barn && data_race(barn->nr_empty) < MAX_EMPTY_SHEAVES) {
-@@ -5936,6 +6117,8 @@ bool __kfree_rcu_sheaf(struct kmem_cache *s, void *obj)
+@@ -5937,6 +6118,8 @@ bool __kfree_rcu_sheaf(struct kmem_cache *s, void *obj)
  	 * Since we flush immediately when size reaches capacity, we never reach
  	 * this with size already at capacity, so no OOB write is possible.
  	 */
 +
 +	check_set_canary(s, obj, s->random_active, s->sheaf_random_inactive);
  	rcu_sheaf->objects[rcu_sheaf->size++] = obj;
- 
+
  	if (likely(rcu_sheaf->size < s->sheaf_capacity)) {
-@@ -5987,7 +6170,7 @@ static void free_to_pcs_bulk(struct kmem_cache *s, size_t size, void **p)
+@@ -5988,7 +6171,7 @@ static void free_to_pcs_bulk(struct kmem_cache *s, size_t size, void **p)
  		memcg_slab_free_hook(s, slab, p + i, 1);
  		alloc_tagging_slab_free_hook(s, slab, p + i, 1);
- 
+
 -		if (unlikely(!slab_free_hook(s, p[i], init, false))) {
 +		if (unlikely(!slab_free_hook(s, p[i], init, false, false))) {
  			p[i] = p[--size];
  			continue;
  		}
-@@ -6048,6 +6231,8 @@ static void free_to_pcs_bulk(struct kmem_cache *s, size_t size, void **p)
+@@ -6049,6 +6232,8 @@ static void free_to_pcs_bulk(struct kmem_cache *s, size_t size, void **p)
  	main = pcs->main;
  	batch = min(size, s->sheaf_capacity - main->size);
- 
+
 +	check_set_canary_bulk(s, batch, p, s->random_active, s->sheaf_random_inactive);
 +
  	memcpy(main->objects + main->size, p, batch * sizeof(void *));
  	main->size += batch;
- 
-@@ -6074,11 +6259,13 @@ static void free_to_pcs_bulk(struct kmem_cache *s, size_t size, void **p)
+
+@@ -6075,11 +6260,13 @@ static void free_to_pcs_bulk(struct kmem_cache *s, size_t size, void **p)
  	 * many full sheaves, free the rest to slab pages
  	 */
  fallback:
 +	check_set_canary_bulk(s, size, p, s->random_active, s->random_inactive);
  	__kmem_cache_free_bulk(s, size, p);
  	stat_add(s, FREE_SLOWPATH, size);
- 
+
  flush_remote:
  	if (remote_nr) {
 +		check_set_canary_bulk(s, remote_nr, &remote_objects[0], s->random_active, s->random_inactive);
  		__kmem_cache_free_bulk(s, remote_nr, &remote_objects[0]);
  		stat_add(s, FREE_SLOWPATH, remote_nr);
  		if (i < size) {
-@@ -6133,6 +6320,7 @@ static void free_deferred_objects(struct irq_work *work)
+@@ -6134,6 +6321,7 @@ static void free_deferred_objects(struct irq_work *work)
  		 */
  		set_freepointer(s, x, NULL);
- 
+
 +		check_set_canary(s, x, s->random_active, s->random_inactive);
  		__slab_free(s, slab, x, x, 1, _THIS_IP_);
  		stat(s, FREE_SLOWPATH);
  	}
-@@ -6163,10 +6351,17 @@ static __fastpath_inline
+@@ -6164,10 +6352,17 @@ static __fastpath_inline
  void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
  	       unsigned long addr)
  {
@@ -2534,7 +2532,7 @@ index e423afa27d1a..56819ec51838 100644
 +
  	memcg_slab_free_hook(s, slab, &object, 1);
  	alloc_tagging_slab_free_hook(s, slab, &object, 1);
- 
+
 -	if (unlikely(!slab_free_hook(s, object, slab_want_init_on_free(s), false)))
 +	/* Make sure canaries are not used on kfence objects. */
 +	/* Defer canary checking if the object is freed back to pcs. */
@@ -2543,12 +2541,12 @@ index e423afa27d1a..56819ec51838 100644
 +
 +	if (unlikely(!slab_free_hook(s, object, slab_want_init_on_free(s), false, canary)))
  		return;
- 
+
  	if (likely(!IS_ENABLED(CONFIG_NUMA) || slab_nid(slab) == numa_mem_id())
-@@ -6175,6 +6370,17 @@ void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
+@@ -6176,6 +6371,17 @@ void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
  			return;
  	}
- 
+
 +	/*
 +	 * linux-hardened: In this scenario, the object was intended to be freed to a
 +	 * sheaf but it failed. The object will thus be freed back to the slab allocator
@@ -2563,15 +2561,15 @@ index e423afa27d1a..56819ec51838 100644
  	__slab_free(s, slab, object, object, 1, addr);
  	stat(s, FREE_SLOWPATH);
  }
-@@ -6184,11 +6390,16 @@ void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
+@@ -6185,11 +6391,16 @@ void slab_free(struct kmem_cache *s, struct slab *slab, void *object,
  static noinline
  void memcg_alloc_abort_single(struct kmem_cache *s, void *object)
  {
 +	bool canary = true;
  	struct slab *slab = virt_to_slab(object);
- 
+
  	alloc_tagging_slab_free_hook(s, slab, &object, 1);
- 
+
 -	if (likely(slab_free_hook(s, object, slab_want_init_on_free(s), false)))
 +	/* Make sure canaries are not used on kfence objects. */
 +	if (is_kfence_address(object))
@@ -2581,18 +2579,18 @@ index e423afa27d1a..56819ec51838 100644
  		__slab_free(s, slab, object, object, 1, _RET_IP_);
  }
  #endif
-@@ -6231,7 +6442,7 @@ static void slab_free_after_rcu_debug(struct rcu_head *rcu_head)
+@@ -6232,7 +6443,7 @@ static void slab_free_after_rcu_debug(struct rcu_head *rcu_head)
  		return;
- 
+
  	/* resume freeing */
 -	if (slab_free_hook(s, object, slab_want_init_on_free(s), true)) {
 +	if (slab_free_hook(s, object, slab_want_init_on_free(s), true, true)) {
  		__slab_free(s, slab, object, object, 1, _THIS_IP_);
  		stat(s, FREE_SLOWPATH);
  	}
-@@ -6252,13 +6463,20 @@ static noinline void warn_free_bad_obj(struct kmem_cache *s, void *obj)
+@@ -6253,13 +6464,20 @@ static noinline void warn_free_bad_obj(struct kmem_cache *s, void *obj)
  	struct slab *slab;
- 
+
  	slab = virt_to_slab(obj);
 +#ifdef CONFIG_BUG_ON_DATA_CORRUPTION
 +	BUG_ON(!slab);
@@ -2602,24 +2600,24 @@ index e423afa27d1a..56819ec51838 100644
  			s->name, obj))
  		return;
 +#endif
- 
+
  	cachep = slab->slab_cache;
- 
+
 +#ifdef CONFIG_BUG_ON_DATA_CORRUPTION
 +	BUG_ON(cachep != s);
 +#else
  	if (WARN_ONCE(cachep != s,
  			"kmem_cache_free(%s, %p): object belongs to different cache %s\n",
  			s->name, obj, cachep ? cachep->name : "(NULL)")) {
-@@ -6266,6 +6484,7 @@ static noinline void warn_free_bad_obj(struct kmem_cache *s, void *obj)
+@@ -6267,6 +6485,7 @@ static noinline void warn_free_bad_obj(struct kmem_cache *s, void *obj)
  			print_tracking(cachep, obj);
  		return;
  	}
 +#endif
  }
- 
+
  /**
-@@ -6319,7 +6538,7 @@ static inline size_t slab_ksize(struct slab *slab)
+@@ -6320,7 +6539,7 @@ static inline size_t slab_ksize(struct slab *slab)
  	 * or any other metadata back there then we can
  	 * only use the space before that information.
  	 */
@@ -2628,23 +2626,23 @@ index e423afa27d1a..56819ec51838 100644
  		return s->inuse;
  	else if (obj_exts_in_object(s, slab))
  		return s->inuse;
-@@ -6399,8 +6618,12 @@ static void free_large_kmalloc(struct page *page, void *object)
+@@ -6400,8 +6619,12 @@ static void free_large_kmalloc(struct page *page, void *object)
  		return;
  	}
- 
+
 +#ifdef CONFIG_BUG_ON_DATA_CORRUPTION
 +	BUG_ON(order == 0);
 +#else
  	if (WARN_ON_ONCE(order == 0))
  		pr_warn_once("object pointer: 0x%p\n", object);
 +#endif
- 
+
  	kmemleak_free(object);
  	kasan_kfree_large(object);
-@@ -7219,6 +7442,23 @@ int __kmem_cache_alloc_bulk(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -7220,6 +7443,23 @@ int __kmem_cache_alloc_bulk(struct kmem_cache *s, gfp_t flags, size_t size,
  		stat_add(s, ALLOC_SLOWPATH, i);
  	}
- 
+
 +	if (has_sanitize_verify(s)) {
 +		int j;
 +
@@ -2663,17 +2661,17 @@ index e423afa27d1a..56819ec51838 100644
 +	check_set_canary_bulk(s, i, p, s->random_inactive, s->random_active);
 +
  	return i;
- 
+
  error:
-@@ -7236,6 +7476,7 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -7237,6 +7477,7 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
  {
  	unsigned int i = 0;
  	void *kfence_obj;
 +	bool init = false;
- 
+
  	if (!size)
  		return 0;
-@@ -7266,8 +7507,10 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -7267,8 +7508,10 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
  		 * the percpu sheaves, we have bigger problems.
  		 */
  		if (unlikely(__kmem_cache_alloc_bulk(s, flags, size - i, p + i) == 0)) {
@@ -2685,7 +2683,7 @@ index e423afa27d1a..56819ec51838 100644
  			if (kfence_obj)
  				__kfence_free(kfence_obj);
  			return 0;
-@@ -7289,8 +7532,11 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
+@@ -7290,8 +7533,11 @@ int kmem_cache_alloc_bulk_noprof(struct kmem_cache *s, gfp_t flags, size_t size,
  	 * memcg and kmem_cache debug support and memory initialization.
  	 * Done outside of the IRQ disabled fastpath loop.
  	 */
@@ -2697,8 +2695,8 @@ index e423afa27d1a..56819ec51838 100644
 +		    init, s->object_size))) {
  		return 0;
  	}
- 
-@@ -7317,10 +7563,10 @@ EXPORT_SYMBOL(kmem_cache_alloc_bulk_noprof);
+
+@@ -7318,10 +7564,10 @@ EXPORT_SYMBOL(kmem_cache_alloc_bulk_noprof);
   * and increases the number of allocations possible without having to
   * take the list_lock.
   */
@@ -2709,10 +2707,10 @@ index e423afa27d1a..56819ec51838 100644
  	IS_ENABLED(CONFIG_SLUB_TINY) ? 1 : PAGE_ALLOC_COSTLY_ORDER;
 -static unsigned int slub_min_objects;
 +static unsigned int slub_min_objects __ro_after_init;
- 
+
  /*
   * Calculate the order of allocation given an slab object size.
-@@ -7535,6 +7781,7 @@ static void early_kmem_cache_node_alloc(int node)
+@@ -7536,6 +7782,7 @@ static void early_kmem_cache_node_alloc(int node)
  #ifdef CONFIG_SLUB_DEBUG
  	init_object(kmem_cache_node, n, SLUB_RED_ACTIVE);
  #endif
@@ -2720,20 +2718,20 @@ index e423afa27d1a..56819ec51838 100644
  	n = kasan_slab_alloc(kmem_cache_node, n, GFP_KERNEL, false);
  	slab->freelist = get_freepointer(kmem_cache_node, n);
  	slab->inuse = 1;
-@@ -7739,6 +7986,9 @@ static int calculate_sizes(struct kmem_cache_args *args, struct kmem_cache *s)
+@@ -7740,6 +7987,9 @@ static int calculate_sizes(struct kmem_cache_args *args, struct kmem_cache *s)
  		s->offset = ALIGN_DOWN(s->object_size / 2, sizeof(void *));
  	}
- 
+
 +	if (IS_ENABLED(CONFIG_SLAB_CANARY))
 +		size += sizeof(void *);
 +
  #ifdef CONFIG_SLUB_DEBUG
  	if (flags & SLAB_STORE_USER) {
  		/*
-@@ -8076,6 +8326,10 @@ void __check_heap_object(const void *ptr, unsigned long n,
+@@ -8077,6 +8327,10 @@ void __check_heap_object(const void *ptr, unsigned long n,
  		offset -= s->red_left_pad;
  	}
- 
+
 +	if (!is_kfence) {
 +		check_canary(s, (void *)ptr - offset, s->random_active);
 +	}
@@ -2741,7 +2739,7 @@ index e423afa27d1a..56819ec51838 100644
  	/* Allow address range falling entirely within usercopy region. */
  	if (offset >= s->useroffset &&
  	    offset - s->useroffset <= s->usersize &&
-@@ -8442,6 +8696,11 @@ int do_kmem_cache_create(struct kmem_cache *s, const char *name,
+@@ -8443,6 +8697,11 @@ int do_kmem_cache_create(struct kmem_cache *s, const char *name,
  	s->flags = kmem_cache_flags(flags, s->name);
  #ifdef CONFIG_SLAB_FREELIST_HARDENED
  	s->random = get_random_long();
@@ -2754,7 +2752,7 @@ index e423afa27d1a..56819ec51838 100644
  	s->align = args->align;
  	s->ctor = args->ctor;
 diff --git a/mm/util.c b/mm/util.c
-index a14de66c9458..e39fe7b338c9 100644
+index a14de66c9..e39fe7b33 100644
 --- a/mm/util.c
 +++ b/mm/util.c
 @@ -391,9 +391,9 @@ unsigned long __weak arch_randomize_brk(struct mm_struct *mm)
@@ -2763,22 +2761,22 @@ index a14de66c9458..e39fe7b338c9 100644
  	if (!IS_ENABLED(CONFIG_64BIT) || is_compat_task())
 -		return randomize_page(mm->brk, SZ_32M);
 +		return mm->brk + get_random_long() % SZ_32M + PAGE_SIZE;
- 
+
 -	return randomize_page(mm->brk, SZ_1G);
 +	return mm->brk + get_random_long() % SZ_1G + PAGE_SIZE;
  }
- 
+
  unsigned long arch_mmap_rnd(void)
 diff --git a/mm/vma_exec.c b/mm/vma_exec.c
-index 8134e1afca68..4e747ea55e52 100644
+index 8134e1afc..4e747ea55 100644
 --- a/mm/vma_exec.c
 +++ b/mm/vma_exec.c
 @@ -7,6 +7,7 @@
- 
+
  #include "vma_internal.h"
  #include "vma.h"
 +#include <linux/random.h>
- 
+
  /*
   * Relocate a VMA downwards by shift bytes. There cannot be any VMAs between
 @@ -151,6 +152,8 @@ int create_init_stack_vma(struct mm_struct *mm, struct vm_area_struct **vmap,
@@ -2788,14 +2786,14 @@ index 8134e1afca68..4e747ea55e52 100644
 +	if (!(current->personality & ADDR_NO_RANDOMIZE) && randomize_va_space)
 +		*top_mem_p ^= get_random_u32() & ~PAGE_MASK;
  	return 0;
- 
+
  err:
 diff --git a/net/ipv4/Kconfig b/net/ipv4/Kconfig
-index 9fc0f1744787..76c406c3c19f 100644
+index 9fc0f1744..76c406c3c 100644
 --- a/net/ipv4/Kconfig
 +++ b/net/ipv4/Kconfig
 @@ -267,6 +267,7 @@ config IP_PIMSM_V2
- 
+
  config SYN_COOKIES
  	bool "IP: TCP syncookie support"
 +	default y
@@ -2804,7 +2802,7 @@ index 9fc0f1744787..76c406c3c19f 100644
  	  flooding". This denial-of-service attack prevents legitimate remote
 @@ -794,3 +795,26 @@ config TCP_MD5SIG
  	  on the Internet.
- 
+
  	  If unsure, say N.
 +
 +config TCP_SIMULT_CONNECT_DEFAULT_ON
@@ -2830,7 +2828,7 @@ index 9fc0f1744787..76c406c3c19f 100644
 +
 +	  If unsure, say N.
 diff --git a/net/ipv4/sysctl_net_ipv4.c b/net/ipv4/sysctl_net_ipv4.c
-index 5654cc9c8a0b..687dc0058b43 100644
+index 5654cc9c8..687dc0058 100644
 --- a/net/ipv4/sysctl_net_ipv4.c
 +++ b/net/ipv4/sysctl_net_ipv4.c
 @@ -622,6 +622,15 @@ static struct ctl_table ipv4_table[] = {
@@ -2847,21 +2845,21 @@ index 5654cc9c8a0b..687dc0058b43 100644
 +		.extra2		= SYSCTL_ONE,
 +	},
  };
- 
+
  static struct ctl_table ipv4_net_table[] = {
 diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
-index 83b825a0d926..9da5dbd3a27e 100644
+index 087548913..3a8888902 100644
 --- a/net/ipv4/tcp_input.c
 +++ b/net/ipv4/tcp_input.c
 @@ -85,6 +85,7 @@
  #include <net/mptcp.h>
- 
+
  int sysctl_tcp_max_orphans __read_mostly = NR_FILE;
 +int sysctl_tcp_simult_connect __read_mostly = IS_ENABLED(CONFIG_TCP_SIMULT_CONNECT_DEFAULT_ON);
- 
+
  #define FLAG_DATA		0x01 /* Incoming frame contained data.		*/
  #define FLAG_WIN_UPDATE		0x02 /* Incoming ACK was a window update.	*/
-@@ -7069,7 +7070,7 @@ static int tcp_rcv_synsent_state_process(struct sock *sk, struct sk_buff *skb,
+@@ -7075,7 +7076,7 @@ static int tcp_rcv_synsent_state_process(struct sock *sk, struct sk_buff *skb,
  		SKB_DR_SET(reason, TCP_RFC7323_PAWS);
  		goto discard_and_undo;
  	}
@@ -2871,7 +2869,7 @@ index 83b825a0d926..9da5dbd3a27e 100644
  		 * simultaneous connect with crossed SYNs.
  		 * Particularly, it can be connect to self.
 diff --git a/scripts/Makefile.modpost b/scripts/Makefile.modpost
-index d7d45067d08b..b501130c534c 100644
+index d7d45067d..b501130c5 100644
 --- a/scripts/Makefile.modpost
 +++ b/scripts/Makefile.modpost
 @@ -47,6 +47,7 @@ modpost-args =										\
@@ -2883,13 +2881,13 @@ index d7d45067d08b..b501130c534c 100644
  	$(if $(KBUILD_NSDEPS),-d modules.nsdeps)					\
  	$(if $(CONFIG_MODULE_ALLOW_MISSING_NAMESPACE_IMPORTS)$(KBUILD_NSDEPS),-N)	\
 diff --git a/scripts/gcc-plugins/Kconfig b/scripts/gcc-plugins/Kconfig
-index 6b34ba19358d..d83e715c9d40 100644
+index 6b34ba193..d83e715c9 100644
 --- a/scripts/gcc-plugins/Kconfig
 +++ b/scripts/gcc-plugins/Kconfig
 @@ -29,6 +29,11 @@ config GCC_PLUGIN_LATENT_ENTROPY
  	  is some slowdown of the boot process (about 0.5%) and fork and
  	  irq processing.
- 
+
 +	  When extra_latent_entropy is passed on the kernel command line,
 +	  entropy will be extracted from up to the first 4GB of RAM while the
 +	  runtime memory allocator is being initialized.  This costs even more
@@ -2897,32 +2895,15 @@ index 6b34ba19358d..d83e715c9d40 100644
 +
  	  Note that entropy extracted this way is not cryptographically
  	  secure!
- 
-diff --git a/scripts/gcc-plugins/gcc-common.h b/scripts/gcc-plugins/gcc-common.h
-index 8f1b3500f8e2..0c69ec2b24e0 100644
---- a/scripts/gcc-plugins/gcc-common.h
-+++ b/scripts/gcc-plugins/gcc-common.h
-@@ -309,7 +309,12 @@ typedef const gimple *const_gimple_ptr;
- #define gimple gimple_ptr
- #define const_gimple const_gimple_ptr
- #undef CONST_CAST_GIMPLE
-+#if BUILDING_GCC_VERSION >= 16000
-+#define CONST_CAST_GIMPLE(X) const_cast<gimple>((X))
-+#define CONST_CAST_TREE(X) const_cast<tree>((X))
-+#else
- #define CONST_CAST_GIMPLE(X) CONST_CAST(gimple, (X))
-+#endif
- 
- /* gimple related */
- static inline gimple gimple_build_assign_with_ops(enum tree_code subcode, tree lhs, tree op1, tree op2 MEM_STAT_DECL)
+
 diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
-index 512b20cbc617..7cc0856eaa96 100644
+index 512b20cbc..7cc0856ea 100644
 --- a/scripts/mod/modpost.c
 +++ b/scripts/mod/modpost.c
 @@ -49,6 +49,8 @@ static bool sec_mismatch_warn_only = true;
  /* Trim EXPORT_SYMBOLs that are unused by in-tree modules */
  static bool trim_unused_exports;
- 
+
 +static int writable_fptr_count = 0;
 +static int writable_fptr_verbose = false;
  /* ignore missing files */
@@ -2934,7 +2915,7 @@ index 512b20cbc617..7cc0856eaa96 100644
  	EXTABLE_TO_NON_TEXT,
 +	DATA_TO_TEXT
  };
- 
+
  /**
 @@ -870,6 +873,12 @@ static const struct sectioncheck sectioncheck[] = {
  	.bad_tosec = { ".altinstr_replacement", NULL },
@@ -2948,11 +2929,11 @@ index 512b20cbc617..7cc0856eaa96 100644
 +	.mismatch = DATA_TO_TEXT
  }
  };
- 
+
 @@ -1035,7 +1044,13 @@ static void default_mismatch_handler(const char *modname, struct elf_info *elf,
  	if (!secref_whitelist(fromsec, fromsym, tosec, tosym))
  		return;
- 
+
 -	sec_mismatch_count++;
 +	if (mismatch->mismatch == DATA_TO_TEXT) {
 +		writable_fptr_count++;
@@ -2961,7 +2942,7 @@ index 512b20cbc617..7cc0856eaa96 100644
 +	} else {
 +		sec_mismatch_count++;
 +	}
- 
+
  	if (!tosym[0])
  		snprintf(taddr_str, sizeof(taddr_str), "0x%x", (unsigned int)taddr);
 @@ -1069,6 +1084,11 @@ static void default_mismatch_handler(const char *modname, struct elf_info *elf,
@@ -2975,11 +2956,11 @@ index 512b20cbc617..7cc0856eaa96 100644
 +		fromsec, fromsym, tosec, tosym);
  	}
  }
- 
+
 @@ -2286,7 +2306,7 @@ int main(int argc, char **argv)
  	LIST_HEAD(dump_lists);
  	struct dump_list *dl, *dl2;
- 
+
 -	while ((opt = getopt(argc, argv, "ei:MmnT:to:au:WwENd:xb")) != -1) {
 +	while ((opt = getopt(argc, argv, "ei:fMmnT:to:au:WwENd:xb")) != -1) {
  		switch (opt) {
@@ -2998,7 +2979,7 @@ index 512b20cbc617..7cc0856eaa96 100644
 @@ -2396,5 +2419,11 @@ int main(int argc, char **argv)
  		warn("suppressed %u unresolved symbol warnings because there were too many)\n",
  		     nr_unresolved - MAX_UNRESOLVED_REPORTS);
- 
+
 +	if (writable_fptr_count && !writable_fptr_verbose)
 +		warn("modpost: Found %d writable function pointer%s.\n"
 +		     "To see full details build your kernel with:\n"
@@ -3008,11 +2989,11 @@ index 512b20cbc617..7cc0856eaa96 100644
  	return error_occurred ? 1 : 0;
  }
 diff --git a/security/Kconfig b/security/Kconfig
-index 6a4393fce9a1..d95435fb7851 100644
+index 6a4393fce..d95435fb7 100644
 --- a/security/Kconfig
 +++ b/security/Kconfig
 @@ -9,7 +9,7 @@ source "security/keys/Kconfig"
- 
+
  config SECURITY_DMESG_RESTRICT
  	bool "Restrict unprivileged access to the kernel syslog"
 -	default n
@@ -3031,7 +3012,7 @@ index 6a4393fce9a1..d95435fb7851 100644
 @@ -72,10 +73,34 @@ config MSEAL_SYSTEM_MAPPINGS
  	  For complete descriptions of memory sealing, please see
  	  Documentation/userspace-api/mseal.rst
- 
+
 +config SECURITY_PERF_EVENTS_RESTRICT
 +	bool "Restrict unprivileged use of performance events"
 +	depends on PERF_EVENTS
@@ -3072,11 +3053,11 @@ index 6a4393fce9a1..d95435fb7851 100644
  	  This enables the socket and networking security hooks.
  	  If enabled, a security module can use these hooks to
 diff --git a/security/Kconfig.hardening b/security/Kconfig.hardening
-index 86f8768c63d4..0068460db967 100644
+index 86f8768c6..0068460db 100644
 --- a/security/Kconfig.hardening
 +++ b/security/Kconfig.hardening
 @@ -158,6 +158,7 @@ config KSTACK_ERASE_RUNTIME_DISABLE
- 
+
  config INIT_ON_ALLOC_DEFAULT_ON
  	bool "Enable heap memory zeroing on allocation by default"
 +	default yes
@@ -3084,7 +3065,7 @@ index 86f8768c63d4..0068460db967 100644
  	help
  	  This has the effect of setting "init_on_alloc=1" on the kernel
 @@ -171,6 +172,7 @@ config INIT_ON_ALLOC_DEFAULT_ON
- 
+
  config INIT_ON_FREE_DEFAULT_ON
  	bool "Enable heap memory zeroing on free by default"
 +	default yes
@@ -3094,7 +3075,7 @@ index 86f8768c63d4..0068460db967 100644
 @@ -209,6 +211,21 @@ config ZERO_CALL_USED_REGS
  	  be evaluated for suitability. For example, x86_64 grows by less
  	  than 1%, and arm64 grows by about 5%.
- 
+
 +config PAGE_SANITIZE_VERIFY
 +	bool "Verify sanitized pages"
 +	default y
@@ -3111,7 +3092,7 @@ index 86f8768c63d4..0068460db967 100644
 +	  objects are zeroed to detect write-after-free bugs.
 +
  endmenu
- 
+
  menu "Bounds checking"
 @@ -218,6 +235,7 @@ config FORTIFY_SOURCE
  	depends on ARCH_HAS_FORTIFY_SOURCE
@@ -3130,7 +3111,7 @@ index 86f8768c63d4..0068460db967 100644
  	  This option checks for obviously wrong memory regions when
  	  copying memory to/from the kernel (via copy_to_user() and
 @@ -248,6 +267,7 @@ menu "Hardening of kernel data structures"
- 
+
  config LIST_HARDENED
  	bool "Check integrity of linked list manipulation"
 +	default y
@@ -3146,7 +3127,7 @@ index 86f8768c63d4..0068460db967 100644
  	  Select this option if the kernel should BUG when it encounters
  	  data corruption in kernel memory structures when they get checked
 diff --git a/security/selinux/Kconfig b/security/selinux/Kconfig
-index 5588c4d573f6..567a33eae460 100644
+index 5588c4d57..567a33eae 100644
 --- a/security/selinux/Kconfig
 +++ b/security/selinux/Kconfig
 @@ -3,7 +3,7 @@ config SECURITY_SELINUX
@@ -3159,13 +3140,13 @@ index 5588c4d573f6..567a33eae460 100644
  	  This selects Security-Enhanced Linux (SELinux).
  	  You will also need a policy configuration and a labeled filesystem.
 diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
-index 6c154a4d94b9..8b1f3501f289 100644
+index 6c154a4d9..8b1f3501f 100644
 --- a/security/selinux/hooks.c
 +++ b/security/selinux/hooks.c
 @@ -141,18 +141,6 @@ static int __init selinux_enabled_setup(char *str)
  __setup("selinux=", selinux_enabled_setup);
  #endif
- 
+
 -static int __init checkreqprot_setup(char *str)
 -{
 -	unsigned long checkreqprot;
@@ -3182,7 +3163,7 @@ index 6c154a4d94b9..8b1f3501f289 100644
   * selinux_secmark_enabled - Check to see if SECMARK is currently enabled
   *
 diff --git a/security/yama/Kconfig b/security/yama/Kconfig
-index a810304123ca..b809050b25d2 100644
+index a81030412..b809050b2 100644
 --- a/security/yama/Kconfig
 +++ b/security/yama/Kconfig
 @@ -2,7 +2,7 @@
@@ -3195,7 +3176,7 @@ index a810304123ca..b809050b25d2 100644
  	  This selects Yama, which extends DAC support with additional
  	  system-wide security settings beyond regular Linux discretionary
 diff --git a/tools/perf/Documentation/security.txt b/tools/perf/Documentation/security.txt
-index 4fe3b8b1958f..a7d88cc23a70 100644
+index 4fe3b8b19..a7d88cc23 100644
 --- a/tools/perf/Documentation/security.txt
 +++ b/tools/perf/Documentation/security.txt
 @@ -148,6 +148,7 @@ Perf tool provides a message similar to the one below:
@@ -3205,9 +3186,9 @@ index 4fe3b8b1958f..a7d88cc23a70 100644
 +   >= 3: Disallow use of any event
     To make the adjusted perf_event_paranoid setting permanent preserve it
     in /etc/sysctl.conf (e.g. kernel.perf_event_paranoid = <setting>)
- 
+
 diff --git a/tools/perf/util/evsel.c b/tools/perf/util/evsel.c
-index f59228c1a39e..d687678a45ea 100644
+index f59228c1a..d687678a4 100644
 --- a/tools/perf/util/evsel.c
 +++ b/tools/perf/util/evsel.c
 @@ -4014,6 +4014,7 @@ int evsel__open_strerror(struct evsel *evsel, struct target *target,
@@ -3218,6 +3199,5 @@ index f59228c1a39e..d687678a45ea 100644
  		 "To make the adjusted perf_event_paranoid setting permanent preserve it\n"
  		 "in /etc/sysctl.conf (e.g. kernel.perf_event_paranoid = <setting>)",
  		 perf_event_paranoid());
--- 
+--
 2.54.0
-


### PR DESCRIPTION
Linux 7.0.11 already contains the GCC 16 compatibility changes in
scripts/gcc-plugins/gcc-common.h