### PR TITLE
7.1: Fix BORE scheduler patch compilation errors

### DIFF
--- a/7.1/sched/0001-bore-cachy.patch
+++ b/7.1/sched/0001-bore-cachy.patch
@@ -1,6 +1,6 @@
-From f385b62c9eeecfadc605af9ea0ed028dcf00b590 Mon Sep 17 00:00:00 2001
+From 7bb604250d5585019e1667818b4a7718a6fd6649 Mon Sep 17 00:00:00 2001
 From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Mon, 4 May 2026 07:56:28 +0200
+Date: Fri, 10 Apr 2026 08:39:56 +0200
 Subject: [PATCH] bore-cachy
 
 Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
@@ -16,14 +16,14 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  kernel/sched/bore.c        | 434 +++++++++++++++++++++++++++++++++++++
  kernel/sched/core.c        |  12 +
  kernel/sched/debug.c       |  61 ++++++
- kernel/sched/fair.c        | 114 ++++++++--
+ kernel/sched/fair.c        | 135 ++++++++++--
  kernel/sched/sched.h       |   9 +
- 13 files changed, 747 insertions(+), 21 deletions(-)
+ 13 files changed, 769 insertions(+), 20 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 368c7b4d7..4237dd677 100644
+index 5a5d3dbc9..b2b2d8c66 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
 @@ -817,6 +817,37 @@ struct kmap_ctrl {
@@ -122,10 +122,10 @@ index 000000000..9215c13a9
 +
 +#endif /* _KERNEL_SCHED_BORE_H */
 diff --git a/init/Kconfig b/init/Kconfig
-index c8f3cccd8..41b49b071 100644
+index 8de7c610d..cb17162f9 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
-@@ -1470,6 +1470,23 @@ config CHECKPOINT_RESTORE
+@@ -1450,6 +1450,23 @@ config CHECKPOINT_RESTORE
  
  	  If unsure, say N here.
  
@@ -175,7 +175,7 @@ index e1359db55..31053e619 100644
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 25e9cb6de..d16448074 100644
+index ede3117fa..3f3af470d 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -147,7 +147,11 @@ static void __unhash_process(struct release_task_post *post, struct task_struct
@@ -191,10 +191,10 @@ index 25e9cb6de..d16448074 100644
  	}
  	list_del_rcu(&p->thread_node);
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 0bcdb1b2d..8088a1596 100644
+index 5dd8301dc..0db23e436 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
-@@ -119,6 +119,10 @@
+@@ -117,6 +117,10 @@
  /* For dup_mmap(). */
  #include "../mm/internal.h"
  
@@ -205,7 +205,7 @@ index 0bcdb1b2d..8088a1596 100644
  #include <trace/events/sched.h>
  
  #define CREATE_TRACE_POINTS
-@@ -2415,6 +2419,11 @@ __latent_entropy struct task_struct *copy_process(
+@@ -2373,6 +2377,11 @@ __latent_entropy struct task_struct *copy_process(
  	p->start_time = ktime_get_ns();
  	p->start_boottime = ktime_get_boottime_ns();
  
@@ -217,7 +217,9 @@ index 0bcdb1b2d..8088a1596 100644
  	/*
  	 * Make it visible to the rest of the system, but dont wake it up yet.
  	 * Need tasklist lock for parent etc handling!
-@@ -2500,7 +2509,11 @@ __latent_entropy struct task_struct *copy_process(
+@@ -2510,9 +2519,13 @@ __latent_entropy struct task_struct *copy_process(
+ 			 */
+ 			p->signal->has_child_subreaper = p->real_parent->signal->has_child_subreaper ||
  							 p->real_parent->signal->is_child_subreaper;
  			if (clone_flags & CLONE_AUTOREAP)
  				p->signal->autoreap = 1;
@@ -230,7 +232,7 @@ index 0bcdb1b2d..8088a1596 100644
  			attach_pid(p, PIDTYPE_TGID);
  			attach_pid(p, PIDTYPE_PGID);
 diff --git a/kernel/futex/waitwake.c b/kernel/futex/waitwake.c
-index ceed9d879..5545a968b 100644
+index 1c2dd03f1..de57e2d54 100644
 --- a/kernel/futex/waitwake.c
 +++ b/kernel/futex/waitwake.c
 @@ -4,6 +4,9 @@
@@ -709,7 +711,7 @@ index 000000000..c27a22cd6
 +#endif // CONFIG_SYSCTL
 +#endif /* CONFIG_SCHED_BORE */
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index bc053fb4d..5b786fa36 100644
+index ab4cfbe9c..bd97f6e6c 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -100,6 +100,10 @@
@@ -723,7 +725,7 @@ index bc053fb4d..5b786fa36 100644
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpu);
  EXPORT_TRACEPOINT_SYMBOL_GPL(ipi_send_cpumask);
  
-@@ -1504,7 +1508,11 @@ int tg_nop(struct task_group *tg, void *data)
+@@ -1440,7 +1444,11 @@ int tg_nop(struct task_group *tg, void *data)
  
  void set_load_weight(struct task_struct *p, bool update_load)
  {
@@ -735,7 +737,7 @@ index bc053fb4d..5b786fa36 100644
  	struct load_weight lw;
  
  	if (task_has_idle_policy(p)) {
-@@ -8889,6 +8897,10 @@ void __init sched_init(void)
+@@ -8603,6 +8611,10 @@ void __init sched_init(void)
  	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
  #endif
  
@@ -747,10 +749,10 @@ index bc053fb4d..5b786fa36 100644
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 74c1617cf..362d601fe 100644
+index 15bf45b6f..282007725 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
-@@ -170,6 +170,53 @@ static const struct file_operations sched_feat_fops = {
+@@ -169,6 +169,53 @@ static const struct file_operations sched_feat_fops = {
  	.release	= single_release,
  };
  
@@ -804,7 +806,7 @@ index 74c1617cf..362d601fe 100644
  static ssize_t sched_scaling_write(struct file *filp, const char __user *ubuf,
  				   size_t cnt, loff_t *ppos)
  {
-@@ -209,6 +256,7 @@ static const struct file_operations sched_scaling_fops = {
+@@ -208,6 +255,7 @@ static const struct file_operations sched_scaling_fops = {
  	.llseek		= seq_lseek,
  	.release	= single_release,
  };
@@ -812,7 +814,7 @@ index 74c1617cf..362d601fe 100644
  
  #ifdef CONFIG_PREEMPT_DYNAMIC
  
-@@ -603,12 +651,19 @@ static __init int sched_init_debug(void)
+@@ -602,12 +650,19 @@ static __init int sched_init_debug(void)
  	debugfs_create_file("preempt", 0644, debugfs_sched, NULL, &sched_dynamic_fops);
  #endif
  
@@ -832,7 +834,7 @@ index 74c1617cf..362d601fe 100644
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
  
-@@ -853,6 +908,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
+@@ -852,6 +907,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
@@ -842,7 +844,7 @@ index 74c1617cf..362d601fe 100644
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, "   %d      %d", task_node(p), task_numa_group_id(p));
  #endif
-@@ -1343,6 +1401,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
+@@ -1331,6 +1389,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  	__PS("nr_involuntary_switches", p->nivcsw);
  
  	P(se.load.weight);
@@ -853,10 +855,10 @@ index 74c1617cf..362d601fe 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index 28c28695e..44078ec17 100644
+index ee2fd37ca..add5b0132 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
-@@ -59,6 +59,10 @@
+@@ -58,6 +58,10 @@
  #include "stats.h"
  #include "autogroup.h"
  
@@ -867,7 +869,7 @@ index 28c28695e..44078ec17 100644
  /*
   * The initial- and re-scaling of tunables is configurable
   *
-@@ -68,28 +72,32 @@
+@@ -67,28 +71,32 @@
   *   SCHED_TUNABLESCALING_LOG - scaled logarithmically, *1+ilog(ncpus)
   *   SCHED_TUNABLESCALING_LINEAR - scaled linear, *ncpus
   *
@@ -911,7 +913,7 @@ index 28c28695e..44078ec17 100644
  
  static int __init setup_sched_thermal_decay_shift(char *str)
  {
-@@ -199,6 +207,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
+@@ -198,6 +206,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
   */
@@ -925,7 +927,7 @@ index 28c28695e..44078ec17 100644
  static unsigned int get_update_sysctl_factor(void)
  {
  	unsigned int cpus = min_t(unsigned int, num_online_cpus(), 8);
-@@ -229,6 +244,7 @@ static void update_sysctl(void)
+@@ -228,6 +243,7 @@ static void update_sysctl(void)
  	SET_SYSCTL(sched_base_slice);
  #undef SET_SYSCTL
  }
@@ -933,7 +935,7 @@ index 28c28695e..44078ec17 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -1064,7 +1080,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -966,7 +982,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   */
  static inline void set_protect_slice(struct cfs_rq *cfs_rq, struct sched_entity *se)
  {
@@ -945,7 +947,7 @@ index 28c28695e..44078ec17 100644
  	u64 vprot = se->deadline;
  
  	if (sched_feat(RUN_TO_PARITY))
-@@ -1142,6 +1162,11 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
+@@ -1044,6 +1064,11 @@ static struct sched_entity *__pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
  		curr = NULL;
  
  	if (curr && protect && protect_slice(curr))
@@ -957,7 +959,7 @@ index 28c28695e..44078ec17 100644
  		return curr;
  
  	/* Pick the leftmost entity if it's eligible */
-@@ -1198,6 +1223,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -1105,6 +1130,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
  /**************************************************************
   * Scheduling class statistics methods:
   */
@@ -965,7 +967,7 @@ index 28c28695e..44078ec17 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -1209,6 +1235,7 @@ int sched_update_scaling(void)
+@@ -1116,6 +1142,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -973,7 +975,7 @@ index 28c28695e..44078ec17 100644
  
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
  
-@@ -1409,6 +1436,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1316,6 +1343,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	resched = update_deadline(cfs_rq, curr);
  
  	if (entity_is_task(curr)) {
@@ -985,19 +987,53 @@ index 28c28695e..44078ec17 100644
  		/*
  		 * If the fair_server is active, we need to account for the
  		 * fair_server time whether or not the task is running on
-@@ -4046,8 +4078,8 @@ rescale_entity(struct sched_entity *se, unsigned long weight, bool rel_vprot)
- 		se->vprot = div64_long(se->vprot * old_weight, weight);
- }
+@@ -3852,17 +3884,23 @@ dequeue_load_avg(struct cfs_rq *cfs_rq, struct sched_entity *se)
+ 
+ static void place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags);
  
 -static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
--			    unsigned long weight)
 +void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
-+		     unsigned long weight)
+ 			    unsigned long weight)
  {
  	bool curr = cfs_rq->curr == se;
  	bool rel_vprot = false;
-@@ -5361,13 +5393,12 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
- static void
+-	u64 avruntime = 0;
++	u64 avruntime = 0;
++#ifdef CONFIG_SCHED_BORE
++	s64 vlag_unscaled = 0;
++#endif /* !CONFIG_SCHED_BORE */
+ 
+ 	if (se->on_rq) {
+ 		/* commit outstanding execution time */
+ 		update_curr(cfs_rq);
+ 		avruntime = avg_vruntime(cfs_rq);
+ 		se->vlag = entity_lag(cfs_rq, se, avruntime);
++#ifdef CONFIG_SCHED_BORE
++		vlag_unscaled = se->vlag;
++#endif /* !CONFIG_SCHED_BORE */
+ 		se->deadline -= avruntime;
+ 		se->rel_deadline = 1;
+ 		if (curr && protect_slice(se)) {
+@@ -4145,6 +4183,16 @@ static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
+ 
+ 	enqueue_load_avg(cfs_rq, se);
+ 	if (se->on_rq) {
++#ifdef CONFIG_SCHED_BORE
++		if (curr) {
++			se->vruntime += vlag_unscaled - se->vlag;
++			if (se->rel_deadline) {
++				se->deadline += se->vruntime;
++				se->rel_deadline = 0;
++			}
++		}
++		else
++#endif /* !CONFIG_SCHED_BORE */
+ 		if (rel_vprot)
+ 			se->vprot += avruntime;
+ 		se->deadline += avruntime;
+ 		se->rel_deadline = 0;
+ 		se->vruntime = avruntime - se->vlag;
+@@ -5422,12 +5470,11 @@ static void
  place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  {
 -	u64 vslice, vruntime = avg_vruntime(cfs_rq);
@@ -1011,7 +1047,7 @@ index 28c28695e..44078ec17 100644
  
  	/*
  	 * Due to how V is constructed as the weighted average of entities,
-@@ -5479,7 +5510,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5263,7 +5310,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		se->rel_deadline = 0;
  		return;
  	}
@@ -1031,7 +1067,7 @@ index 28c28695e..44078ec17 100644
  	/*
  	 * When joining the competition; the existing tasks will be,
  	 * on average, halfway through their slice, as such start tasks
-@@ -5488,6 +5530,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -5272,6 +5330,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
  		vslice /= 2;
  
@@ -1041,40 +1077,61 @@ index 28c28695e..44078ec17 100644
  	/*
  	 * EEVDF: vd_i = ve_i + r_i/w_i
  	 */
-@@ -5498,7 +5543,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
+@@ -5282,7 +5343,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
  static inline int cfs_rq_throttled(struct cfs_rq *cfs_rq);
  
  static void
--requeue_delayed_entity(struct sched_entity *se);
+-requeue_delayed_entity(struct sched_entity *se, int flags);
 +requeue_delayed_entity(struct sched_entity *se, int flags);
  
  static void
  enqueue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
-@@ -7143,7 +7188,7 @@ static int choose_idle_cpu(int cpu, struct task_struct *p)
+@@ -5724,7 +5785,14 @@ dequeue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 		if (sched_feat(DELAY_DEQUEUE) && delay &&
+ 		    !entity_eligible(cfs_rq, se)) {
+ 			update_load_avg(cfs_rq, se, 0);
+-			update_entity_lag(cfs_rq, se);
++#ifdef CONFIG_SCHED_BORE
++			if (!static_branch_likely(&sched_bore_key) || sched_feat(DELAY_ZERO))
++				update_entity_lag(cfs_rq, se);
++#else
++			update_entity_lag(cfs_rq, se);
++#endif
+ 			set_delayed(se);
+ 			return false;
+ 		}
+@@ -6911,7 +6976,7 @@ static int sched_idle_cpu(int cpu)
  }
  
  static void
--requeue_delayed_entity(struct sched_entity *se)
+-requeue_delayed_entity(struct sched_entity *se, int flags)
 +requeue_delayed_entity(struct sched_entity *se, int flags)
  {
  	struct cfs_rq *cfs_rq = cfs_rq_of(se);
++	int requeue_flags = 0;
++#ifdef CONFIG_SCHED_BORE
++	if (static_branch_likely(&sched_bore_key))
++		requeue_flags = ENQUEUE_WAKEUP;
++#endif
  
-@@ -7159,7 +7204,13 @@ requeue_delayed_entity(struct sched_entity *se)
+ 	/*
+ 	 * se->sched_delayed should imply: se->on_rq == 1.
+ 	 * Because a delayed entity is one that is still on
+ 	 * the runqueue competing until elegibility.
+ 	 */
+ 	WARN_ON_ONCE(!se->sched_delayed);
+ 	WARN_ON_ONCE(!se->on_rq);
+ 
+ 	if (update_entity_lag(cfs_rq, se)) {
  		cfs_rq->nr_queued--;
  		if (se != cfs_rq->curr)
  			__dequeue_entity(cfs_rq, se);
 -		place_entity(cfs_rq, se, 0);
-+#ifdef CONFIG_SCHED_BORE
-+		if (static_branch_likely(&sched_bore_key))
-+			flags |= ENQUEUE_WAKEUP;
-+		else
-+#endif /* CONFIG_SCHED_BORE */
-+			flags = 0;
-+		place_entity(cfs_rq, se, flags);
- 		if (se != cfs_rq->curr)
- 			__enqueue_entity(cfs_rq, se);
- 		cfs_rq->nr_queued++;
-@@ -7198,7 +7249,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
++		place_entity(cfs_rq, se, requeue_flags);
+ 			if (se != cfs_rq->curr)
+ 				__enqueue_entity(cfs_rq, se);
+ 			cfs_rq->nr_queued++;
+@@ -6970,7 +7044,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_enqueue(&rq->cfs, p);
  
  	if (flags & ENQUEUE_DELAYED) {
@@ -1083,7 +1140,7 @@ index 28c28695e..44078ec17 100644
  		return;
  	}
  
-@@ -7216,7 +7267,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -6988,7 +7062,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	for_each_sched_entity(se) {
  		if (se->on_rq) {
  			if (se->sched_delayed)
@@ -1092,7 +1149,7 @@ index 28c28695e..44078ec17 100644
  			break;
  		}
  		cfs_rq = cfs_rq_of(se);
-@@ -7420,6 +7471,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -7195,6 +7269,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  		util_est_dequeue(&rq->cfs, p);
  
  	util_est_update(&rq->cfs, p, flags & DEQUEUE_SLEEP);
@@ -1108,7 +1165,7 @@ index 28c28695e..44078ec17 100644
  	if (dequeue_entities(rq, &p->se, flags) < 0)
  		return false;
  
-@@ -9437,16 +9497,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -9211,16 +9294,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -1134,7 +1191,7 @@ index 28c28695e..44078ec17 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -13929,6 +13998,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
+@@ -13667,6 +13759,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  	WARN_ON_ONCE(p->se.sched_delayed);
  
  	attach_task_cfs_rq(p);
@@ -1145,10 +1202,10 @@ index 28c28695e..44078ec17 100644
  	set_task_max_allowed_capacity(p);
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index a4eb46e12..8e45a6ed9 100644
+index fd2760ee6..de7fd529d 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -2242,7 +2242,11 @@ extern int group_balance_cpu(struct sched_group *sg);
+@@ -2219,7 +2219,11 @@ extern int group_balance_cpu(struct sched_group *sg);
  extern void update_sched_domain_debugfs(void);
  extern void dirty_sched_domain_sysctl(int cpu);
  
@@ -1160,7 +1217,7 @@ index a4eb46e12..8e45a6ed9 100644
  
  static inline const struct cpumask *task_user_cpus(struct task_struct *p)
  {
-@@ -3166,7 +3170,12 @@ static inline void attach_one_task(struct rq *rq, struct task_struct *p)
+@@ -3013,7 +3017,12 @@ extern void wakeup_preempt(struct rq *rq, struct task_struct *p, int flags);
  extern __read_mostly unsigned int sysctl_sched_nr_migrate;
  extern __read_mostly unsigned int sysctl_sched_migration_cost;
  
@@ -1174,5 +1231,5 @@ index a4eb46e12..8e45a6ed9 100644
  extern int sysctl_resched_latency_warn_ms;
  extern int sysctl_resched_latency_warn_once;
 -- 
-2.54.0
+2.53.0
 


### PR DESCRIPTION
This PR fixes compilation and patching errors for the BORE scheduler patch on Linux 7.1.0.

It updates `0001-bore-cachy.patch` for `7.1` to align with upstream changes:
- `copy_process` in `kernel/fork.c` now includes the `CLONE_AUTOREAP` logic.
- `reweight_entity` in `kernel/sched/fair.c` now uses the `avruntime` variable and calls `entity_lag` directly.
- `place_entity` in `kernel/sched/fair.c` keeps `update_zero` context.
- `dequeue_entity` in `kernel/sched/fair.c` runs `update_entity_lag` conditionally if BORE is active (otherwise unconditionally as per 7.1.0 defaults).
- `requeue_delayed_entity` in `kernel/sched/fair.c` now takes `flags` as part of its signature, and we pass `requeue_flags` based on BORE status.

These changes allow `linux-cachyos-bore` to build cleanly.
