### PR TITLE
7.1: Remove unused and deprecated linux/of_gpio.h from handheld patch

### DIFF
--- a/7.1/misc/0001-handheld.patch
+++ b/7.1/misc/0001-handheld.patch
@@ -84,18 +84,18 @@ Signed-off-by: Eric Naim <dnaim@cachyos.org>
  sound/soc/codecs/Makefile                     |    1 +
  sound/soc/codecs/aw87xxx/Kconfig              |    5 +
  sound/soc/codecs/aw87xxx/Makefile             |    4 +
- sound/soc/codecs/aw87xxx/aw87xxx.c            | 1601 +++++
+ sound/soc/codecs/aw87xxx/aw87xxx.c            | 1600 +++++
  sound/soc/codecs/aw87xxx/aw87xxx.h            |  130 +
  sound/soc/codecs/aw87xxx/aw87xxx_acf_bin.c    | 1558 +++++
  sound/soc/codecs/aw87xxx/aw87xxx_acf_bin.h    |  191 +
- sound/soc/codecs/aw87xxx/aw87xxx_bin_parse.c  |  515 ++
+ sound/soc/codecs/aw87xxx/aw87xxx_bin_parse.c  |  514 ++
  sound/soc/codecs/aw87xxx/aw87xxx_bin_parse.h  |   73 +
- sound/soc/codecs/aw87xxx/aw87xxx_device.c     |  977 +++
+ sound/soc/codecs/aw87xxx/aw87xxx_device.c     |  976 +++
  sound/soc/codecs/aw87xxx/aw87xxx_device.h     |  149 +
  sound/soc/codecs/aw87xxx/aw87xxx_dsp.c        |  355 ++
  sound/soc/codecs/aw87xxx/aw87xxx_dsp.h        |   65 +
  sound/soc/codecs/aw87xxx/aw87xxx_log.h        |   33 +
- sound/soc/codecs/aw87xxx/aw87xxx_monitor.c    | 1208 ++++
+ sound/soc/codecs/aw87xxx/aw87xxx_monitor.c    | 1207 ++++
  sound/soc/codecs/aw87xxx/aw87xxx_monitor.h    |   96 +
  sound/soc/codecs/aw87xxx/aw87xxx_pid_18_reg.h | 2315 ++++++++
  sound/soc/codecs/aw87xxx/aw87xxx_pid_39_reg.h |   67 +
@@ -15181,7 +15181,7 @@ new file mode 100644
 index 000000000000..3d732400e449
 --- /dev/null
 +++ b/sound/soc/codecs/aw87xxx/aw87xxx.c
-@@ -0,0 +1,1601 @@
+@@ -0,0 +1,1600 @@
 +/*
 + * aw87xxx.c  aw87xxx pa module
 + *
@@ -15200,7 +15200,6 @@ index 000000000000..3d732400e449
 +#include <sound/pcm.h>
 +#include <sound/pcm_params.h>
 +#include <linux/gpio.h>
-+#include <linux/of_gpio.h>
 +#include <linux/gpio/consumer.h>
 +#include <linux/interrupt.h>
 +#include <linux/delay.h>
@@ -18685,7 +18684,7 @@ new file mode 100644
 index 000000000000..7eab9efde147
 --- /dev/null
 +++ b/sound/soc/codecs/aw87xxx/aw87xxx_bin_parse.c
-@@ -0,0 +1,515 @@
+@@ -0,0 +1,514 @@
 +/*
 +* aw87xxx_bin_parse.c
 +*
@@ -18700,7 +18699,6 @@ index 000000000000..7eab9efde147
 +#include <linux/module.h>
 +#include <linux/kernel.h>
 +#include <linux/i2c.h>
-+#include <linux/of_gpio.h>
 +#include <linux/delay.h>
 +#include <linux/device.h>
 +#include <linux/firmware.h>
@@ -19285,7 +19283,7 @@ new file mode 100644
 index 000000000000..a4c9ad7d96dc
 --- /dev/null
 +++ b/sound/soc/codecs/aw87xxx/aw87xxx_device.c
-@@ -0,0 +1,977 @@
+@@ -0,0 +1,976 @@
 +/*
 + * aw87xxx_device.c  aw87xxx pa module
 + *
@@ -19302,7 +19300,6 @@ index 000000000000..a4c9ad7d96dc
 +
 +#include <linux/i2c.h>
 +#include <linux/gpio.h>
-+#include <linux/of_gpio.h>
 +#include <linux/interrupt.h>
 +#include <linux/delay.h>
 +#include <linux/kernel.h>
@@ -20894,7 +20891,7 @@ new file mode 100644
 index 000000000000..f580506b2786
 --- /dev/null
 +++ b/sound/soc/codecs/aw87xxx/aw87xxx_monitor.c
-@@ -0,0 +1,1208 @@
+@@ -0,0 +1,1207 @@
 +/*
 + * aw87xxx_monitor.c
 + *
@@ -20920,7 +20917,6 @@ index 000000000000..f580506b2786
 +#include <linux/hrtimer.h>
 +#include <linux/i2c.h>
 +#include <linux/gpio.h>
-+#include <linux/of_gpio.h>
 +#include <linux/interrupt.h>
 +#include <linux/irq.h>
 +#include <linux/firmware.h>


### PR DESCRIPTION
`linux/of_gpio.h` header has been dropped from linux mainline source. Including this header may cause build failures such as `sound/soc/codecs/aw87xxx/aw87xxx.c:19:10: fatal error: 'linux/of_gpio.h' file not found`, which i encountered while building my custom kernel.

Removing it should be completely safe, because:

i checked of_gpio.h's usage across the four affected files (aw87xxx.c, aw87xxx_bin_parse.c, aw87xxx_device.c, aw87xxx_monitor.c) and none of them calls of_get_named_gpio() or any other function exclusive to of_gpio.h. What they actually use is:

devm_gpiod_get() in aw87xxx.c, which comes from <linux/gpio/consumer.h>
gpio_is_valid() and gpio_set_value_cansleep() in aw87xxx_device.c, which come from <linux/gpio.h>
aw87xxx_bin_parse.c and aw87xxx_monitor.c don't even use any GPIO-related code in their bodies, the include was just dead weight.