### PR TITLE
7.1: revert MAX_SURFACES 4 to 6 in dc.h (breaks amdgpu init)

### DIFF
--- a/7.1/misc/0001-handheld.patch
+++ b/7.1/misc/0001-handheld.patch
@@ -20,7 +20,6 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  drivers/gpu/drm/amd/amdgpu/amdgpu_mode.h      |    2 -
  .../gpu/drm/amd/amdgpu/atombios_encoders.c    |   10 +-
  .../gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c |    5 +-
- drivers/gpu/drm/amd/display/dc/dc.h           |    2 +-
  .../amd/display/dc/hwss/dce110/dce110_hwseq.c |   33 +-
  .../drm/amd/display/dc/link/link_detection.c  |    2 +-
  .../drm/amd/display/dc/link/link_validation.c |   11 +
@@ -106,7 +105,7 @@ Signed-off-by: Peter Jung <admin@ptr1337.dev>
  sound/soc/codecs/aw87xxx/aw87xxx_pid_76_reg.h | 1205 ++++
  sound/soc/codecs/aw87xxx/aw87xxx_pid_9b_reg.h |   81 +
  sound/soc/codecs/max98388.c                   |   24 +-
- 101 files changed, 33587 insertions(+), 184 deletions(-)
+ 100 files changed, 33586 insertions(+), 183 deletions(-)
  create mode 100644 drivers/extcon/extcon-steamdeck.c
  create mode 100644 drivers/hid/hid-asus-ally.c
  create mode 100644 drivers/hid/hid-asus-ally.h
@@ -720,19 +719,6 @@ index f74a258f868a..ebbec303a640 100644
  	bool cursor_update = false;
  	bool pflip_present = false;
  	bool dirty_rects_changed = false;
-diff --git a/drivers/gpu/drm/amd/display/dc/dc.h b/drivers/gpu/drm/amd/display/dc/dc.h
-index 23f2fce2a6a7..27b93870053d 100644
---- a/drivers/gpu/drm/amd/display/dc/dc.h
-+++ b/drivers/gpu/drm/amd/display/dc/dc.h
-@@ -68,7 +68,7 @@ struct dcn_dccg_reg_state;
- /**
-  * MAX_SURFACES - representative of the upper bound of surfaces that can be piped to a single CRTC
-  */
--#define MAX_SURFACES 4
-+#define MAX_SURFACES 6
- /**
-  * MAX_PLANES - representative of the upper bound of planes that are supported by the HW
-  */
 diff --git a/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c b/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c
 index f0abbb7c2cb2..8f57fc58fea4 100644
 --- a/drivers/gpu/drm/amd/display/dc/hwss/dce110/dce110_hwseq.c


### PR DESCRIPTION
Fixes the issues I described in both comments: 

https://github.com/CachyOS/kernel-patches/pull/165#issuecomment-4755767978

https://github.com/CachyOS/kernel-patches/pull/165#issuecomment-4760333604
