### PR TITLE
sched: fix duplicate CONFIG_SCHED_ALT guard in idle.c

### DIFF
--- a/7.1/sched/0001-prjc-cachy.patch
+++ b/7.1/sched/0001-prjc-cachy.patch
@@ -10681,7 +10681,6 @@ index 912b2a846..3848a9c06 100644
  }
  
 +#ifndef CONFIG_SCHED_ALT
-+#ifndef CONFIG_SCHED_ALT
  /*
   * idle-task scheduling class.
   */


### PR DESCRIPTION
Remove a duplicated CONFIG_SCHED_ALT guard in 7.1/sched/0001-prjc-cachy.patch.

The patch currently adds two consecutive:

#ifndef CONFIG_SCHED_ALT

lines before the idle scheduling class section in kernel/sched/idle.c.

This results in an unmatched preprocessor guard and caused a build failure during linux-cachyos-bmq compilation.