### PR TITLE
7.2: forward-port BORE scheduler to 7.2-rc2-3

### DIFF
--- a/7.2/sched/0001-bore-cachy.patch
+++ b/7.2/sched/0001-bore-cachy.patch
@@ -1,9 +1,8 @@
-From ee96d896f8d0220200f19927c3baf48d7f4e88d5 Mon Sep 17 00:00:00 2001
-From: Piotr Gorski <lucjan.lucjanov@gmail.com>
-Date: Tue, 30 Jun 2026 08:06:36 +0200
-Subject: [PATCH] bore-cachy
+From 7e3de6bdabbaa4f7a68128ef4a906c25d1e9c60c Mon Sep 17 00:00:00 2001
+From: loner <2788892716@qq.com>
+Date: Thu, 9 Jul 2026 09:25:53 +0800
+Subject: [PATCH] bore-cachy: forward-port BORE scheduler to CachyOS 7.2-rc2-3
 
-Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
 ---
  include/linux/sched.h      |  34 +++
  include/linux/sched/bore.h |  46 ++++
@@ -18,15 +17,15 @@ Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>
  kernel/sched/debug.c       |  61 +++++
  kernel/sched/fair.c        | 166 +++++++++++--
  kernel/sched/sched.h       |   9 +
- 13 files changed, 834 insertions(+), 23 deletions(-)
+ 13 files changed, 835 insertions(+), 22 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index eefef9035..4e403d806 100644
+index 1cf9805b..49fc3f58 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -823,6 +823,37 @@ struct kmap_ctrl {
+@@ -824,6 +824,37 @@ struct kmap_ctrl {
  #endif
  };
  
@@ -64,7 +63,7 @@ index eefef9035..4e403d806 100644
  struct task_struct {
  #ifdef CONFIG_THREAD_INFO_IN_TASK
  	/*
-@@ -884,6 +915,9 @@ struct task_struct {
+@@ -885,6 +916,9 @@ struct task_struct {
  #ifdef CONFIG_SCHED_CLASS_EXT
  	struct sched_ext_entity		scx;
  #endif
@@ -76,7 +75,7 @@ index eefef9035..4e403d806 100644
  #ifdef CONFIG_SCHED_CORE
 diff --git a/include/linux/sched/bore.h b/include/linux/sched/bore.h
 new file mode 100644
-index 000000000..76afe1d25
+index 00000000..76afe1d2
 --- /dev/null
 +++ b/include/linux/sched/bore.h
 @@ -0,0 +1,46 @@
@@ -127,7 +126,7 @@ index 000000000..76afe1d25
 +
 +#endif /* _KERNEL_SCHED_BORE_H */
 diff --git a/init/Kconfig b/init/Kconfig
-index 39e153f9a..7137c1f53 100644
+index 39e153f9..7137c1f5 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1481,6 +1481,23 @@ config CHECKPOINT_RESTORE
@@ -155,7 +154,7 @@ index 39e153f9a..7137c1f53 100644
  	bool "Automatic process group scheduling"
  	select CGROUPS
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index e1359db55..31053e619 100644
+index e1359db5..31053e61 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -81,3 +81,20 @@ config HZ
@@ -180,7 +179,7 @@ index e1359db55..31053e619 100644
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 1056422bc..51955518f 100644
+index 1056422b..51955518 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -147,7 +147,11 @@ static void __unhash_process(struct release_task_post *post, struct task_struct
@@ -196,7 +195,7 @@ index 1056422bc..51955518f 100644
  	}
  	list_del_rcu(&p->thread_node);
 diff --git a/kernel/fork.c b/kernel/fork.c
-index 8cff03e6e..06996fc11 100644
+index ec832f56..4f9f195f 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -120,6 +120,10 @@
@@ -210,7 +209,7 @@ index 8cff03e6e..06996fc11 100644
  #include <trace/events/sched.h>
  
  #define CREATE_TRACE_POINTS
-@@ -2447,6 +2451,11 @@ __latent_entropy struct task_struct *copy_process(
+@@ -2448,6 +2452,11 @@ __latent_entropy struct task_struct *copy_process(
  	p->start_time = ktime_get_ns();
  	p->start_boottime = ktime_get_boottime_ns();
  
@@ -222,7 +221,7 @@ index 8cff03e6e..06996fc11 100644
  	/*
  	 * Make it visible to the rest of the system, but dont wake it up yet.
  	 * Need tasklist lock for parent etc handling!
-@@ -2532,7 +2541,11 @@ __latent_entropy struct task_struct *copy_process(
+@@ -2533,7 +2542,11 @@ __latent_entropy struct task_struct *copy_process(
  							 p->real_parent->signal->is_child_subreaper;
  			if (clone_flags & CLONE_AUTOREAP)
  				p->signal->autoreap = 1;
@@ -235,7 +234,7 @@ index 8cff03e6e..06996fc11 100644
  			attach_pid(p, PIDTYPE_TGID);
  			attach_pid(p, PIDTYPE_PGID);
 diff --git a/kernel/futex/waitwake.c b/kernel/futex/waitwake.c
-index d4483d15d..7fa31c8d7 100644
+index d4483d15..7fa31c8d 100644
 --- a/kernel/futex/waitwake.c
 +++ b/kernel/futex/waitwake.c
 @@ -4,6 +4,9 @@
@@ -265,7 +264,7 @@ index d4483d15d..7fa31c8d7 100644
  	__set_current_state(TASK_RUNNING);
  }
 diff --git a/kernel/sched/Makefile b/kernel/sched/Makefile
-index b1f1a3670..f95a7b3d5 100644
+index b1f1a367..f95a7b3d 100644
 --- a/kernel/sched/Makefile
 +++ b/kernel/sched/Makefile
 @@ -40,3 +40,4 @@ obj-y += core.o
@@ -275,7 +274,7 @@ index b1f1a3670..f95a7b3d5 100644
 +obj-$(CONFIG_SCHED_BORE) += bore.o
 diff --git a/kernel/sched/bore.c b/kernel/sched/bore.c
 new file mode 100644
-index 000000000..7587cbc78
+index 00000000..7587cbc7
 --- /dev/null
 +++ b/kernel/sched/bore.c
 @@ -0,0 +1,466 @@
@@ -746,7 +745,7 @@ index 000000000..7587cbc78
 +#endif // CONFIG_SYSCTL
 +#endif /* CONFIG_SCHED_BORE */
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 699491196..6d0f1c3ff 100644
+index edd1a3fc..ba904573 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -100,6 +100,10 @@
@@ -784,7 +783,7 @@ index 699491196..6d0f1c3ff 100644
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index 40584b27e..976c3129d 100644
+index c15291cb..d7f04e23 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -170,6 +170,53 @@ static const struct file_operations sched_feat_fops = {
@@ -849,7 +848,7 @@ index 40584b27e..976c3129d 100644
  
  #ifdef CONFIG_SCHED_CACHE
  static ssize_t
-@@ -645,12 +693,19 @@ static __init int sched_init_debug(void)
+@@ -721,12 +769,19 @@ static __init int sched_init_debug(void)
  	debugfs_create_file("preempt", 0644, debugfs_sched, NULL, &sched_dynamic_fops);
  #endif
  
@@ -869,7 +868,7 @@ index 40584b27e..976c3129d 100644
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
  
-@@ -911,6 +966,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
+@@ -992,6 +1047,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
@@ -879,7 +878,7 @@ index 40584b27e..976c3129d 100644
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, "   %d      %d", task_node(p), task_numa_group_id(p));
  #endif
-@@ -1401,6 +1459,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
+@@ -1484,6 +1542,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  	__PS("nr_involuntary_switches", p->nivcsw);
  
  	P(se.load.weight);
@@ -890,10 +889,10 @@ index 40584b27e..976c3129d 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index e88f50d4e..eeff9cc22 100644
+index cfd84963..f173dad5 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
-@@ -58,6 +58,10 @@
+@@ -59,6 +59,10 @@
  #include "stats.h"
  #include "autogroup.h"
  
@@ -904,7 +903,7 @@ index e88f50d4e..eeff9cc22 100644
  /*
   * The initial- and re-scaling of tunables is configurable
   *
-@@ -67,28 +71,32 @@
+@@ -68,28 +72,32 @@
   *   SCHED_TUNABLESCALING_LOG - scaled logarithmically, *1+ilog(ncpus)
   *   SCHED_TUNABLESCALING_LINEAR - scaled linear, *ncpus
   *
@@ -948,7 +947,7 @@ index e88f50d4e..eeff9cc22 100644
  
  static int __init setup_sched_thermal_decay_shift(char *str)
  {
-@@ -198,6 +206,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
+@@ -199,6 +207,13 @@ static inline void update_load_set(struct load_weight *lw, unsigned long w)
   *
   * This idea comes from the SD scheduler of Con Kolivas:
   */
@@ -962,7 +961,7 @@ index e88f50d4e..eeff9cc22 100644
  static unsigned int get_update_sysctl_factor(void)
  {
  	unsigned int cpus = min_t(unsigned int, num_online_cpus(), 8);
-@@ -228,6 +243,7 @@ static void update_sysctl(void)
+@@ -229,6 +244,7 @@ static void update_sysctl(void)
  	SET_SYSCTL(sched_base_slice);
  #undef SET_SYSCTL
  }
@@ -970,7 +969,7 @@ index e88f50d4e..eeff9cc22 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -1092,7 +1108,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -1060,7 +1076,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   */
  static inline void set_protect_slice(struct cfs_rq *cfs_rq, struct sched_entity *se)
  {
@@ -982,7 +981,7 @@ index e88f50d4e..eeff9cc22 100644
  	u64 vprot = se->deadline;
  
  	if (sched_feat(RUN_TO_PARITY))
-@@ -1169,8 +1189,17 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
+@@ -1137,8 +1157,17 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
  	if (curr && (!curr->on_rq || !entity_eligible(cfs_rq, curr)))
  		curr = NULL;
  
@@ -1002,7 +1001,7 @@ index e88f50d4e..eeff9cc22 100644
  
  	/* Pick the leftmost entity if it's eligible */
  	if (se && entity_eligible(cfs_rq, se)) {
-@@ -1226,6 +1255,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -1194,6 +1223,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
  /**************************************************************
   * Scheduling class statistics methods:
   */
@@ -1010,7 +1009,7 @@ index e88f50d4e..eeff9cc22 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -1237,6 +1267,7 @@ int sched_update_scaling(void)
+@@ -1205,6 +1235,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -1018,7 +1017,7 @@ index e88f50d4e..eeff9cc22 100644
  
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
  
-@@ -1980,6 +2011,38 @@ static void account_llc_dequeue(struct rq *rq, struct task_struct *p) {}
+@@ -1946,6 +1977,38 @@ static void account_llc_dequeue(struct rq *rq, struct task_struct *p) {}
  
  #endif /* CONFIG_SCHED_CACHE */
  
@@ -1057,20 +1056,19 @@ index e88f50d4e..eeff9cc22 100644
  /*
   * Used by other classes to account runtime.
   */
-@@ -2015,6 +2078,11 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -1987,6 +2050,10 @@ static void update_curr(struct cfs_rq *cfs_rq)
+ 	curr->vruntime += calc_delta_fair(delta_exec, curr);
  	resched = update_deadline(cfs_rq, curr);
  
- 	if (entity_is_task(curr)) {
 +#ifdef CONFIG_SCHED_BORE
-+		struct task_struct *p = task_of(curr);
-+		update_curr_bore(p, delta_exec);
++	update_curr_bore(task_of(curr), delta_exec);
 +#endif /* CONFIG_SCHED_BORE */
 +
- 		/*
- 		 * If the fair_server is active, we need to account for the
- 		 * fair_server time whether or not the task is running on
-@@ -4672,8 +4740,8 @@ rescale_entity(struct sched_entity *se, unsigned long weight, bool rel_vprot)
- 		se->vprot = div64_long(se->vprot * old_weight, weight);
+ 	/*
+ 	 * If the fair_server is active, we need to account for the
+ 	 * fair_server time whether or not the task is running on
+@@ -4688,8 +4755,8 @@ static void reweight_eevdf(struct cfs_rq *cfs_rq, struct sched_entity *se,
+ 	}
  }
  
 -static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
@@ -1078,14 +1076,15 @@ index e88f50d4e..eeff9cc22 100644
 +void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
 +		     unsigned long weight)
  {
- 	bool curr = cfs_rq->curr == se;
- 	bool rel_vprot = false;
-@@ -5976,13 +6044,12 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
+ 	if (se->load.weight == weight)
+ 		return;
+@@ -6107,14 +6174,13 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
  static void
  place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  {
 -	u64 vslice, vruntime = avg_vruntime(cfs_rq);
 +	u64 vslice = 0, vruntime = avg_vruntime(cfs_rq);
+ 	unsigned int nr_queued = cfs_rq->h_nr_queued;
  	bool update_zero = false;
  	s64 lag = 0;
  
@@ -1093,9 +1092,9 @@ index e88f50d4e..eeff9cc22 100644
  		se->slice = sysctl_sched_base_slice;
 -	vslice = calc_delta_fair(se->slice, se);
  
- 	/*
- 	 * Due to how V is constructed as the weighted average of entities,
-@@ -6094,7 +6161,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 	if (flags & ENQUEUE_QUEUED)
+ 		nr_queued -= 1;
+@@ -6229,7 +6295,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		se->rel_deadline = 0;
  		return;
  	}
@@ -1115,7 +1114,7 @@ index e88f50d4e..eeff9cc22 100644
  	/*
  	 * When joining the competition; the existing tasks will be,
  	 * on average, halfway through their slice, as such start tasks
-@@ -6103,6 +6181,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -6238,6 +6315,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
  		vslice /= 2;
  
@@ -1125,26 +1124,17 @@ index e88f50d4e..eeff9cc22 100644
  	/*
  	 * EEVDF: vd_i = ve_i + r_i/w_i
  	 */
-@@ -6113,7 +6194,7 @@ static void check_enqueue_throttle(struct cfs_rq *cfs_rq);
- static inline int cfs_rq_throttled(struct cfs_rq *cfs_rq);
- 
- static void
--requeue_delayed_entity(struct sched_entity *se);
-+requeue_delayed_entity(struct sched_entity *se, int flags);
- 
- static void
- enqueue_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
-@@ -7776,7 +7857,7 @@ static int choose_idle_cpu(int cpu, struct task_struct *p)
+@@ -7830,7 +7910,7 @@ static int choose_idle_cpu(int cpu, struct task_struct *p)
  }
  
  static void
--requeue_delayed_entity(struct sched_entity *se)
-+requeue_delayed_entity(struct sched_entity *se, int flags)
+-requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se)
++requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  {
- 	struct cfs_rq *cfs_rq = cfs_rq_of(se);
- 
-@@ -7792,7 +7873,13 @@ requeue_delayed_entity(struct sched_entity *se)
- 		cfs_rq->nr_queued--;
+ 	/*
+ 	 * se->sched_delayed should imply: se->on_rq == 1.
+@@ -7844,7 +7924,13 @@ requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se)
+ 		cfs_rq->h_nr_queued--;
  		if (se != cfs_rq->curr)
  			__dequeue_entity(cfs_rq, se);
 -		place_entity(cfs_rq, se, 0);
@@ -1157,42 +1147,45 @@ index e88f50d4e..eeff9cc22 100644
 +		place_entity(cfs_rq, se, flags);
  		if (se != cfs_rq->curr)
  			__enqueue_entity(cfs_rq, se);
- 		cfs_rq->nr_queued++;
-@@ -7831,7 +7918,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
- 		util_est_enqueue(&rq->cfs, p);
+ 		cfs_rq->h_nr_queued++;
+@@ -7921,7 +8007,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 		util_est_enqueue(cfs_rq, p);
  
  	if (flags & ENQUEUE_DELAYED) {
--		requeue_delayed_entity(se);
-+		requeue_delayed_entity(se, flags);
+-		requeue_delayed_entity(cfs_rq, se);
++		requeue_delayed_entity(cfs_rq, se, flags);
  		return;
  	}
  
-@@ -7849,7 +7936,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
- 	for_each_sched_entity(se) {
- 		if (se->on_rq) {
- 			if (se->sched_delayed)
--				requeue_delayed_entity(se);
-+				requeue_delayed_entity(se, flags);
- 			break;
- 		}
- 		cfs_rq = cfs_rq_of(se);
-@@ -8052,6 +8139,15 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+@@ -7941,7 +8027,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 		place_entity(cfs_rq, se, flags);
+ 
+ 	if (se->on_rq && se->sched_delayed)
+-		requeue_delayed_entity(cfs_rq, se);
++		requeue_delayed_entity(cfs_rq, se, flags);
+ 
+ 	weight = enqueue_hierarchy(p, flags);
+ 
+@@ -8111,6 +8197,18 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	if (!p->se.sched_delayed)
  		util_est_dequeue(&rq->cfs, p);
  
 +#ifdef CONFIG_SCHED_BORE
-+	struct cfs_rq *cfs_rq = cfs_rq_of(&p->se);
-+	struct sched_entity *se = &p->se;
-+	if ((flags & DEQUEUE_SLEEP) && entity_is_task(se)) {
-+		if (cfs_rq->curr == se)
-+			update_curr(cfs_rq);
-+		restart_burst_bore(p);
++	{
++		struct cfs_rq *cfs_rq = cfs_rq_of(&p->se);
++		struct sched_entity *se = &p->se;
++		if ((flags & DEQUEUE_SLEEP) && entity_is_task(se)) {
++			if (cfs_rq->curr == se)
++			    update_curr(cfs_rq);
++			restart_burst_bore(p);
++		}
 +	}
 +#endif /* CONFIG_SCHED_BORE */
- 	if (dequeue_entities(rq, &p->se, flags) < 0)
++
+ 	if (!__dequeue_task(rq, p, flags))
  		return false;
  
-@@ -9881,6 +9977,18 @@ static void wakeup_preempt_fair(struct rq *rq, struct task_struct *p, int wake_f
+@@ -9914,6 +10012,18 @@ static void wakeup_preempt_fair(struct rq *rq, struct task_struct *p, int wake_f
  		goto pick;
  	}
  
@@ -1211,7 +1204,7 @@ index e88f50d4e..eeff9cc22 100644
  	/*
  	 * Ignore wakee preemption on WF_FORK as it is less likely that
  	 * there is shared data as exec often follow fork. Do not
-@@ -10051,16 +10159,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -10080,16 +10190,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -1237,7 +1230,7 @@ index e88f50d4e..eeff9cc22 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -15041,6 +15158,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
+@@ -15055,6 +15174,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  	WARN_ON_ONCE(p->se.sched_delayed);
  
  	attach_task_cfs_rq(p);
@@ -1248,10 +1241,10 @@ index e88f50d4e..eeff9cc22 100644
  	set_task_max_allowed_capacity(p);
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 5fac34a2f..8e46cd6a0 100644
+index 4664869d..85d4c65d 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -2264,7 +2264,11 @@ extern int group_balance_cpu(struct sched_group *sg);
+@@ -2267,7 +2267,11 @@ extern int group_balance_cpu(struct sched_group *sg);
  extern void update_sched_domain_debugfs(void);
  extern void dirty_sched_domain_sysctl(int cpu);
  
@@ -1263,7 +1256,7 @@ index 5fac34a2f..8e46cd6a0 100644
  
  static inline const struct cpumask *task_user_cpus(struct task_struct *p)
  {
-@@ -3109,7 +3113,12 @@ static inline void attach_one_task(struct rq *rq, struct task_struct *p)
+@@ -3113,7 +3117,12 @@ static inline void attach_one_task(struct rq *rq, struct task_struct *p)
  extern __read_mostly unsigned int sysctl_sched_nr_migrate;
  extern __read_mostly unsigned int sysctl_sched_migration_cost;
  
@@ -1276,6 +1269,3 @@ index 5fac34a2f..8e46cd6a0 100644
  
  extern int sysctl_resched_latency_warn_ms;
  extern int sysctl_resched_latency_warn_once;
--- 
-2.54.0
-


### PR DESCRIPTION
### Key Modifications
* **`requeue_delayed_entity` Signature Alignment**: Adapts BORE's delayed entity requeue mechanism to CachyOS's refactored multi-parameter signature, preserving the necessary scheduler flags during wakeup.
* **Task Dequeue Pathway Refactoring**: Aligns BORE's dequeue hooks with CachyOS's custom `__dequeue_task` helper, while resolving compiler restrictions regarding declaration-after-statement under strict build flags.
* **`update_curr` Guard Clause Integration**: Integrates BORE's execution runtime tracking with CachyOS's early-return task-checking pattern to ensure safe and correct runtime accounting.
