### PR TITLE
7.2: forward-port BORE scheduler to 7.2-rc3-3

### DIFF
--- a/7.2/sched/0001-bore-cachy.patch
+++ b/7.2/sched/0001-bore-cachy.patch
@@ -1,8 +1,9 @@
-From 7e3de6bdabbaa4f7a68128ef4a906c25d1e9c60c Mon Sep 17 00:00:00 2001
+From 48c71af2a19c61b9120df5dd4ce8e3a81987d7d4 Mon Sep 17 00:00:00 2001
 From: loner <2788892716@qq.com>
-Date: Thu, 9 Jul 2026 09:25:53 +0800
-Subject: [PATCH] bore-cachy: forward-port BORE scheduler to CachyOS 7.2-rc2-3
+Date: Sat, 18 Jul 2026 04:16:00 +0800
+Subject: [PATCH] bore-cachy: 7.2-rc3-3
 
+Signed-off-by: loner <2788892716@qq.com>
 ---
  include/linux/sched.h      |  34 +++
  include/linux/sched/bore.h |  46 ++++
@@ -15,17 +16,17 @@ Subject: [PATCH] bore-cachy: forward-port BORE scheduler to CachyOS 7.2-rc2-3
  kernel/sched/bore.c        | 466 +++++++++++++++++++++++++++++++++++++
  kernel/sched/core.c        |  12 +
  kernel/sched/debug.c       |  61 +++++
- kernel/sched/fair.c        | 166 +++++++++++--
+ kernel/sched/fair.c        | 160 +++++++++++--
  kernel/sched/sched.h       |   9 +
- 13 files changed, 835 insertions(+), 22 deletions(-)
+ 13 files changed, 832 insertions(+), 19 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
 diff --git a/include/linux/sched.h b/include/linux/sched.h
-index 1cf9805b..49fc3f58 100644
+index e29c97ace..6a4c43a2d 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -824,6 +824,37 @@ struct kmap_ctrl {
+@@ -823,6 +823,37 @@ struct kmap_ctrl {
  #endif
  };
  
@@ -63,7 +64,7 @@ index 1cf9805b..49fc3f58 100644
  struct task_struct {
  #ifdef CONFIG_THREAD_INFO_IN_TASK
  	/*
-@@ -885,6 +916,9 @@ struct task_struct {
+@@ -884,6 +915,9 @@ struct task_struct {
  #ifdef CONFIG_SCHED_CLASS_EXT
  	struct sched_ext_entity		scx;
  #endif
@@ -75,7 +76,7 @@ index 1cf9805b..49fc3f58 100644
  #ifdef CONFIG_SCHED_CORE
 diff --git a/include/linux/sched/bore.h b/include/linux/sched/bore.h
 new file mode 100644
-index 00000000..76afe1d2
+index 000000000..76afe1d25
 --- /dev/null
 +++ b/include/linux/sched/bore.h
 @@ -0,0 +1,46 @@
@@ -126,7 +127,7 @@ index 00000000..76afe1d2
 +
 +#endif /* _KERNEL_SCHED_BORE_H */
 diff --git a/init/Kconfig b/init/Kconfig
-index 39e153f9..7137c1f5 100644
+index c682cb5b5..c488da8fc 100644
 --- a/init/Kconfig
 +++ b/init/Kconfig
 @@ -1481,6 +1481,23 @@ config CHECKPOINT_RESTORE
@@ -154,7 +155,7 @@ index 39e153f9..7137c1f5 100644
  	bool "Automatic process group scheduling"
  	select CGROUPS
 diff --git a/kernel/Kconfig.hz b/kernel/Kconfig.hz
-index e1359db5..31053e61 100644
+index e1359db55..31053e619 100644
 --- a/kernel/Kconfig.hz
 +++ b/kernel/Kconfig.hz
 @@ -81,3 +81,20 @@ config HZ
@@ -179,7 +180,7 @@ index e1359db5..31053e61 100644
 +	 an unnecessarily large base slice, resulting in high scheduling
 +	 latency and poor system responsiveness.
 diff --git a/kernel/exit.c b/kernel/exit.c
-index 1056422b..51955518 100644
+index 2c0b1c029..6724f762f 100644
 --- a/kernel/exit.c
 +++ b/kernel/exit.c
 @@ -147,7 +147,11 @@ static void __unhash_process(struct release_task_post *post, struct task_struct
@@ -195,7 +196,7 @@ index 1056422b..51955518 100644
  	}
  	list_del_rcu(&p->thread_node);
 diff --git a/kernel/fork.c b/kernel/fork.c
-index ec832f56..4f9f195f 100644
+index ec832f56e..4f9f195f1 100644
 --- a/kernel/fork.c
 +++ b/kernel/fork.c
 @@ -120,6 +120,10 @@
@@ -234,7 +235,7 @@ index ec832f56..4f9f195f 100644
  			attach_pid(p, PIDTYPE_TGID);
  			attach_pid(p, PIDTYPE_PGID);
 diff --git a/kernel/futex/waitwake.c b/kernel/futex/waitwake.c
-index d4483d15..7fa31c8d 100644
+index d4483d15d..7fa31c8d7 100644
 --- a/kernel/futex/waitwake.c
 +++ b/kernel/futex/waitwake.c
 @@ -4,6 +4,9 @@
@@ -264,7 +265,7 @@ index d4483d15..7fa31c8d 100644
  	__set_current_state(TASK_RUNNING);
  }
 diff --git a/kernel/sched/Makefile b/kernel/sched/Makefile
-index b1f1a367..f95a7b3d 100644
+index b1f1a3670..f95a7b3d5 100644
 --- a/kernel/sched/Makefile
 +++ b/kernel/sched/Makefile
 @@ -40,3 +40,4 @@ obj-y += core.o
@@ -274,7 +275,7 @@ index b1f1a367..f95a7b3d 100644
 +obj-$(CONFIG_SCHED_BORE) += bore.o
 diff --git a/kernel/sched/bore.c b/kernel/sched/bore.c
 new file mode 100644
-index 00000000..7587cbc7
+index 000000000..7587cbc78
 --- /dev/null
 +++ b/kernel/sched/bore.c
 @@ -0,0 +1,466 @@
@@ -745,7 +746,7 @@ index 00000000..7587cbc7
 +#endif // CONFIG_SYSCTL
 +#endif /* CONFIG_SCHED_BORE */
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index edd1a3fc..ba904573 100644
+index e55a8f257..e7dc2925e 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -100,6 +100,10 @@
@@ -771,7 +772,7 @@ index edd1a3fc..ba904573 100644
  	struct load_weight lw;
  
  	if (task_has_idle_policy(p)) {
-@@ -8927,6 +8935,10 @@ void __init sched_init(void)
+@@ -8930,6 +8938,10 @@ void __init sched_init(void)
  	BUG_ON(!sched_class_above(&ext_sched_class, &idle_sched_class));
  #endif
  
@@ -783,7 +784,7 @@ index edd1a3fc..ba904573 100644
  
  #ifdef CONFIG_FAIR_GROUP_SCHED
 diff --git a/kernel/sched/debug.c b/kernel/sched/debug.c
-index c15291cb..d7f04e23 100644
+index 40584b27e..976c3129d 100644
 --- a/kernel/sched/debug.c
 +++ b/kernel/sched/debug.c
 @@ -170,6 +170,53 @@ static const struct file_operations sched_feat_fops = {
@@ -848,7 +849,7 @@ index c15291cb..d7f04e23 100644
  
  #ifdef CONFIG_SCHED_CACHE
  static ssize_t
-@@ -721,12 +769,19 @@ static __init int sched_init_debug(void)
+@@ -645,12 +693,19 @@ static __init int sched_init_debug(void)
  	debugfs_create_file("preempt", 0644, debugfs_sched, NULL, &sched_dynamic_fops);
  #endif
  
@@ -868,7 +869,7 @@ index c15291cb..d7f04e23 100644
  	debugfs_create_u32("migration_cost_ns", 0644, debugfs_sched, &sysctl_sched_migration_cost);
  	debugfs_create_u32("nr_migrate", 0644, debugfs_sched, &sysctl_sched_nr_migrate);
  
-@@ -992,6 +1047,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
+@@ -911,6 +966,9 @@ print_task(struct seq_file *m, struct rq *rq, struct task_struct *p)
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_sleep_runtime)),
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
@@ -878,7 +879,7 @@ index c15291cb..d7f04e23 100644
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, "   %d      %d", task_node(p), task_numa_group_id(p));
  #endif
-@@ -1484,6 +1542,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
+@@ -1401,6 +1459,9 @@ void proc_sched_show_task(struct task_struct *p, struct pid_namespace *ns,
  	__PS("nr_involuntary_switches", p->nivcsw);
  
  	P(se.load.weight);
@@ -889,7 +890,7 @@ index c15291cb..d7f04e23 100644
  	P(se.avg.runnable_sum);
  	P(se.avg.util_sum);
 diff --git a/kernel/sched/fair.c b/kernel/sched/fair.c
-index cfd84963..f173dad5 100644
+index b259d8e95..77ce69656 100644
 --- a/kernel/sched/fair.c
 +++ b/kernel/sched/fair.c
 @@ -59,6 +59,10 @@
@@ -969,7 +970,7 @@ index cfd84963..f173dad5 100644
  
  void __init sched_init_granularity(void)
  {
-@@ -1060,7 +1076,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
+@@ -1093,7 +1109,11 @@ struct sched_entity *__pick_first_entity(struct cfs_rq *cfs_rq)
   */
  static inline void set_protect_slice(struct cfs_rq *cfs_rq, struct sched_entity *se)
  {
@@ -981,7 +982,7 @@ index cfd84963..f173dad5 100644
  	u64 vprot = se->deadline;
  
  	if (sched_feat(RUN_TO_PARITY))
-@@ -1137,8 +1157,17 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
+@@ -1170,8 +1190,17 @@ static struct sched_entity *pick_eevdf(struct cfs_rq *cfs_rq, bool protect)
  	if (curr && (!curr->on_rq || !entity_eligible(cfs_rq, curr)))
  		curr = NULL;
  
@@ -1001,7 +1002,7 @@ index cfd84963..f173dad5 100644
  
  	/* Pick the leftmost entity if it's eligible */
  	if (se && entity_eligible(cfs_rq, se)) {
-@@ -1194,6 +1223,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
+@@ -1227,6 +1256,7 @@ struct sched_entity *__pick_last_entity(struct cfs_rq *cfs_rq)
  /**************************************************************
   * Scheduling class statistics methods:
   */
@@ -1009,7 +1010,7 @@ index cfd84963..f173dad5 100644
  int sched_update_scaling(void)
  {
  	unsigned int factor = get_update_sysctl_factor();
-@@ -1205,6 +1235,7 @@ int sched_update_scaling(void)
+@@ -1238,6 +1268,7 @@ int sched_update_scaling(void)
  
  	return 0;
  }
@@ -1017,7 +1018,7 @@ index cfd84963..f173dad5 100644
  
  static void clear_buddies(struct cfs_rq *cfs_rq, struct sched_entity *se);
  
-@@ -1946,6 +1977,38 @@ static void account_llc_dequeue(struct rq *rq, struct task_struct *p) {}
+@@ -1981,6 +2012,38 @@ static void account_llc_dequeue(struct rq *rq, struct task_struct *p) {}
  
  #endif /* CONFIG_SCHED_CACHE */
  
@@ -1056,7 +1057,7 @@ index cfd84963..f173dad5 100644
  /*
   * Used by other classes to account runtime.
   */
-@@ -1987,6 +2050,10 @@ static void update_curr(struct cfs_rq *cfs_rq)
+@@ -2015,6 +2078,10 @@ static void update_curr(struct cfs_rq *cfs_rq)
  	curr->vruntime += calc_delta_fair(delta_exec, curr);
  	resched = update_deadline(cfs_rq, curr);
  
@@ -1064,11 +1065,11 @@ index cfd84963..f173dad5 100644
 +	update_curr_bore(task_of(curr), delta_exec);
 +#endif /* CONFIG_SCHED_BORE */
 +
- 	/*
- 	 * If the fair_server is active, we need to account for the
- 	 * fair_server time whether or not the task is running on
-@@ -4688,8 +4755,8 @@ static void reweight_eevdf(struct cfs_rq *cfs_rq, struct sched_entity *se,
- 	}
+ 	if (entity_is_task(curr)) {
+ 		/*
+ 		 * If the fair_server is active, we need to account for the
+@@ -4673,8 +4740,8 @@ rescale_entity(struct sched_entity *se, unsigned long weight, bool rel_vprot)
+ 		se->vprot = div64_long(se->vprot * old_weight, weight);
  }
  
 -static void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
@@ -1076,15 +1077,14 @@ index cfd84963..f173dad5 100644
 +void reweight_entity(struct cfs_rq *cfs_rq, struct sched_entity *se,
 +		     unsigned long weight)
  {
- 	if (se->load.weight == weight)
- 		return;
-@@ -6107,14 +6174,13 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
+ 	bool curr = cfs_rq->curr == se;
+ 	bool rel_vprot = false;
+@@ -5977,13 +6044,12 @@ void __setparam_fair(struct task_struct *p, const struct sched_attr *attr)
  static void
  place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  {
 -	u64 vslice, vruntime = avg_vruntime(cfs_rq);
 +	u64 vslice = 0, vruntime = avg_vruntime(cfs_rq);
- 	unsigned int nr_queued = cfs_rq->h_nr_queued;
  	bool update_zero = false;
  	s64 lag = 0;
  
@@ -1092,9 +1092,9 @@ index cfd84963..f173dad5 100644
  		se->slice = sysctl_sched_base_slice;
 -	vslice = calc_delta_fair(se->slice, se);
  
- 	if (flags & ENQUEUE_QUEUED)
- 		nr_queued -= 1;
-@@ -6229,7 +6295,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+ 	/*
+ 	 * Due to how V is constructed as the weighted average of entities,
+@@ -6095,7 +6161,18 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  		se->rel_deadline = 0;
  		return;
  	}
@@ -1114,7 +1114,7 @@ index cfd84963..f173dad5 100644
  	/*
  	 * When joining the competition; the existing tasks will be,
  	 * on average, halfway through their slice, as such start tasks
-@@ -6238,6 +6315,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -6104,6 +6181,9 @@ place_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
  	if (sched_feat(PLACE_DEADLINE_INITIAL) && (flags & ENQUEUE_INITIAL))
  		vslice /= 2;
  
@@ -1124,49 +1124,28 @@ index cfd84963..f173dad5 100644
  	/*
  	 * EEVDF: vd_i = ve_i + r_i/w_i
  	 */
-@@ -7830,7 +7910,7 @@ static int choose_idle_cpu(int cpu, struct task_struct *p)
- }
- 
- static void
--requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se)
-+requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se, int flags)
+@@ -7780,6 +7860,7 @@ static void
+ requeue_delayed_entity(struct sched_entity *se)
  {
+ 	struct cfs_rq *cfs_rq = cfs_rq_of(se);
++	int flags = 0;
+ 
  	/*
  	 * se->sched_delayed should imply: se->on_rq == 1.
-@@ -7844,7 +7924,13 @@ requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se)
- 		cfs_rq->h_nr_queued--;
+@@ -7793,7 +7874,11 @@ requeue_delayed_entity(struct sched_entity *se)
+ 		cfs_rq->nr_queued--;
  		if (se != cfs_rq->curr)
  			__dequeue_entity(cfs_rq, se);
 -		place_entity(cfs_rq, se, 0);
 +#ifdef CONFIG_SCHED_BORE
 +		if (static_branch_likely(&sched_bore_key))
 +			flags |= ENQUEUE_WAKEUP;
-+		else
 +#endif /* CONFIG_SCHED_BORE */
-+			flags = 0;
 +		place_entity(cfs_rq, se, flags);
  		if (se != cfs_rq->curr)
  			__enqueue_entity(cfs_rq, se);
- 		cfs_rq->h_nr_queued++;
-@@ -7921,7 +8007,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
- 		util_est_enqueue(cfs_rq, p);
- 
- 	if (flags & ENQUEUE_DELAYED) {
--		requeue_delayed_entity(cfs_rq, se);
-+		requeue_delayed_entity(cfs_rq, se, flags);
- 		return;
- 	}
- 
-@@ -7941,7 +8027,7 @@ enqueue_task_fair(struct rq *rq, struct task_struct *p, int flags)
- 		place_entity(cfs_rq, se, flags);
- 
- 	if (se->on_rq && se->sched_delayed)
--		requeue_delayed_entity(cfs_rq, se);
-+		requeue_delayed_entity(cfs_rq, se, flags);
- 
- 	weight = enqueue_hierarchy(p, flags);
- 
-@@ -8111,6 +8197,18 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
+ 		cfs_rq->nr_queued++;
+@@ -8053,6 +8138,19 @@ static bool dequeue_task_fair(struct rq *rq, struct task_struct *p, int flags)
  	if (!p->se.sched_delayed)
  		util_est_dequeue(&rq->cfs, p);
  
@@ -1174,18 +1153,19 @@ index cfd84963..f173dad5 100644
 +	{
 +		struct cfs_rq *cfs_rq = cfs_rq_of(&p->se);
 +		struct sched_entity *se = &p->se;
++
 +		if ((flags & DEQUEUE_SLEEP) && entity_is_task(se)) {
 +			if (cfs_rq->curr == se)
-+			    update_curr(cfs_rq);
++				update_curr(cfs_rq);
 +			restart_burst_bore(p);
 +		}
 +	}
 +#endif /* CONFIG_SCHED_BORE */
 +
- 	if (!__dequeue_task(rq, p, flags))
+ 	if (dequeue_entities(rq, &p->se, flags) < 0)
  		return false;
  
-@@ -9914,6 +10012,18 @@ static void wakeup_preempt_fair(struct rq *rq, struct task_struct *p, int wake_f
+@@ -9944,6 +10042,18 @@ static void wakeup_preempt_fair(struct rq *rq, struct task_struct *p, int wake_f
  		goto pick;
  	}
  
@@ -1204,7 +1184,7 @@ index cfd84963..f173dad5 100644
  	/*
  	 * Ignore wakee preemption on WF_FORK as it is less likely that
  	 * there is shared data as exec often follow fork. Do not
-@@ -10080,16 +10190,25 @@ static void yield_task_fair(struct rq *rq)
+@@ -10114,16 +10224,25 @@ static void yield_task_fair(struct rq *rq)
  	/*
  	 * Are we the only task in the tree?
  	 */
@@ -1230,7 +1210,7 @@ index cfd84963..f173dad5 100644
  	/*
  	 * Tell update_rq_clock() that we've just updated,
  	 * so we don't do microscopic update in schedule()
-@@ -15055,6 +15174,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
+@@ -15107,6 +15226,9 @@ static void switched_to_fair(struct rq *rq, struct task_struct *p)
  	WARN_ON_ONCE(p->se.sched_delayed);
  
  	attach_task_cfs_rq(p);
@@ -1241,10 +1221,10 @@ index cfd84963..f173dad5 100644
  	set_task_max_allowed_capacity(p);
  
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index 4664869d..85d4c65d 100644
+index 1598e2107..3ff4577c0 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -2267,7 +2267,11 @@ extern int group_balance_cpu(struct sched_group *sg);
+@@ -2268,7 +2268,11 @@ extern int group_balance_cpu(struct sched_group *sg);
  extern void update_sched_domain_debugfs(void);
  extern void dirty_sched_domain_sysctl(int cpu);
  
@@ -1256,7 +1236,7 @@ index 4664869d..85d4c65d 100644
  
  static inline const struct cpumask *task_user_cpus(struct task_struct *p)
  {
-@@ -3113,7 +3117,12 @@ static inline void attach_one_task(struct rq *rq, struct task_struct *p)
+@@ -3220,7 +3224,12 @@ static inline void attach_one_task(struct rq *rq, struct task_struct *p)
  extern __read_mostly unsigned int sysctl_sched_nr_migrate;
  extern __read_mostly unsigned int sysctl_sched_migration_cost;
  
@@ -1269,3 +1249,6 @@ index 4664869d..85d4c65d 100644
  
  extern int sysctl_resched_latency_warn_ms;
  extern int sysctl_resched_latency_warn_once;
+-- 
+2.54.0
+


### PR DESCRIPTION
Key Modifications
- Drop the unused flags parameter from BORE's requeue_delayed_entity; ENQUEUE_WAKEUP is now decided internally via sched_bore_key, matching the upstream refactor.
- Align BORE's dequeue_task_fair hook with CachyOS's new dequeue_entities() return-based control flow.
- Initialize vslice = 0 in place_entity and drop the premature calc_delta_fair call to match the refactored placement path.

Failing CI before this fix: https://github.com/lonerOrz/cachyos-loner/actions/runs/29519518046/job/87693072908?pr=38#step:7:177