### PR TITLE
7.2: forward-port BORE scheduler 6.8.0 to 7.2-rc5-1

### DIFF
--- a/7.2/sched/0001-bore-cachy.patch
+++ b/7.2/sched/0001-bore-cachy.patch
@@ -1,23 +1,25 @@
-From 7e3de6bdabbaa4f7a68128ef4a906c25d1e9c60c Mon Sep 17 00:00:00 2001
-From: loner <2788892716@qq.com>
-Date: Thu, 9 Jul 2026 09:25:53 +0800
-Subject: [PATCH] bore-cachy: forward-port BORE scheduler to CachyOS 7.2-rc2-3
+From 95efd6a7821a8bf92b0c950fa2906c25d1e9c60c Mon Sep 17 00:00:00 2001
+From: Filip <denuvo@tuta.io>
+Date: Wed, 29 Jul 2026 16:35:00 +0200
+Subject: [PATCH] bore-cachy: BORE 6.8.0 scheduler for CachyOS 7.2-rc5
 
 ---
- include/linux/sched.h      |  34 +++
- include/linux/sched/bore.h |  46 ++++
- init/Kconfig               |  17 ++
- kernel/Kconfig.hz          |  17 ++
- kernel/exit.c              |   4 +
- kernel/fork.c              |  13 ++
- kernel/futex/waitwake.c    |  11 +
- kernel/sched/Makefile      |   1 +
- kernel/sched/bore.c        | 466 +++++++++++++++++++++++++++++++++++++
- kernel/sched/core.c        |  12 +
- kernel/sched/debug.c       |  61 +++++
- kernel/sched/fair.c        | 166 +++++++++++--
- kernel/sched/sched.h       |   9 +
- 13 files changed, 835 insertions(+), 22 deletions(-)
+ include/linux/sched.h        |  28 +++
+ include/linux/sched/bore.h   |  49 ++++
+ init/Kconfig                 |  17 ++
+ kernel/Kconfig.hz            |  17 ++
+ kernel/exit.c                |   4 +
+ kernel/fork.c                |  13 +
+ kernel/futex/waitwake.c      |  11 +
+ kernel/sched/Makefile        |   1 +
+ kernel/sched/bore.c          | 466 +++++++++++++++++++++++++++++++++++
+ kernel/sched/build_utility.c |   4 +
+ kernel/sched/core.c          |  12 +
+ include/linux/sched.h        |  28 +++
+ kernel/sched/debug.c         |  61 +++++
+ kernel/sched/fair.c          | 166 +++++++++++--
+ kernel/sched/sched.h         |   9 +
+ 14 files changed, 836 insertions(+), 22 deletions(-)
  create mode 100644 include/linux/sched/bore.h
  create mode 100644 kernel/sched/bore.c
 
@@ -25,7 +27,7 @@ diff --git a/include/linux/sched.h b/include/linux/sched.h
 index 1cf9805b..49fc3f58 100644
 --- a/include/linux/sched.h
 +++ b/include/linux/sched.h
-@@ -824,6 +824,37 @@ struct kmap_ctrl {
+@@ -824,6 +824,31 @@ struct kmap_ctrl {
  #endif
  };
  
@@ -46,13 +48,7 @@ index 1cf9805b..49fc3f58 100644
 +	u64				burst_time;
 +	u16				prev_penalty;
 +	u16				curr_penalty;
-+	union {
-+		u16			penalty;
-+		struct {
-+			u8		_;
-+			u8		score;
-+		};
-+	};
++	u16				penalty;
 +	bool			stop_update;
 +	bool			futex_waiting;
 +	struct bore_bc	subtree;
@@ -63,7 +59,7 @@ index 1cf9805b..49fc3f58 100644
  struct task_struct {
  #ifdef CONFIG_THREAD_INFO_IN_TASK
  	/*
-@@ -885,6 +916,9 @@ struct task_struct {
+@@ -885,6 +910,9 @@ struct task_struct {
  #ifdef CONFIG_SCHED_CLASS_EXT
  	struct sched_ext_entity		scx;
  #endif
@@ -78,7 +74,7 @@ new file mode 100644
 index 00000000..76afe1d2
 --- /dev/null
 +++ b/include/linux/sched/bore.h
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,49 @@
 +#ifndef _KERNEL_SCHED_BORE_H
 +#define _KERNEL_SCHED_BORE_H
 +
@@ -92,7 +88,7 @@ index 00000000..76afe1d2
 +#define SCHED_BORE_AUTHOR   "Masahito Suzuki"
 +#define SCHED_BORE_PROGNAME "BORE CPU Scheduler modification"
 +
-+#define SCHED_BORE_VERSION  "6.8.0-rc1"
++#define SCHED_BORE_VERSION  "6.8.0"
 +
 +extern u8   __read_mostly sched_bore;
 +DECLARE_STATIC_KEY_TRUE(sched_bore_key);
@@ -104,6 +100,9 @@ index 00000000..76afe1d2
 +extern u8   __read_mostly sched_burst_protect_slice_lv;
 +DECLARE_STATIC_KEY_TRUE(sched_burst_protect_slice_cond_key);
 +DECLARE_STATIC_KEY_FALSE(sched_burst_protect_slice_prefer_key);
++
++static inline u8 bore_score(struct task_struct *p)
++{ return p->bore.penalty >> 8; }
 +
 +extern u8   effective_prio_bore(struct task_struct *p);
 +extern void update_curr_bore(struct task_struct *p, u64 delta_exec);
@@ -363,7 +362,7 @@ index 00000000..7587cbc7
 +u8 effective_prio_bore(struct task_struct *p) {
 +	int prio = p->static_prio - MAX_RT_PRIO;
 +	if (static_branch_likely(&sched_bore_key))
-+		prio += p->bore.score;
++		prio += bore_score(p);
 +	prio &= ~(prio >> 31);
 +	s32 diff = prio - maxval_prio;
 +	prio -= (diff & ~(diff >> 31));
@@ -744,6 +743,21 @@ index 00000000..7587cbc7
 +
 +#endif // CONFIG_SYSCTL
 +#endif /* CONFIG_SCHED_BORE */
+diff --git a/kernel/sched/build_utility.c b/kernel/sched/build_utility.c
+index e2cf3b08d..aad225930 100644
+--- a/kernel/sched/build_utility.c
++++ b/kernel/sched/build_utility.c
+@@ -54,6 +54,10 @@
+ #include "stats.h"
+ #include "autogroup.h"
+ 
++#ifdef CONFIG_SCHED_BORE
++#include <linux/sched/bore.h>
++#endif /* CONFIG_SCHED_BORE */
++
+ #include "clock.c"
+ 
+ #ifdef CONFIG_CGROUP_CPUACCT
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
 index edd1a3fc..ba904573 100644
 --- a/kernel/sched/core.c
@@ -873,7 +887,7 @@ index c15291cb..d7f04e23 100644
  		SPLIT_NS(schedstat_val_or_zero(p->stats.sum_block_runtime)));
  
 +#ifdef CONFIG_SCHED_BORE
-+	SEQ_printf(m, " %2d", p->bore.score);
++	SEQ_printf(m, " %2d", bore_score(p));
 +#endif /* CONFIG_SCHED_BORE */
  #ifdef CONFIG_NUMA_BALANCING
  	SEQ_printf(m, "   %d      %d", task_node(p), task_numa_group_id(p));
@@ -883,7 +897,7 @@ index c15291cb..d7f04e23 100644
  
  	P(se.load.weight);
 +#ifdef CONFIG_SCHED_BORE
-+	P(bore.score);
++	__PS("bore.score", bore_score(p));
 +#endif /* CONFIG_SCHED_BORE */
  	P(se.avg.load_sum);
  	P(se.avg.runnable_sum);


### PR DESCRIPTION
## BORE 6.8.0 port to 7.2-rc5 

1. **`requeue_delayed_entity` API Update**:
   Upstream changed the function signature to include the runqueue context:
   * **Old (rc1-4):** `requeue_delayed_entity(struct sched_entity *se)`
   * **New (rc5):** `requeue_delayed_entity(struct cfs_rq *cfs_rq, struct sched_entity *se)`

2. **`update_curr` Context Flattening**:
   The `update_curr` function was refactored in `rc5` to check `!entity_is_task` and return early at the very beginning. 
   We moved `update_curr_bore` outside of the nested `if (entity_is_task)` check (which was removed upstream) to the function's root level to prevent code rejection.

3. **`dequeue_task_fair` Realignment**:
   Upstream replaced direct calls of `dequeue_entities` inside `dequeue_task_fair` with `__dequeue_task`. The patch was adjusted to place the BORE burst-restart trigger points around this new wrapper function.

4. **`place_entity` Sequence Reorganization**:
   The EEVDF calculation sequence inside `place_entity` shifted, causing BORE's custom `vslice_found:` label and target context to mismatch. The patch's hunks have been realigned to insert BORE's custom wakeup logic in the correct calculation sequence.